### PR TITLE
docs(repo-setup): GitFlowブランチ戦略・保護ルール設計・テスト設計書

### DIFF
--- a/docs/architecture/dev.md
+++ b/docs/architecture/dev.md
@@ -39,6 +39,9 @@ flowchart LR
 | `build-nightly` | 日次 cron | 未署名バイナリ、`develop` から（main は常にタグ付きリリース状態のため nightly 対象ではない） | matrix |
 | `release` | タグ `v*.*.*` push（`main` への release/hotfix マージ後に付与） | 署名済み・公証済み・SBOM 付き成果物を Releases に登録 | matrix |
 | `pages` | main push（`docs/` 差分時） | `mdBook` / Astro 等で設計書＆ランディングページを GitHub Pages へ | ubuntu-latest |
+| `branch-policy` | PR opened / synchronize | PR の source/target ブランチ名を `§7.1` の命名規則と `§7.2` の PR ソース制限で検証。違反は即 fail（`main` への PR が `release/*` / `hotfix/*` 以外、`develop` への PR が `feature/*` / `release/*` / `hotfix/*` 以外、など） | ubuntu-latest |
+| `pr-title-check` | PR opened / edited / synchronize | PR タイトルを Conventional Commits 正規表現で検証（`feat:` / `fix:` / `docs:` / `chore:` / `refactor:` / `test:` / `ci:` / `build:` / `perf:`、Breaking は `!:` 付）。違反は fail（squash merge 時のコミットメッセージとして採用されるため） | ubuntu-latest |
+| `back-merge-check` | PR merged to `main`（release/hotfix）／日次 cron | `main` への release/hotfix マージ後 24h 以内に同ブランチが `develop` にも back-merge されているかを GitHub API で確認。未実施なら `back-merge-missing` ラベル付き Issue を自動起票し release 担当者にアサイン | ubuntu-latest |
 
 **Ubuntu は X11 と Wayland の両セッションでテストする**（Wayland のホットキー実装は X11 と別経路のため）。GitHub Actions の `ubuntu-24.04` は既定で Wayland セッション、`ubuntu-22.04` は X11 セッションを使える。詳細は環境差分ドキュメント（`environment-diff.md`）を参照。
 
@@ -120,14 +123,14 @@ gitGraph
 
 ### 7.2 ブランチ保護ルール
 
-GitHub のブランチ保護設定は下表の通り。**include administrators = true**（管理者も規則に従う）、**force push = disabled**、**delete = disabled** は全保護ブランチ共通。
+GitHub のブランチ保護設定は下表の通り。**enforce_admins = true**（管理者も規則に従う）、**force push = disabled**、**delete = disabled** は全保護ブランチ共通。緊急時例外は §7.4 で定義する **bypass allowances**（Rulesets の `bypass_actors`）で、特定チーム（`@shikomi-dev/security-hotfix`）だけに必要最小限の迂回を許す（`enforce_admins` は無効化せず、管理者個人への特権も与えない）。
 
 | 設定項目 | `main` | `develop` | `release/*` | `hotfix/*` |
 |---------|--------|-----------|-------------|-----------|
 | 直接 push | ❌ 禁止 | ❌ 禁止 | ❌ 禁止（PR 経由のみ） | ❌ 禁止（PR 経由のみ） |
 | PR 必須 | ✅ | ✅ | ✅ | ✅ |
-| 必須 status checks | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` / `back-merge-check` | `lint` / `unit-core` / `test-infra` / `audit` | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` | 同左 |
-| 必須レビュー人数 | **2 名**（CODEOWNERS 必須） | 1 名（CODEOWNERS 必須） | 2 名（CODEOWNERS 必須） | 2 名（CODEOWNERS 必須、緊急時は 1 名＋事後レビュー） |
+| 必須 status checks | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` / `branch-policy` / `pr-title-check` / `back-merge-check` | `lint` / `unit-core` / `test-infra` / `audit` / `branch-policy` / `pr-title-check` | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` / `branch-policy` / `pr-title-check` | 同左 |
+| 必須レビュー人数 | **2 名**（CODEOWNERS 必須、緊急時は §7.4 bypass allowances で軽減可） | 1 名（CODEOWNERS 必須） | 2 名（CODEOWNERS 必須） | 2 名（CODEOWNERS 必須、緊急時は §7.4 bypass allowances で軽減可） |
 | PR ソース制限 | `release/*` または `hotfix/*` のみ（branch naming rule で強制） | `feature/*` / `release/*` / `hotfix/*` のみ | `develop` から作成 | `main` から作成 |
 | マージ方法許可 | **merge commit のみ**（release/hotfix の分岐履歴を保持） | squash merge（feature）＋ merge commit（release/hotfix back-merge） | merge commit | merge commit |
 | linear history 強制 | ❌（merge commit 必須のため） | ❌ | ❌ | ❌ |
@@ -166,7 +169,28 @@ GitHub のブランチ保護設定は下表の通り。**include administrators 
 4. **back-merge**: 同じ hotfix を `develop` へも merge commit で戻す
 5. **片付け**: ブランチ削除
 
-**緊急時例外**: セキュリティ脆弱性（`SECURITY.md` 経由の報告）は 1 名承認＋事後レビュー可。事後レビュー期限は main マージから 72h。未実施は Issue として自動起票（`security-post-review` ラベル）
+**緊急時例外（bypass allowances 方式）**:
+
+`enforce_admins = true` を**無効化せず**、個人管理者にも特権を付与しない。緊急時例外は GitHub **Rulesets の `bypass_actors`** 機能で、専用チーム `@shikomi-dev/security-hotfix` にだけ必要最小限の迂回権限を明示的に付与する形で実現する（§7.2 の `enforce_admins=true` 方針と矛盾しない）。
+
+| 項目 | 設定 |
+|------|------|
+| 対象ブランチ | `main`、`hotfix/*` |
+| 許可する bypass actor | `@shikomi-dev/security-hotfix` チーム（メンテナ 2 名以上で構成、SECURITY.md の脆弱性トリアージ担当） |
+| bypass モード | `pull_request`（PR 自体は必須だが、レビュー数を 1 名に軽減できる）。**`always`（直接 push）は使わない** |
+| 軽減対象ルール | 「必須レビュー 2 名」のみ。`enforce_admins` / `required_status_checks`（lint/unit-core/test-infra/audit）/ `signed_commits` は**軽減対象外**（セキュリティ hotfix でも CI は通す） |
+| トリガ条件 | `SECURITY.md` 経由で受領した脆弱性レポートが High / Critical 評価、かつ現行リリースに影響 |
+| 事後レビュー | main マージから **72h 以内に 2 名目レビュー**を GitHub の `required_reviewers` コマンドで追加取得。未実施は `security-post-review` ラベル付き Issue が自動起票され、release 担当者にアサイン |
+| 監査 | bypass 使用時は GitHub Audit log に自動記録される。月次で CODEOWNERS が `@shikomi-dev/security-hotfix` メンバー構成と bypass 使用履歴を確認 |
+
+**設計原則との整合**:
+- **Fail Fast**: 事後レビュー 72h 未実施は自動 Issue 化で検知
+- **Tell, Don't Ask**: bypass 権限はチームに付与し、**個人の判断で enforce_admins を切る運用を排除**（人間の手でブランチ保護を一時的に off→on する手順は不可逆な事故の温床）
+- **Fail Secure**: bypass は「レビュー数軽減のみ」。CI と署名コミットという客観的検証は軽減しない
+
+出典:
+- GitHub Rulesets bypass actors: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository#granting-bypass-permissions-for-your-ruleset
+- Branch protection `enforce_admins`: https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection
 
 ### 7.5 マージ戦略とコミット規約
 

--- a/docs/architecture/dev.md
+++ b/docs/architecture/dev.md
@@ -41,7 +41,7 @@ flowchart LR
 | `pages` | main push（`docs/` 差分時） | `mdBook` / Astro 等で設計書＆ランディングページを GitHub Pages へ | ubuntu-latest |
 | `branch-policy` | PR opened / synchronize | PR の source/target ブランチ名を `§7.1` の命名規則と `§7.2` の PR ソース制限で検証。違反は即 fail（`main` への PR が `release/*` / `hotfix/*` 以外、`develop` への PR が `feature/*` / `release/*` / `hotfix/*` 以外、など） | ubuntu-latest |
 | `pr-title-check` | PR opened / edited / synchronize | PR タイトルを Conventional Commits 正規表現で検証（`feat:` / `fix:` / `docs:` / `chore:` / `refactor:` / `test:` / `ci:` / `build:` / `perf:`、Breaking は `!:` 付）。違反は fail（squash merge 時のコミットメッセージとして採用されるため） | ubuntu-latest |
-| `back-merge-check` | PR merged to `main`（release/hotfix）／日次 cron | `main` への release/hotfix マージ後 24h 以内に同ブランチが `develop` にも back-merge されているかを GitHub API で確認。未実施なら `back-merge-missing` ラベル付き Issue を自動起票し release 担当者にアサイン | ubuntu-latest |
+| `back-merge-check` | PR merged to `main`（release/hotfix）／日次 cron | **事後監視ジョブ（PR required status check としては登録しない — post-merge/cron トリガのため PR 時点では未実行であり required check として機能しないため、責務を分離する）**。`main` への release/hotfix マージ後 24h 以内に同ブランチが `develop` にも back-merge されているかを GitHub API で確認。未実施なら `back-merge-missing` ラベル付き Issue を自動起票し release 担当者にアサイン | ubuntu-latest |
 
 **Ubuntu は X11 と Wayland の両セッションでテストする**（Wayland のホットキー実装は X11 と別経路のため）。GitHub Actions の `ubuntu-24.04` は既定で Wayland セッション、`ubuntu-22.04` は X11 セッションを使える。詳細は環境差分ドキュメント（`environment-diff.md`）を参照。
 
@@ -129,7 +129,7 @@ GitHub のブランチ保護設定は下表の通り。**enforce_admins = true**
 |---------|--------|-----------|-------------|-----------|
 | 直接 push | ❌ 禁止 | ❌ 禁止 | ❌ 禁止（PR 経由のみ） | ❌ 禁止（PR 経由のみ） |
 | PR 必須 | ✅ | ✅ | ✅ | ✅ |
-| 必須 status checks | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` / `branch-policy` / `pr-title-check` / `back-merge-check` | `lint` / `unit-core` / `test-infra` / `audit` / `branch-policy` / `pr-title-check` | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` / `branch-policy` / `pr-title-check` | 同左 |
+| 必須 status checks | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` / `branch-policy` / `pr-title-check`（`back-merge-check` は post-merge/cron 監視のため PR required には含めない — §7.6） | `lint` / `unit-core` / `test-infra` / `audit` / `branch-policy` / `pr-title-check` | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` / `branch-policy` / `pr-title-check` | 同左 |
 | 必須レビュー人数 | **2 名**（CODEOWNERS 必須、緊急時は §7.4 bypass allowances で軽減可） | 1 名（CODEOWNERS 必須） | 2 名（CODEOWNERS 必須） | 2 名（CODEOWNERS 必須、緊急時は §7.4 bypass allowances で軽減可） |
 | PR ソース制限 | `release/*` または `hotfix/*` のみ（branch naming rule で強制） | `feature/*` / `release/*` / `hotfix/*` のみ | `develop` から作成 | `main` から作成 |
 | マージ方法許可 | **merge commit のみ**（release/hotfix の分岐履歴を保持） | squash merge（feature）＋ merge commit（release/hotfix back-merge） | merge commit | merge commit |
@@ -222,7 +222,12 @@ GitHub のブランチ保護設定は下表の通り。**enforce_admins = true**
 **back-merge 検知 CI（`back-merge-check`）**:
 - `release/*` / `hotfix/*` が `main` にマージされた後、**同じ branch を `develop` にもマージする PR が存在するか**を GitHub API で確認
 - 24h 以内に back-merge PR が開かれていない場合、自動的に Issue 起票（`back-merge-missing` ラベル）し、release 担当者にアサイン
-- これにより「`main` だけにマージして `develop` 退行」を Fail Fast で検知
+- これにより「`main` だけにマージして `develop` 退行」を事後検知
+
+**本ジョブは PR required status check として登録しない**。責務を分離する設計判断:
+- PR required status check は PR head commit の check status を評価する仕組みで、post-merge/cron トリガのジョブは PR head 時点では未実行であり、required に登録すると恒久的に pending のまま残って**偽陽性の block**を生む（Fail Fast の真逆）
+- back-merge は「**事後**に履行されるべき契約」であり、「PR マージ前に検証する」必要はない。Fail Fast は「事後違反を最速で検知し Issue 化する」という形で達成する（Single Responsibility に従い PR ゲート系統とは分離）
+- 代わりに main への release/hotfix PR 側で PR テンプレ・チェックリストに「back-merge PR を 24h 以内に作成する」責任を明示（§7.3 手順 4 / §7.4 手順 4）
 
 ## 8. コスト
 

--- a/docs/architecture/dev.md
+++ b/docs/architecture/dev.md
@@ -35,7 +35,7 @@ flowchart LR
 | `unit-core` | PR / push | `shikomi-core` ユニットテスト、`cargo nextest` | ubuntu-latest 単一（I/O なし、OS 非依存） |
 | `test-infra` | PR / push | `shikomi-infra` の OS 依存テスト | Win / macOS / Ubuntu（22.04 x11 + 24.04 wayland）の matrix |
 | `audit` | PR / push / nightly | `cargo-deny check`, Dependabot alerts 集約 | ubuntu-latest |
-| `build-preview` | PR `labeled: preview` | 未署名の 3-OS ビルドを artifact として PR に添付 | matrix |
+| `build-preview` | PR `labeled: preview` | **オプトインの開発者補助ジョブ（PR required status check としては登録しない — §7.6 の条件付トリガ・ジョブ分離方針に従う）**。未署名の 3-OS ビルドを artifact として PR に添付し、手元で動作確認したいレビュアのために提供 | matrix |
 | `build-nightly` | 日次 cron | 未署名バイナリ、`develop` から（main は常にタグ付きリリース状態のため nightly 対象ではない） | matrix |
 | `release` | タグ `v*.*.*` push（`main` への release/hotfix マージ後に付与） | 署名済み・公証済み・SBOM 付き成果物を Releases に登録 | matrix |
 | `pages` | main push（`docs/` 差分時） | `mdBook` / Astro 等で設計書＆ランディングページを GitHub Pages へ | ubuntu-latest |
@@ -129,7 +129,7 @@ GitHub のブランチ保護設定は下表の通り。**enforce_admins = true**
 |---------|--------|-----------|-------------|-----------|
 | 直接 push | ❌ 禁止 | ❌ 禁止 | ❌ 禁止（PR 経由のみ） | ❌ 禁止（PR 経由のみ） |
 | PR 必須 | ✅ | ✅ | ✅ | ✅ |
-| 必須 status checks | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` / `branch-policy` / `pr-title-check`（`back-merge-check` は post-merge/cron 監視のため PR required には含めない — §7.6） | `lint` / `unit-core` / `test-infra` / `audit` / `branch-policy` / `pr-title-check` | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` / `branch-policy` / `pr-title-check` | 同左 |
+| 必須 status checks | `lint` / `unit-core` / `test-infra` / `audit` / `branch-policy` / `pr-title-check`（`build-preview` / `back-merge-check` は条件付トリガ・post-merge/cron のため PR required には含めない — §7.6） | `lint` / `unit-core` / `test-infra` / `audit` / `branch-policy` / `pr-title-check` | `lint` / `unit-core` / `test-infra` / `audit` / `branch-policy` / `pr-title-check` | 同左 |
 | 必須レビュー人数 | **2 名**（CODEOWNERS 必須、緊急時は §7.4 bypass allowances で軽減可） | 1 名（CODEOWNERS 必須） | 2 名（CODEOWNERS 必須） | 2 名（CODEOWNERS 必須、緊急時は §7.4 bypass allowances で軽減可） |
 | PR ソース制限 | `release/*` または `hotfix/*` のみ（branch naming rule で強制） | `feature/*` / `release/*` / `hotfix/*` のみ | `develop` から作成 | `main` から作成 |
 | マージ方法許可 | **merge commit のみ**（release/hotfix の分岐履歴を保持） | squash merge（feature）＋ merge commit（release/hotfix back-merge） | merge commit | merge commit |
@@ -224,10 +224,19 @@ GitHub のブランチ保護設定は下表の通り。**enforce_admins = true**
 - 24h 以内に back-merge PR が開かれていない場合、自動的に Issue 起票（`back-merge-missing` ラベル）し、release 担当者にアサイン
 - これにより「`main` だけにマージして `develop` 退行」を事後検知
 
-**本ジョブは PR required status check として登録しない**。責務を分離する設計判断:
-- PR required status check は PR head commit の check status を評価する仕組みで、post-merge/cron トリガのジョブは PR head 時点では未実行であり、required に登録すると恒久的に pending のまま残って**偽陽性の block**を生む（Fail Fast の真逆）
-- back-merge は「**事後**に履行されるべき契約」であり、「PR マージ前に検証する」必要はない。Fail Fast は「事後違反を最速で検知し Issue 化する」という形で達成する（Single Responsibility に従い PR ゲート系統とは分離）
-- 代わりに main への release/hotfix PR 側で PR テンプレ・チェックリストに「back-merge PR を 24h 以内に作成する」責任を明示（§7.3 手順 4 / §7.4 手順 4）
+**条件付トリガ・ジョブを PR required status check に登録しない一般方針**:
+
+PR required status check は GitHub の仕様上「PR head commit に対して当該 check が**実行済み**かつ**success**」であることを要求する。したがって、以下のいずれかに該当するジョブを required に登録すると、対象外 PR では恒久的に pending のまま残り**偽陽性の block**を生む（Fail Fast の真逆で、真の異常がノイズに埋もれる）。本リポジトリでは当該パターンのジョブを一律 required から除外し、別系統の Fail Fast 機構で担保する。
+
+| ジョブ | 非対象 PR | required 登録時の事故 | 代替の Fail Fast |
+|-------|---------|----------------------|-----------------|
+| `back-merge-check` | 全 PR（post-merge / 日次 cron トリガ） | 全 PR が恒久 pending | 事後 24h 以内の back-merge 未実施を検知し `back-merge-missing` Issue 自動起票（§7.3 手順 4 / §7.4 手順 4 で PR テンプレに責任明示） |
+| `build-preview` | `preview` ラベル未付与 PR（= release/hotfix → main PR など日常の大半） | ラベル無し PR が恒久 pending | リリース側は `release` ジョブ（tag push トリガ）が 3-OS 署名ビルド・公証・SBOM・checksum を不可避で実施。開発時の動作確認は `preview` ラベルで opt-in 起動し、通過は任意 |
+
+**設計原則**:
+- **Single Responsibility**: PR ゲート（`lint` / `unit-core` / `test-infra` / `audit` / `branch-policy` / `pr-title-check`）と「事後監視」「opt-in 補助」を分離する
+- **Fail Fast**: 「検知できない」ことではなく「誤検知で本物のシグナルが埋もれる」ことが最悪の失敗モード。required の意味を正しく保つ
+- **Fail Secure**: リリース品質の最終担保は tag push 起動の `release` ジョブ側で**必ず**署名・公証が走る設計であり、`build-preview` が走らなくとも未署名バイナリが本番に流れることはない
 
 ## 8. コスト
 

--- a/docs/architecture/dev.md
+++ b/docs/architecture/dev.md
@@ -10,8 +10,8 @@ shikomi はクラウド「dev 環境」を持たないデスクトップ OSS の
 flowchart LR
     Dev[開発者] -- Push / PR --> GH[GitHub]
     PR[Pull Request] --> LintTest
-    Push[main Push] --> Nightly
-    Tag[v*.*.* tag] --> Release
+    Push[develop Push] --> Nightly
+    Tag[v*.*.* tag on main] --> Release
 
     subgraph GHA[GitHub Actions]
         direction TB
@@ -36,8 +36,8 @@ flowchart LR
 | `test-infra` | PR / push | `shikomi-infra` の OS 依存テスト | Win / macOS / Ubuntu（22.04 x11 + 24.04 wayland）の matrix |
 | `audit` | PR / push / nightly | `cargo-deny check`, Dependabot alerts 集約 | ubuntu-latest |
 | `build-preview` | PR `labeled: preview` | 未署名の 3-OS ビルドを artifact として PR に添付 | matrix |
-| `build-nightly` | 日次 cron | 未署名バイナリ、main から | matrix |
-| `release` | タグ `v*.*.*` push | 署名済み・公証済み・SBOM 付き成果物を Releases に登録 | matrix |
+| `build-nightly` | 日次 cron | 未署名バイナリ、`develop` から（main は常にタグ付きリリース状態のため nightly 対象ではない） | matrix |
+| `release` | タグ `v*.*.*` push（`main` への release/hotfix マージ後に付与） | 署名済み・公証済み・SBOM 付き成果物を Releases に登録 | matrix |
 | `pages` | main push（`docs/` 差分時） | `mdBook` / Astro 等で設計書＆ランディングページを GitHub Pages へ | ubuntu-latest |
 
 **Ubuntu は X11 と Wayland の両セッションでテストする**（Wayland のホットキー実装は X11 と別経路のため）。GitHub Actions の `ubuntu-24.04` は既定で Wayland セッション、`ubuntu-22.04` は X11 セッションを使える。詳細は環境差分ドキュメント（`environment-diff.md`）を参照。
@@ -59,7 +59,7 @@ flowchart LR
 - Dependabot: Rust (`cargo`), npm (`shikomi-gui/ui`), GitHub Actions の 3 エコシステムに対し週次
 - **lock file ガード**: `cargo --locked` / `pnpm install --frozen-lockfile` は「lock 再生成の禁止」しか検知できない。Cargo.toml 無変更で lock が書き換わった PR を検知するには追加ステップが必要:
   1. CI 冒頭で `cargo --locked fetch --offline` / `pnpm install --frozen-lockfile` を実行し、lock と manifest が一致しない場合 fail
-  2. **PR diff ガード**: `git diff --name-only origin/main...HEAD` で `Cargo.lock` / `pnpm-lock.yaml` が変更されているかつ `Cargo.toml` / `shikomi-*/Cargo.toml` / `package.json` に変更がない場合、**PR ラベル `deps-lockfile-only`** の付与をマージ条件に要求。ラベルは意図的な更新（`cargo update -p <crate>` 等）である根拠を PR 本文に記載した場合のみレビュアが付与する
+  2. **PR diff ガード**: `git diff --name-only origin/${GITHUB_BASE_REF}...HEAD`（GitFlow 上、feature PR は `develop`、release/hotfix PR は `main` が base になる）で `Cargo.lock` / `pnpm-lock.yaml` が変更されているかつ `Cargo.toml` / `shikomi-*/Cargo.toml` / `package.json` に変更がない場合、**PR ラベル `deps-lockfile-only`** の付与をマージ条件に要求。ラベルは意図的な更新（`cargo update -p <crate>` 等）である根拠を PR 本文に記載した場合のみレビュアが付与する
   3. 上記により「意図せず `cargo update` が発火して lock 全体が書換わる」事故を PR レビューで確実に止める
 - CVE 検知時: Dependabot alert → Severity High 以上は `security` ラベル付 Issue 自動起票、72h 以内にトリアージ
 
@@ -73,12 +73,132 @@ flowchart LR
 
 Wayland のホットキー portal は**対話的同意ダイアログ**が前提のため、CI では portal モック（`ashpd::backend` の test fixture）で代替する。
 
-## 7. ブランチ保護・マージ戦略
+## 7. ブランチ戦略・保護ルール・リリース運用（GitFlow）
 
-- `main` ブランチは保護：直接 push 禁止、PR 必須、required checks は `lint` / `unit-core` / `test-infra` / `audit`
-- レビュー: CODEOWNERS による最低 1 名承認必須
-- マージ戦略: **squash merge** 既定（履歴を線形に保つ、CHANGELOG 生成が容易）
-- Conventional Commits 準拠を PR テンプレートで促し、`release-please` で自動 CHANGELOG と タグ付け
+**方針**: **GitFlow** を採用する。shikomi は「署名付き tagged リリースの世代管理」「nightly での先行検証」「hotfix による緊急リリース」の 3 つをきれいに分離できる分岐モデルが必須で、trunk-based + release-please ではリリース前の release candidate 期間（署名・公証・キーチェーン連携の最終確認）を保持できないため GitFlow が適合する。
+
+### 7.1 ブランチモデル
+
+```mermaid
+gitGraph
+    commit id: "init"
+    branch develop
+    commit id: "dev base"
+    branch feature/hotkey
+    commit
+    commit
+    checkout develop
+    merge feature/hotkey
+    branch release/0.1.0
+    commit id: "bump 0.1.0"
+    checkout main
+    merge release/0.1.0 tag: "v0.1.0"
+    checkout develop
+    merge release/0.1.0
+    commit id: "next feature"
+    checkout main
+    branch hotfix/0.1.1
+    commit id: "fix crash"
+    checkout main
+    merge hotfix/0.1.1 tag: "v0.1.1"
+    checkout develop
+    merge hotfix/0.1.1
+```
+
+| ブランチ | 役割 | 起点 | マージ先 | 命名規則 | 生存期間 |
+|---------|-----|-----|---------|---------|---------|
+| `main` | **リリース済み** の唯一の真実源。各コミットはタグ付きリリースに対応 | （永続） | — | `main` | 永続 |
+| `develop` | 次期リリースの統合ブランチ。全 feature がここに集約 | （永続、初期は `main` から分岐） | release → main 経由で反映 | `develop` | 永続 |
+| `feature/*` | 単一機能・単一 Issue の作業ブランチ | `develop` | `develop` | `feature/{issue-number}-{slug}` または `feature/{slug}`（例: `feature/12-hotkey-registrar`） | マージ後削除 |
+| `release/*` | 機能凍結後の RC 期間。バージョン bump / CHANGELOG 確定 / 署名動作確認 / 小修正のみ | `develop` | `main`（tag 付与）＋ `develop`（back-merge） | `release/{version}`（例: `release/0.1.0`、**`v` 接頭辞なし**、タグ側に `v` を付ける） | RC 完了後削除 |
+| `hotfix/*` | リリース済み版への緊急修正 | `main` | `main`（tag 付与）＋ `develop`（back-merge） | `hotfix/{version}`（例: `hotfix/0.1.1`） | 修正リリース後削除 |
+
+**設計原則との整合**:
+- **Fail Fast**: `develop` は CI required checks を通らない限り他ブランチから影響を受けない。release/hotfix が `main` にマージされた瞬間 tag push が release ジョブを起動し、署名・公証失敗は即座に可視化される
+- **Tell, Don't Ask**: release/hotfix の back-merge は**強制ルール**（`develop` に取り込まないと次リリースで退行する）。CI で back-merge 未実施を検知し fail させる（§7.6）
+- **DRY**: Conventional Commits を 1 つの真実源として、CI・CHANGELOG・PR テンプレが全て参照する
+
+### 7.2 ブランチ保護ルール
+
+GitHub のブランチ保護設定は下表の通り。**include administrators = true**（管理者も規則に従う）、**force push = disabled**、**delete = disabled** は全保護ブランチ共通。
+
+| 設定項目 | `main` | `develop` | `release/*` | `hotfix/*` |
+|---------|--------|-----------|-------------|-----------|
+| 直接 push | ❌ 禁止 | ❌ 禁止 | ❌ 禁止（PR 経由のみ） | ❌ 禁止（PR 経由のみ） |
+| PR 必須 | ✅ | ✅ | ✅ | ✅ |
+| 必須 status checks | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` / `back-merge-check` | `lint` / `unit-core` / `test-infra` / `audit` | `lint` / `unit-core` / `test-infra` / `audit` / `build-preview` | 同左 |
+| 必須レビュー人数 | **2 名**（CODEOWNERS 必須） | 1 名（CODEOWNERS 必須） | 2 名（CODEOWNERS 必須） | 2 名（CODEOWNERS 必須、緊急時は 1 名＋事後レビュー） |
+| PR ソース制限 | `release/*` または `hotfix/*` のみ（branch naming rule で強制） | `feature/*` / `release/*` / `hotfix/*` のみ | `develop` から作成 | `main` から作成 |
+| マージ方法許可 | **merge commit のみ**（release/hotfix の分岐履歴を保持） | squash merge（feature）＋ merge commit（release/hotfix back-merge） | merge commit | merge commit |
+| linear history 強制 | ❌（merge commit 必須のため） | ❌ | ❌ | ❌ |
+| Conversation 解決必須 | ✅ | ✅ | ✅ | ✅ |
+| Signed commits 必須 | ✅（GPG/SSH/Sigstore いずれか） | ✅ | ✅ | ✅ |
+| 古い承認の再取得 | 新 commit で承認無効化 | 新 commit で承認無効化 | 新 commit で承認無効化 | 同左 |
+
+**PR ソース制限の実現**:
+- GitHub ブランチ保護ルールネイティブでは「どのブランチから PR できるか」を直接制限できない。代わりに `.github/workflows/branch-policy.yml` で PR 作成時に source branch 名を検査し、`main` への PR が `release/*` / `hotfix/*` 以外なら即 fail させる（required status check として登録）
+- `develop` への直接 `feature/*` 以外の commit 流入も同様に検知
+
+**CODEOWNERS**:
+- `docs/architecture/` は設計責任者（複数名）
+- `.github/` は全体オーナー
+- `shikomi-core/` / `shikomi-infra/` は Rust チーム
+- `shikomi-gui/` は GUI チーム
+- ルート直下（`LICENSE`, `README.md`, `SECURITY.md`, `CONTRIBUTING.md`）は全体オーナー
+
+### 7.3 リリース手順（release ブランチ）
+
+1. **開始**: `develop` の機能が整った時点で、リリース責任者が `release/X.Y.Z` を `develop` から切る。この瞬間以降 `develop` には**次期リリース対象の feature のみマージ可**（今回のリリースには含めない）
+2. **RC 作業**: `release/X.Y.Z` 上で以下のみ許可
+   - ワークスペース版数の bump（`Cargo.toml` の `workspace.package.version`、`tauri.conf.json`、`package.json`）
+   - `CHANGELOG.md` の確定（§7.6 の `git-cliff` により自動生成 → 人間が校正）
+   - RC ビルドの署名・公証動作確認（macOS notarytool、Windows Azure Trusted Signing、Linux minisign）
+   - RC で発見された bug 修正のみ（新機能は**絶対に**入れない）
+3. **main への昇格**: `release/X.Y.Z` → `main` への PR を作成し、CODEOWNERS 2 名承認＋全 required checks 通過で **merge commit** マージ。直後に `vX.Y.Z` タグを付与して push（tag push が `release` ジョブを起動）
+4. **back-merge**: 同じ `release/X.Y.Z` を `develop` にも merge commit で戻す。これを忘れると `develop` のバージョンが `main` より古くなり、次回 release で衝突する。§7.6 の `back-merge-check` CI で検知・強制
+5. **片付け**: `release/X.Y.Z` ブランチ削除（GitHub 設定 "Automatically delete head branches" で自動化）
+
+### 7.4 hotfix 手順
+
+1. **開始**: `main`（= 現行リリース）でバグが報告されたら、ホットフィックス責任者が `hotfix/X.Y.(Z+1)` を `main` から切る
+2. **修正作業**: `hotfix/X.Y.(Z+1)` 上でバグ修正のみ実施。バージョン bump は patch のみ
+3. **main への昇格**: `hotfix/X.Y.(Z+1)` → `main` への PR を作成し、CODEOWNERS 2 名承認＋required checks 通過で **merge commit**。`vX.Y.(Z+1)` タグ付与
+4. **back-merge**: 同じ hotfix を `develop` へも merge commit で戻す
+5. **片付け**: ブランチ削除
+
+**緊急時例外**: セキュリティ脆弱性（`SECURITY.md` 経由の報告）は 1 名承認＋事後レビュー可。事後レビュー期限は main マージから 72h。未実施は Issue として自動起票（`security-post-review` ラベル）
+
+### 7.5 マージ戦略とコミット規約
+
+| PR 種別 | ソース | 宛先 | マージ方法 | 理由 |
+|--------|-------|------|----------|------|
+| feature | `feature/*` | `develop` | **squash merge** | feature ブランチ内の作業コミットは履歴に残さない。PR タイトルが 1 commit のメッセージになる。Conventional Commits（例: `feat(hotkey): add Wayland portal fallback`） |
+| release → main | `release/*` | `main` | **merge commit**（`--no-ff`） | 「このコミットはリリース分岐から来た」という事実を history に残す。タグと 1:1 対応 |
+| release → develop | `release/*` | `develop` | **merge commit**（`--no-ff`） | 同上（back-merge 痕跡を残す） |
+| hotfix → main | `hotfix/*` | `main` | **merge commit**（`--no-ff`） | 同上 |
+| hotfix → develop | `hotfix/*` | `develop` | **merge commit**（`--no-ff`） | 同上 |
+
+**Conventional Commits 必須**（§7.6 の CHANGELOG 自動化の前提）:
+- `feat:` / `fix:` / `docs:` / `chore:` / `refactor:` / `test:` / `ci:` / `build:` / `perf:` のいずれか
+- Breaking change は `feat!:` または `BREAKING CHANGE:` フッター
+- PR 作成時に `.github/workflows/pr-title-check.yml` で PR タイトルを正規表現検証し、違反は required check fail（squash merge 時の commit メッセージとして採用されるため）
+
+### 7.6 CHANGELOG 自動化（release-please からの移行）
+
+**決定**: `release-please` は trunk-based 前提で GitFlow と噛み合わないため **`git-cliff` に切替**。
+
+- `git-cliff` は Rust 製、Conventional Commits を読み、任意のリビジョン範囲で CHANGELOG を生成できる
+- 設定: リポジトリ直下の `cliff.toml` にグルーピングルールを記載（`feat` → `Features`、`fix` → `Bug Fixes` 等）
+- 生成タイミング:
+  1. `release/*` ブランチ作成直後に `git-cliff --tag vX.Y.Z` で未リリース区間を CHANGELOG.md に確定追記
+  2. 人間が release PR 上で文言校正
+  3. `main` マージ＆ tag push 後、GitHub Actions が `git-cliff --current` で GitHub Release の release note を自動生成
+- 出典: https://git-cliff.org/docs/configuration
+
+**back-merge 検知 CI（`back-merge-check`）**:
+- `release/*` / `hotfix/*` が `main` にマージされた後、**同じ branch を `develop` にもマージする PR が存在するか**を GitHub API で確認
+- 24h 以内に back-merge PR が開かれていない場合、自動的に Issue 起票（`back-merge-missing` ラベル）し、release 担当者にアサイン
+- これにより「`main` だけにマージして `develop` 退行」を Fail Fast で検知
 
 ## 8. コスト
 

--- a/docs/architecture/test-design.md
+++ b/docs/architecture/test-design.md
@@ -40,18 +40,20 @@
 | TC-U14 | REPO-01 | `SECURITY.md` に脆弱性報告窓口の記載を含む | ユニット | 正常系 |
 | TC-U15 | REPO-01 | `CODEOWNERS` に `docs/architecture/` の責務割当を含む | ユニット | 正常系 |
 | TC-U16 | REPO-05 | `CONTRIBUTING.md` に `feature/*` → `develop` のマージ先が明記されている | ユニット | 正常系 |
-| TC-I01 | REPO-02 | `main` ブランチ保護: PR 必須・2名レビュー・status checks・force push 禁止・merge commit のみ・会話解決必須・bypass list | 結合 | 正常系 |
-| TC-I02 | REPO-02 | `develop` ブランチ保護: PR 必須・1名レビュー・status checks・force push 禁止 | 結合 | 正常系 |
+| TC-I01 | REPO-02 | `main` ブランチ保護: PR 必須・2名レビュー・status checks（branch-policy/pr-title-check含む）・force push 禁止・会話解決必須・bypass list | 結合 | 正常系 |
+| TC-I02 | REPO-02 | `develop` ブランチ保護: PR 必須・1名レビュー・status checks（branch-policy/pr-title-check含む）・force push 禁止 | 結合 | 正常系 |
 | TC-I03 | REPO-02 | `main` ブランチ: signed commits 必須設定 | 結合 | 正常系 |
 | TC-I04 | REPO-02 | `develop` ブランチ: signed commits 必須設定 | 結合 | 正常系 |
 | TC-I05 | REPO-02 | `main`: PR ソース制限（`release/*` / `hotfix/*` のみ許可する branch-policy ワークフローが存在する） | 結合 | 正常系 |
 | TC-I06 | REPO-05 | `develop` ブランチが存在する | 結合 | 正常系 |
 | TC-I07 | REPO-02 | `main` / `develop`: enforce_admins = true + bypass list にセキュリティ緊急例外アクターが設定されている | 結合 | 正常系 |
 | TC-I08 | REPO-02 | `main` への直接 PR を許可しない branch-policy ワークフローの静的確認（ファイル存在・ソース制限ロジック） | 結合 | 異常系 |
-| TC-I09 | REPO-02 | `main` マージ戦略: merge commit のみ許可（squash merge / rebase merge 禁止） | 結合 | 正常系 |
+| TC-I09 | REPO-02 | `main` マージ方法規約の文書化確認（CONTRIBUTING.md に merge commit 使用規約が明記されているか） | 結合 | 正常系 |
 | TC-I10 | REPO-02 | `develop` マージ戦略: squash merge + merge commit 許可（rebase merge 禁止） | 結合 | 正常系 |
 | TC-I11 | REPO-02 | `main` / `develop`: required_conversation_resolution == true | 結合 | 正常系 |
 | TC-I12 | REPO-02 | bypass list にセキュリティ緊急対応アクター（チームまたはユーザー）が 1 件以上設定されている | 結合 | 正常系 |
+| TC-I13 | REPO-02 | `.github/workflows/pr-title-check.yml` の存在確認 | 結合 | 正常系 |
+| TC-I14 | REPO-02 | `.github/workflows/back-merge-check.yml` の存在確認 | 結合 | 正常系 |
 | TC-E01 | REPO-01, REPO-03, REPO-04 | 新規コントリビューターが必要情報を取得できるシナリオ | E2E | 正常系 |
 | TC-E02 | REPO-05, REPO-06 | コアメンバーが GitFlow に従い develop へ PR を作成できるシナリオ | E2E | 正常系 |
 
@@ -102,7 +104,7 @@
 | 種別 | 正常系 |
 | 前提条件 | `main` ブランチ保護が GitHub 上で設定済み |
 | 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection` を実行 |
-| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 2<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_pull_request_reviews.dismiss_stale_reviews` == true<br>- `required_pull_request_reviews.bypass_pull_request_allowances` に 1 件以上のアクター（teams または users）が設定されている<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit`, `build-preview`, `back-merge-check` が含まれる<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false<br>- `required_conversation_resolution.enabled` == true |
+| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 2<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_pull_request_reviews.dismiss_stale_reviews` == true<br>- `required_pull_request_reviews.bypass_pull_request_allowances` に 1 件以上のアクター（teams または users）が設定されている<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit`, `build-preview`, `back-merge-check`, `branch-policy`, `pr-title-check` が含まれる<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false<br>- `required_conversation_resolution.enabled` == true |
 
 ### TC-I02: develop ブランチ保護ルール確認
 
@@ -114,7 +116,7 @@
 | 種別 | 正常系 |
 | 前提条件 | `develop` ブランチ保護が GitHub 上で設定済み |
 | 操作 | `gh api repos/shikomi-dev/shikomi/branches/develop/protection` を実行 |
-| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 1<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit` が含まれる<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false |
+| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 1<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit`, `branch-policy`, `pr-title-check` が含まれる<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false |
 
 ### TC-I03: main ブランチの signed commits 必須確認
 
@@ -190,7 +192,9 @@
 | 操作 | 1. `gh api repos/shikomi-dev/shikomi/contents/.github/workflows/branch-policy.yml` でワークフローファイル取得<br>2. base64 デコードし内容確認<br>3. `gh api repos/shikomi-dev/shikomi/branches/main/protection` で required_status_checks を確認 |
 | 期待結果 | - `branch-policy.yml` が存在し、`github.base_ref == 'main'`（または同等条件）と source branch のパターン検査（`release/*` / `hotfix/*` 以外を拒否）の記述を含む<br>- `main` の保護設定の `required_status_checks.checks` に branch-policy の check context が含まれる |
 
-### TC-I09: main マージ戦略確認（merge commit のみ）
+### TC-I09: main マージ方法規約の文書化確認
+
+> **置換理由**: GitHub はリポジトリ単位でのみマージ方法を設定するため、main 専用の「merge commit のみ」制限は `allow_squash_merge` フラグでは技術的に実現不能（TC-I10 と矛盾する）。main での merge commit 使用は規約として CONTRIBUTING.md に文書化し、TC-I08 の branch-policy による PR ソース制限（`release/*` / `hotfix/*` のみ）と組み合わせることで実質的な運用制約を実現する。
 
 | 項目 | 内容 |
 |------|------|
@@ -198,9 +202,9 @@
 | 対応する受入基準ID | REPO-02 |
 | 対応する工程 | 基本設計（dev.md §7.5） |
 | 種別 | 正常系 |
-| 前提条件 | リポジトリ設定が完了済み |
-| 操作 | `gh api repos/shikomi-dev/shikomi` でリポジトリ設定を取得 |
-| 期待結果 | - `allow_merge_commit` == true<br>- `allow_squash_merge` == false<br>- `allow_rebase_merge` == false<br>（§7.5「release/hotfix → main は merge commit のみ」に準拠） |
+| 前提条件 | `CONTRIBUTING.md` が存在する |
+| 操作 | `gh api repos/shikomi-dev/shikomi/contents/CONTRIBUTING.md` を取得し base64 デコードして内容確認 |
+| 期待結果 | `grep -iP "merge.commit"` または `grep -i "merge commit"` がマッチする行が 1 件以上存在する（main への PR は merge commit を使用するという規約が文書化されている） |
 
 ### TC-I10: develop マージ戦略確認（squash + merge commit 許可）
 
@@ -214,7 +218,7 @@
 | 操作 | `gh api repos/shikomi-dev/shikomi` でリポジトリ設定を取得（リポジトリ全体設定で squash/merge commit 両方許可かつ rebase 禁止） |
 | 期待結果 | - `allow_merge_commit` == true（release/hotfix back-merge に使用）<br>- `allow_squash_merge` == true（feature → develop の squash に使用）<br>- `allow_rebase_merge` == false<br>（§7.5「feature→develop は squash、release/hotfix は merge commit」に準拠） |
 
-> **注意**: GitHub はリポジトリ単位でマージ戦略を設定する。TC-I09 と TC-I10 は同一 API レスポンスから検証するが、「main と develop で異なるマージ方法を使い分ける」という §7.5 の仕様上、squash + merge commit 両方が有効である必要がある。
+> **注意**: GitHub はリポジトリ単位でマージ戦略を設定するため、「develop のみ squash merge」という per-branch 制限は技術的に不可能。TC-I10 は「squash + merge commit 両方が有効（rebase は禁止）」を確認する。feature→develop での squash 使用・release/hotfix→main での merge commit 使用はいずれも TC-I09 で文書化規約として補完する。
 
 ### TC-I11: required_conversation_resolution 確認
 
@@ -239,6 +243,30 @@
 | 前提条件 | `main` 保護設定済み、セキュリティ緊急対応チームが GitHub 上に存在する |
 | 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection` を実行し `bypass_pull_request_allowances` を確認 |
 | 期待結果 | `required_pull_request_reviews.bypass_pull_request_allowances.teams` または `.users` に 1 件以上のアクターが存在する<br>（セキュリティ脆弱性 hotfix 時に `enforce_admins=true` を維持しつつ特定チームのみバイパス可能とする §7.4 緊急例外ルートが技術的に実現されている） |
+
+### TC-I13: pr-title-check.yml の存在確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I13 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §3, §7.5） |
+| 種別 | 正常系 |
+| 前提条件 | `feature/repo-setup` → `develop` マージ済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi/contents/.github/workflows/pr-title-check.yml` |
+| 期待結果 | HTTP 200。content に Conventional Commits パターン（`feat`/`fix`/`docs` 等）を検証する正規表現の記述を含む |
+
+### TC-I14: back-merge-check.yml の存在確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I14 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §3, §7.6） |
+| 種別 | 正常系 |
+| 前提条件 | `feature/repo-setup` → `develop` マージ済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi/contents/.github/workflows/back-merge-check.yml` |
+| 期待結果 | HTTP 200。content に `develop` への back-merge PR 存在確認ロジック（`release/*` または `hotfix/*` のマージ後に develop への PR を検査する記述）を含む |
 
 ## 6. ユニットテスト設計（ファイル存在・内容検証）
 
@@ -334,7 +362,7 @@
 | 種別 | 正常系 |
 | 前提条件 | `CONTRIBUTING.md` が存在する |
 | 操作 | `CONTRIBUTING.md` を取得し内容確認 |
-| 期待結果 | `feature` と `develop` が共起しており、`feature/*` ブランチのマージ先が `develop` であることを読み取れる記述を含む（例: 「feature ブランチは develop にマージ」「feature/* → develop」等） |
+| 期待結果 | `grep -P "feature.*develop"` がマッチする行が 1 件以上存在する。または `grep -P "feature/"` と `grep -P "develop"` が前後 3 行以内に共起する記述が存在する<br>具体的な合格例: `feature/* → develop`、`feature ブランチは develop にマージ`、`feature/xxx を develop にマージ` 等の記述 |
 
 ## 7. モック方針
 
@@ -371,15 +399,36 @@ gh api repos/shikomi-dev/shikomi/branches/main/protection | jq '{
 }'
 ```
 
-### 実行コマンド例（結合テスト TC-I09/TC-I10: マージ戦略確認）
+### 実行コマンド例（結合テスト TC-I09: merge commit 規約確認）
 
 ```bash
-# リポジトリ設定のマージ戦略確認
+# CONTRIBUTING.md の merge commit 規約明記確認
+gh api repos/shikomi-dev/shikomi/contents/CONTRIBUTING.md \
+  | jq -r '.content' | base64 -d \
+  | grep -iP "merge.commit" && echo "PASS" || echo "FAIL"
+```
+
+### 実行コマンド例（結合テスト TC-I10: マージ戦略確認）
+
+```bash
+# リポジトリ設定のマージ戦略確認（squash + merge commit 両方有効・rebase 禁止）
 gh api repos/shikomi-dev/shikomi | jq '{
   allow_merge_commit: .allow_merge_commit,
   allow_squash_merge: .allow_squash_merge,
   allow_rebase_merge: .allow_rebase_merge
 }'
+```
+
+### 実行コマンド例（結合テスト TC-I13/TC-I14: ワークフロー存在確認）
+
+```bash
+# pr-title-check.yml 存在確認
+gh api repos/shikomi-dev/shikomi/contents/.github/workflows/pr-title-check.yml \
+  | jq '.name'
+
+# back-merge-check.yml 存在確認
+gh api repos/shikomi-dev/shikomi/contents/.github/workflows/back-merge-check.yml \
+  | jq '.name'
 ```
 
 ### 実行コマンド例（ユニットテスト TC-U08 〜 TC-U13）
@@ -420,3 +469,4 @@ echo "$CONTENT" | grep -q "hotfix"   && echo "PASS" || echo "FAIL"
 
 *作成: 涅マユリ（テスト担当）/ 2026-04-22*
 *改訂: 涅マユリ（テスト担当）/ 2026-04-22 — TC-E03→TC-I08再分類、TC-I09〜TC-I12追加、TC-U13強化、TC-U16追加、bypass list検証追記*
+*改訂: 涅マユリ（テスト担当）/ 2026-04-22 — TC-I09を矛盾する allow_squash_merge==false から merge commit 規約文書化確認に置換、TC-I01/I02の必須 status checks に branch-policy/pr-title-check 追加、TC-I13/I14（ワークフロー存在確認）新設、TC-U16 期待結果を具体的 grep パターンに変更*

--- a/docs/architecture/test-design.md
+++ b/docs/architecture/test-design.md
@@ -1,0 +1,334 @@
+# テスト設計書 — repo-setup（リポジトリ整備）
+
+## 1. 概要
+
+| 項目 | 内容 |
+|------|------|
+| 対象 feature | repo-setup（GitFlow ブランチ整備・リポジトリガバナンスファイル整備） |
+| 対象ブランチ | `feature/repo-setup` |
+| 設計根拠 | `docs/architecture/dev.md` §7（GitFlow ブランチ戦略・保護ルール）|
+| テスト実行タイミング | `feature/repo-setup` → `develop` へのマージ前、および `develop` → `main` マージ前 |
+
+## 2. テスト対象と受入基準
+
+| 受入基準ID | 受入基準 | 検証レベル |
+|-----------|---------|-----------|
+| REPO-01 | 全対象ファイルがリポジトリルートまたは所定パスに存在する | ユニット |
+| REPO-02 | ブランチ保護ルールが §7.2 の仕様通りに GitHub に設定されている | 結合 |
+| REPO-03 | LICENSE に MIT 文言と著作権表記が含まれる | ユニット |
+| REPO-04 | README.md にインストール手順・権限要件・使い方が含まれる | ユニット |
+| REPO-05 | `develop` ブランチが存在し、`feature/*` のデフォルトマージ先が `develop` である | 結合 |
+| REPO-06 | `.github/` テンプレート群が存在し、Issue/PR 作成時に自動適用される | E2E |
+
+## 3. テストマトリクス（トレーサビリティ）
+
+| テストID | 受入基準ID | 検証対象ファイル/設定 | テストレベル | 種別 |
+|---------|-----------|---------------------|------------|------|
+| TC-U01 | REPO-01 | `README.md` の存在 | ユニット | 正常系 |
+| TC-U02 | REPO-01 | `LICENSE` の存在 | ユニット | 正常系 |
+| TC-U03 | REPO-01 | `CONTRIBUTING.md` の存在 | ユニット | 正常系 |
+| TC-U04 | REPO-01 | `SECURITY.md` の存在 | ユニット | 正常系 |
+| TC-U05 | REPO-01 | `CODEOWNERS` の存在 | ユニット | 正常系 |
+| TC-U06 | REPO-01 | `.github/ISSUE_TEMPLATE/*.yml` の存在（1件以上）| ユニット | 正常系 |
+| TC-U07 | REPO-01 | `.github/pull_request_template.md` の存在 | ユニット | 正常系 |
+| TC-U08 | REPO-03 | `LICENSE` に「MIT License」文言を含む | ユニット | 正常系 |
+| TC-U09 | REPO-03 | `LICENSE` に著作権年・著作者名を含む（`Copyright`） | ユニット | 正常系 |
+| TC-U10 | REPO-04 | `README.md` にインストール手順セクションを含む | ユニット | 正常系 |
+| TC-U11 | REPO-04 | `README.md` に権限要件の記載を含む | ユニット | 正常系 |
+| TC-U12 | REPO-04 | `README.md` に使い方（Usage）の記載を含む | ユニット | 正常系 |
+| TC-U13 | REPO-01 | `CONTRIBUTING.md` に GitFlow ブランチモデルの記載を含む | ユニット | 正常系 |
+| TC-U14 | REPO-01 | `SECURITY.md` に脆弱性報告窓口の記載を含む | ユニット | 正常系 |
+| TC-U15 | REPO-01 | `CODEOWNERS` に `docs/architecture/` の責務割当を含む | ユニット | 正常系 |
+| TC-I01 | REPO-02 | `main` ブランチ保護: PR 必須・2名レビュー・status checks・force push 禁止 | 結合 | 正常系 |
+| TC-I02 | REPO-02 | `develop` ブランチ保護: PR 必須・1名レビュー・status checks・force push 禁止 | 結合 | 正常系 |
+| TC-I03 | REPO-02 | `main` ブランチ: signed commits 必須設定 | 結合 | 正常系 |
+| TC-I04 | REPO-02 | `develop` ブランチ: signed commits 必須設定 | 結合 | 正常系 |
+| TC-I05 | REPO-02 | `main`: PR ソース制限（`release/*` / `hotfix/*` のみ許可する branch-policy ワークフローが存在する） | 結合 | 正常系 |
+| TC-I06 | REPO-05 | `develop` ブランチが存在する | 結合 | 正常系 |
+| TC-I07 | REPO-02 | `main` / `develop`: include_administrators = true（管理者も保護ルール適用） | 結合 | 正常系 |
+| TC-E01 | REPO-01, REPO-03, REPO-04 | 新規コントリビューターが必要情報を取得できるシナリオ | E2E | 正常系 |
+| TC-E02 | REPO-05, REPO-06 | コアメンバーが GitFlow に従い develop へ PR を作成できるシナリオ | E2E | 正常系 |
+| TC-E03 | REPO-02 | `feature/*` から `main` への直接 PR が branch-policy チェックで失敗するシナリオ | E2E | 異常系 |
+
+## 4. E2Eテスト設計（受入基準 REPO-01, 02, 05, 06 の振る舞い検証）
+
+> **ツール選択根拠**: このシステムは GitHub リポジトリそのもの（CLI/公開 API が主インターフェース）。
+> Playwright は不要。`gh` CLI + `gh api` でブラックボックス検証する。
+
+### TC-E01: 新規コントリビューターのオンボーディングシナリオ
+
+**ペルソナ**: 外部コントリビューター（プロジェクトにはじめて貢献しようとする開発者）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-E01 |
+| 対応する受入基準ID | REPO-01, REPO-03, REPO-04 |
+| 対応する工程 | 要件定義（キャプテン・アメリカからの要求） |
+| 種別 | 正常系 |
+| 前提条件 | `feature/repo-setup` が `develop` にマージ済み。GitHub 上でリポジトリが公開状態 |
+| 操作 | 1. `gh repo view shikomi-dev/shikomi` でリポジトリ概要を取得<br>2. `gh api repos/shikomi-dev/shikomi/contents/LICENSE` で LICENSE を確認<br>3. `gh api repos/shikomi-dev/shikomi/contents/README.md` で README を確認<br>4. `gh api repos/shikomi-dev/shikomi/contents/CONTRIBUTING.md` で CONTRIBUTING を確認<br>5. `gh api repos/shikomi-dev/shikomi/contents/SECURITY.md` で SECURITY を確認 |
+| 期待結果 | - 全ファイルの取得が成功する（HTTP 200、content フィールドに base64 データあり）<br>- LICENSE の内容に「MIT License」と「Copyright」を含む<br>- README の内容にインストール手順・権限要件・使い方のキーワードを含む<br>- CONTRIBUTING の内容に GitFlow / feature / develop のキーワードを含む<br>- SECURITY の内容に脆弱性報告（security / vulnerability / report 等）のキーワードを含む |
+
+### TC-E02: コアメンバーの GitFlow ワークフローシナリオ
+
+**ペルソナ**: コアメンバー（定常的に開発する内部メンバー）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-E02 |
+| 対応する受入基準ID | REPO-05, REPO-06 |
+| 対応する工程 | 要件定義 |
+| 種別 | 正常系 |
+| 前提条件 | `develop` ブランチが存在する。`.github/pull_request_template.md` が存在する |
+| 操作 | 1. `gh api repos/shikomi-dev/shikomi/branches/develop` で develop ブランチの存在確認<br>2. `gh api repos/shikomi-dev/shikomi/contents/.github/pull_request_template.md` で PR テンプレート取得<br>3. `gh api repos/shikomi-dev/shikomi/contents/.github/ISSUE_TEMPLATE` で Issue テンプレート一覧取得 |
+| 期待結果 | - develop ブランチが HTTP 200 で取得できる<br>- PR テンプレートが取得でき、content が空でない<br>- Issue テンプレートが 1 件以上存在する（配列が空でない） |
+
+### TC-E03: main への直接 PR がブランチポリシーで拒否されるシナリオ
+
+**ペルソナ**: コアメンバー（誤って main に直接 PR を作成しようとした）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-E03 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 要件定義 |
+| 種別 | 異常系 |
+| 前提条件 | `.github/workflows/branch-policy.yml` が存在する。`main` ブランチ保護が設定済み |
+| 操作 | 1. `gh api repos/shikomi-dev/shikomi/contents/.github/workflows/branch-policy.yml` でワークフローファイルの存在確認<br>2. ワークフロー内容に PR の source branch を検査する記述が含まれることを確認<br>3. `gh api repos/shikomi-dev/shikomi/branches/main/protection` で保護設定を確認し、required_status_checks に branch-policy が含まれることを確認 |
+| 期待結果 | - `branch-policy.yml` が存在し、内容に `github.base_ref == 'main'` かつ source branch 検査の記述を含む<br>- `main` の保護設定の required_status_checks に branch-policy 相当のチェックが含まれる |
+
+## 5. 結合テスト設計（GitHub API による設定値の契約検証）
+
+> **検証スタイル**: `gh api` で実際の GitHub 設定値を取得し、§7.2 の仕様と具体的に照合する（contract testing）。
+
+### TC-I01: main ブランチ保護ルール確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I01 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.2） |
+| 種別 | 正常系 |
+| 前提条件 | `main` ブランチ保護が GitHub 上で設定済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection` を実行 |
+| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 2<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_pull_request_reviews.dismiss_stale_reviews` == true<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit`, `build-preview`, `back-merge-check` が含まれる<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false |
+
+### TC-I02: develop ブランチ保護ルール確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I02 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.2） |
+| 種別 | 正常系 |
+| 前提条件 | `develop` ブランチ保護が GitHub 上で設定済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi/branches/develop/protection` を実行 |
+| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 1<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit` が含まれる<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false |
+
+### TC-I03: main ブランチの signed commits 必須確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I03 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.2） |
+| 種別 | 正常系 |
+| 前提条件 | `main` ブランチ保護が設定済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection/required_signatures` を実行 |
+| 期待結果 | `enabled` == true |
+
+### TC-I04: develop ブランチの signed commits 必須確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I04 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.2） |
+| 種別 | 正常系 |
+| 前提条件 | `develop` ブランチ保護が設定済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi/branches/develop/protection/required_signatures` を実行 |
+| 期待結果 | `enabled` == true |
+
+### TC-I05: branch-policy ワークフローの存在確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I05 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.2） |
+| 種別 | 正常系 |
+| 前提条件 | `feature/repo-setup` → `develop` マージ済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi/contents/.github/workflows/branch-policy.yml` |
+| 期待結果 | HTTP 200、content に `github.base_ref` の検査ロジックを含む |
+
+### TC-I06: develop ブランチの存在確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I06 |
+| 対応する受入基準ID | REPO-05 |
+| 対応する工程 | 基本設計（dev.md §7.1） |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | `gh api repos/shikomi-dev/shikomi/branches/develop` |
+| 期待結果 | HTTP 200、`name` == `"develop"` |
+
+### TC-I07: 管理者保護ルール適用確認（include_administrators）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I07 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.2） |
+| 種別 | 正常系 |
+| 前提条件 | `main` / `develop` 保護設定済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection` および `develop/protection` |
+| 期待結果 | `enforce_admins.enabled` == true（両ブランチとも） |
+
+## 6. ユニットテスト設計（ファイル存在・内容検証）
+
+> **ツール**: `gh api repos/shikomi-dev/shikomi/contents/{path}` で取得し base64 デコードして文字列検索。
+> または git clone 後のローカルファイルを直接確認。
+
+### TC-U01〜TC-U07: ファイル存在確認群
+
+| テストID | 検証対象パス | 期待結果 |
+|---------|------------|---------|
+| TC-U01 | `README.md` | HTTP 200 / ファイルが存在する |
+| TC-U02 | `LICENSE` | HTTP 200 / ファイルが存在する |
+| TC-U03 | `CONTRIBUTING.md` | HTTP 200 / ファイルが存在する |
+| TC-U04 | `SECURITY.md` | HTTP 200 / ファイルが存在する |
+| TC-U05 | `CODEOWNERS` | HTTP 200 / ファイルが存在する |
+| TC-U06 | `.github/ISSUE_TEMPLATE/` | ディレクトリに `.yml` ファイルが 1 件以上存在する |
+| TC-U07 | `.github/pull_request_template.md` | HTTP 200 / ファイルが存在する |
+
+**前提条件**: `feature/repo-setup` が `develop` にマージ済み（または feature ブランチ上で検証）
+**操作**: `gh api repos/shikomi-dev/shikomi/contents/{path}?ref=develop`
+**対応する受入基準ID**: REPO-01
+
+### TC-U08〜TC-U09: LICENSE 内容確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-U08 |
+| 対応する受入基準ID | REPO-03 |
+| 対応する工程 | 要件定義 |
+| 種別 | 正常系 |
+| 前提条件 | `LICENSE` が存在する |
+| 操作 | `LICENSE` を取得し内容を確認 |
+| 期待結果 | 「MIT License」の文字列を含む |
+
+| テストID | TC-U09 |
+|---------|--------|
+| 期待結果 | 「Copyright」の文字列を含む（著作権年・著作者名が記載されている） |
+
+### TC-U10〜TC-U12: README 必須記載確認
+
+| テストID | 検証キーワード | 目的 | 対応する受入基準ID |
+|---------|-------------|------|-----------------|
+| TC-U10 | `install` または `インストール` または `## Install` | インストール手順セクションの存在 | REPO-04 |
+| TC-U11 | `permission` または `権限` または `0600` または `ACL` | 権限要件の記載 | REPO-04 |
+| TC-U12 | `usage` または `使い方` または `## Usage` | 使い方セクションの存在 | REPO-04 |
+
+**前提条件**: `README.md` が存在する
+**操作**: README.md を取得し、各キーワードが含まれているか確認（大文字小文字区別なし）
+
+### TC-U13: CONTRIBUTING.md GitFlow 記載確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-U13 |
+| 対応する受入基準ID | REPO-01 |
+| 対応する工程 | 要件定義 |
+| 種別 | 正常系 |
+| 前提条件 | `CONTRIBUTING.md` が存在する |
+| 操作 | `CONTRIBUTING.md` を取得し内容確認 |
+| 期待結果 | 「feature」「develop」「GitFlow」または「ブランチ」のいずれかを含む |
+
+### TC-U14: SECURITY.md 脆弱性報告窓口確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-U14 |
+| 対応する受入基準ID | REPO-01 |
+| 対応する工程 | 要件定義 |
+| 種別 | 正常系 |
+| 前提条件 | `SECURITY.md` が存在する |
+| 操作 | `SECURITY.md` を取得し内容確認 |
+| 期待結果 | 「report」または「報告」または「vulnerability」または「脆弱性」を含む |
+
+### TC-U15: CODEOWNERS 責務割当確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-U15 |
+| 対応する受入基準ID | REPO-01 |
+| 対応する工程 | 要件定義 |
+| 種別 | 正常系 |
+| 前提条件 | `CODEOWNERS` が存在する |
+| 操作 | `CODEOWNERS` を取得し内容確認 |
+| 期待結果 | `docs/architecture/` のパターンに対する所有者割当が存在する |
+
+## 7. モック方針
+
+| 検証対象 | モック要否 | 理由 |
+|---------|---------|------|
+| GitHub API（ブランチ保護・ファイル取得） | **不要**（本物を使用） | このテストの目的は「GitHub 上に正しく設定されているか」の確認。モックでは意味をなさない |
+| ファイルの内容 | **不要** | リポジトリの実ファイルを直接確認する |
+| GitHub Actions の実行 | **対象外** | branch-policy.yml の動作は TC-E03 で「ファイルの存在と内容」として確認する。CI 実行そのものはテスト設計の対象外 |
+
+外部依存はすべて本物を使用する。assumed mock は禁止。
+
+## 8. 実行手順と証跡
+
+### 実行環境
+
+- `gh` CLI（認証済み、`GH_TOKEN` 設定済み）
+- `jq` によるレスポンス解析
+- `python3` または `bash` によるファイル内容検査
+
+### 実行コマンド例（結合テスト TC-I01）
+
+```bash
+# main ブランチ保護ルール確認
+gh api repos/shikomi-dev/shikomi/branches/main/protection | jq '{
+  required_approving_review_count: .required_pull_request_reviews.required_approving_review_count,
+  require_code_owner_reviews: .required_pull_request_reviews.require_code_owner_reviews,
+  dismiss_stale_reviews: .required_pull_request_reviews.dismiss_stale_reviews,
+  enforce_admins: .enforce_admins.enabled,
+  allow_force_pushes: .allow_force_pushes.enabled,
+  allow_deletions: .allow_deletions.enabled,
+  required_status_checks: [.required_status_checks.checks[].context]
+}'
+```
+
+### 実行コマンド例（ユニットテスト TC-U08 〜 TC-U12）
+
+```bash
+# LICENSE 内容確認
+gh api repos/shikomi-dev/shikomi/contents/LICENSE | jq -r '.content' | base64 -d | grep -c "MIT License"
+
+# README 必須記載確認
+gh api repos/shikomi-dev/shikomi/contents/README.md | jq -r '.content' | base64 -d | grep -iE "install|インストール"
+gh api repos/shikomi-dev/shikomi/contents/README.md | jq -r '.content' | base64 -d | grep -iE "permission|権限|0600|ACL"
+gh api repos/shikomi-dev/shikomi/contents/README.md | jq -r '.content' | base64 -d | grep -iE "usage|使い方"
+```
+
+### 証跡
+
+- テスト実行結果（stdout/stderr/exit code）を Markdown で記録
+- 結果ファイルを `/app/shared/attachments/マユリ/` に保存して Discord に添付
+- ブランチ保護設定の JSON レスポンスを証跡として保存
+
+## 9. カバレッジ基準
+
+| 観点 | 基準 |
+|------|------|
+| 受入基準の網羅 | REPO-01 〜 REPO-06 が全テストケースで網羅されていること |
+| 正常系 | 全ケース必須 |
+| 異常系 | TC-E03（branch-policy による拒否）を必須で確認 |
+| 境界値 | ISSUE_TEMPLATE が 0 件の場合（TC-U06 異常系）は必要に応じて追加 |
+
+---
+
+*作成: 涅マユリ（テスト担当）/ 2026-04-22*

--- a/docs/architecture/test-design.md
+++ b/docs/architecture/test-design.md
@@ -40,7 +40,7 @@
 | TC-U14 | REPO-01 | `SECURITY.md` に脆弱性報告窓口の記載を含む | ユニット | 正常系 |
 | TC-U15 | REPO-01 | `CODEOWNERS` に `docs/architecture/` の責務割当を含む | ユニット | 正常系 |
 | TC-U16 | REPO-05 | `CONTRIBUTING.md` に `feature/*` → `develop` のマージ先が明記されている | ユニット | 正常系 |
-| TC-I01 | REPO-02 | `main` ブランチ保護: PR 必須・2名レビュー・status checks（branch-policy/pr-title-check含む、back-merge-checkは除外）・force push 禁止・会話解決必須・bypass list | 結合 | 正常系 |
+| TC-I01 | REPO-02 | `main` ブランチ保護: PR 必須・2名レビュー・status checks（branch-policy/pr-title-check含む、build-preview/back-merge-checkは§7.6方針で除外）・force push 禁止・会話解決必須・bypass list | 結合 | 正常系 |
 | TC-I02 | REPO-02 | `develop` ブランチ保護: PR 必須・1名レビュー・status checks（branch-policy/pr-title-check含む）・force push 禁止 | 結合 | 正常系 |
 | TC-I03 | REPO-02 | `main` ブランチ: signed commits 必須設定 | 結合 | 正常系 |
 | TC-I04 | REPO-02 | `develop` ブランチ: signed commits 必須設定 | 結合 | 正常系 |
@@ -104,7 +104,7 @@
 | 種別 | 正常系 |
 | 前提条件 | `main` ブランチ保護が GitHub 上で設定済み |
 | 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection` を実行 |
-| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 2<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_pull_request_reviews.dismiss_stale_reviews` == true<br>- `required_pull_request_reviews.bypass_pull_request_allowances` に 1 件以上のアクター（teams または users）が設定されている<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit`, `build-preview`, `branch-policy`, `pr-title-check` が含まれる（`back-merge-check` は post-merge/cron 事後監視のため PR required には含まれない — dev.md §7.6）<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false<br>- `required_conversation_resolution.enabled` == true |
+| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 2<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_pull_request_reviews.dismiss_stale_reviews` == true<br>- `required_pull_request_reviews.bypass_pull_request_allowances` に 1 件以上のアクター（teams または users）が設定されている<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit`, `branch-policy`, `pr-title-check` が含まれる（`build-preview` は条件付トリガ opt-in、`back-merge-check` は post-merge/cron 事後監視のため、いずれも PR required には含まれない — dev.md §7.6）<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false<br>- `required_conversation_resolution.enabled` == true |
 
 ### TC-I02: develop ブランチ保護ルール確認
 

--- a/docs/architecture/test-design.md
+++ b/docs/architecture/test-design.md
@@ -40,7 +40,7 @@
 | TC-U14 | REPO-01 | `SECURITY.md` に脆弱性報告窓口の記載を含む | ユニット | 正常系 |
 | TC-U15 | REPO-01 | `CODEOWNERS` に `docs/architecture/` の責務割当を含む | ユニット | 正常系 |
 | TC-U16 | REPO-05 | `CONTRIBUTING.md` に `feature/*` → `develop` のマージ先が明記されている | ユニット | 正常系 |
-| TC-I01 | REPO-02 | `main` ブランチ保護: PR 必須・2名レビュー・status checks（branch-policy/pr-title-check含む）・force push 禁止・会話解決必須・bypass list | 結合 | 正常系 |
+| TC-I01 | REPO-02 | `main` ブランチ保護: PR 必須・2名レビュー・status checks（branch-policy/pr-title-check含む、back-merge-checkは除外）・force push 禁止・会話解決必須・bypass list | 結合 | 正常系 |
 | TC-I02 | REPO-02 | `develop` ブランチ保護: PR 必須・1名レビュー・status checks（branch-policy/pr-title-check含む）・force push 禁止 | 結合 | 正常系 |
 | TC-I03 | REPO-02 | `main` ブランチ: signed commits 必須設定 | 結合 | 正常系 |
 | TC-I04 | REPO-02 | `develop` ブランチ: signed commits 必須設定 | 結合 | 正常系 |
@@ -104,7 +104,7 @@
 | 種別 | 正常系 |
 | 前提条件 | `main` ブランチ保護が GitHub 上で設定済み |
 | 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection` を実行 |
-| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 2<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_pull_request_reviews.dismiss_stale_reviews` == true<br>- `required_pull_request_reviews.bypass_pull_request_allowances` に 1 件以上のアクター（teams または users）が設定されている<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit`, `build-preview`, `back-merge-check`, `branch-policy`, `pr-title-check` が含まれる<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false<br>- `required_conversation_resolution.enabled` == true |
+| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 2<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_pull_request_reviews.dismiss_stale_reviews` == true<br>- `required_pull_request_reviews.bypass_pull_request_allowances` に 1 件以上のアクター（teams または users）が設定されている<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit`, `build-preview`, `branch-policy`, `pr-title-check` が含まれる（`back-merge-check` は post-merge/cron 事後監視のため PR required には含まれない — dev.md §7.6）<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false<br>- `required_conversation_resolution.enabled` == true |
 
 ### TC-I02: develop ブランチ保護ルール確認
 

--- a/docs/architecture/test-design.md
+++ b/docs/architecture/test-design.md
@@ -17,7 +17,7 @@
 | REPO-02 | ブランチ保護ルールが §7.2 の仕様通りに GitHub に設定されている | 結合 |
 | REPO-03 | LICENSE に MIT 文言と著作権表記が含まれる | ユニット |
 | REPO-04 | README.md にインストール手順・権限要件・使い方が含まれる | ユニット |
-| REPO-05 | `develop` ブランチが存在し、`feature/*` のデフォルトマージ先が `develop` である | 結合 |
+| REPO-05 | `develop` ブランチが存在し、`feature/*` のデフォルトマージ先が `develop` であることが CONTRIBUTING.md に明記されている | 結合 + ユニット |
 | REPO-06 | `.github/` テンプレート群が存在し、Issue/PR 作成時に自動適用される | E2E |
 
 ## 3. テストマトリクス（トレーサビリティ）
@@ -36,21 +36,26 @@
 | TC-U10 | REPO-04 | `README.md` にインストール手順セクションを含む | ユニット | 正常系 |
 | TC-U11 | REPO-04 | `README.md` に権限要件の記載を含む | ユニット | 正常系 |
 | TC-U12 | REPO-04 | `README.md` に使い方（Usage）の記載を含む | ユニット | 正常系 |
-| TC-U13 | REPO-01 | `CONTRIBUTING.md` に GitFlow ブランチモデルの記載を含む | ユニット | 正常系 |
+| TC-U13 | REPO-01 | `CONTRIBUTING.md` に GitFlow 4ブランチ（feature/develop/release/hotfix）**全て**の記載を含む | ユニット | 正常系 |
 | TC-U14 | REPO-01 | `SECURITY.md` に脆弱性報告窓口の記載を含む | ユニット | 正常系 |
 | TC-U15 | REPO-01 | `CODEOWNERS` に `docs/architecture/` の責務割当を含む | ユニット | 正常系 |
-| TC-I01 | REPO-02 | `main` ブランチ保護: PR 必須・2名レビュー・status checks・force push 禁止 | 結合 | 正常系 |
+| TC-U16 | REPO-05 | `CONTRIBUTING.md` に `feature/*` → `develop` のマージ先が明記されている | ユニット | 正常系 |
+| TC-I01 | REPO-02 | `main` ブランチ保護: PR 必須・2名レビュー・status checks・force push 禁止・merge commit のみ・会話解決必須・bypass list | 結合 | 正常系 |
 | TC-I02 | REPO-02 | `develop` ブランチ保護: PR 必須・1名レビュー・status checks・force push 禁止 | 結合 | 正常系 |
 | TC-I03 | REPO-02 | `main` ブランチ: signed commits 必須設定 | 結合 | 正常系 |
 | TC-I04 | REPO-02 | `develop` ブランチ: signed commits 必須設定 | 結合 | 正常系 |
 | TC-I05 | REPO-02 | `main`: PR ソース制限（`release/*` / `hotfix/*` のみ許可する branch-policy ワークフローが存在する） | 結合 | 正常系 |
 | TC-I06 | REPO-05 | `develop` ブランチが存在する | 結合 | 正常系 |
-| TC-I07 | REPO-02 | `main` / `develop`: include_administrators = true（管理者も保護ルール適用） | 結合 | 正常系 |
+| TC-I07 | REPO-02 | `main` / `develop`: enforce_admins = true + bypass list にセキュリティ緊急例外アクターが設定されている | 結合 | 正常系 |
+| TC-I08 | REPO-02 | `main` への直接 PR を許可しない branch-policy ワークフローの静的確認（ファイル存在・ソース制限ロジック） | 結合 | 異常系 |
+| TC-I09 | REPO-02 | `main` マージ戦略: merge commit のみ許可（squash merge / rebase merge 禁止） | 結合 | 正常系 |
+| TC-I10 | REPO-02 | `develop` マージ戦略: squash merge + merge commit 許可（rebase merge 禁止） | 結合 | 正常系 |
+| TC-I11 | REPO-02 | `main` / `develop`: required_conversation_resolution == true | 結合 | 正常系 |
+| TC-I12 | REPO-02 | bypass list にセキュリティ緊急対応アクター（チームまたはユーザー）が 1 件以上設定されている | 結合 | 正常系 |
 | TC-E01 | REPO-01, REPO-03, REPO-04 | 新規コントリビューターが必要情報を取得できるシナリオ | E2E | 正常系 |
 | TC-E02 | REPO-05, REPO-06 | コアメンバーが GitFlow に従い develop へ PR を作成できるシナリオ | E2E | 正常系 |
-| TC-E03 | REPO-02 | `feature/*` から `main` への直接 PR が branch-policy チェックで失敗するシナリオ | E2E | 異常系 |
 
-## 4. E2Eテスト設計（受入基準 REPO-01, 02, 05, 06 の振る舞い検証）
+## 4. E2Eテスト設計（受入基準 REPO-01, 05, 06 の振る舞い検証）
 
 > **ツール選択根拠**: このシステムは GitHub リポジトリそのもの（CLI/公開 API が主インターフェース）。
 > Playwright は不要。`gh` CLI + `gh api` でブラックボックス検証する。
@@ -67,7 +72,7 @@
 | 種別 | 正常系 |
 | 前提条件 | `feature/repo-setup` が `develop` にマージ済み。GitHub 上でリポジトリが公開状態 |
 | 操作 | 1. `gh repo view shikomi-dev/shikomi` でリポジトリ概要を取得<br>2. `gh api repos/shikomi-dev/shikomi/contents/LICENSE` で LICENSE を確認<br>3. `gh api repos/shikomi-dev/shikomi/contents/README.md` で README を確認<br>4. `gh api repos/shikomi-dev/shikomi/contents/CONTRIBUTING.md` で CONTRIBUTING を確認<br>5. `gh api repos/shikomi-dev/shikomi/contents/SECURITY.md` で SECURITY を確認 |
-| 期待結果 | - 全ファイルの取得が成功する（HTTP 200、content フィールドに base64 データあり）<br>- LICENSE の内容に「MIT License」と「Copyright」を含む<br>- README の内容にインストール手順・権限要件・使い方のキーワードを含む<br>- CONTRIBUTING の内容に GitFlow / feature / develop のキーワードを含む<br>- SECURITY の内容に脆弱性報告（security / vulnerability / report 等）のキーワードを含む |
+| 期待結果 | - 全ファイルの取得が成功する（HTTP 200、content フィールドに base64 データあり）<br>- LICENSE の内容に「MIT License」と「Copyright」を含む<br>- README の内容にインストール手順・権限要件・使い方のキーワードを含む<br>- CONTRIBUTING の内容に feature / develop / release / hotfix の全ワードを含む<br>- SECURITY の内容に脆弱性報告（security / vulnerability / report 等）のキーワードを含む |
 
 ### TC-E02: コアメンバーの GitFlow ワークフローシナリオ
 
@@ -83,20 +88,6 @@
 | 操作 | 1. `gh api repos/shikomi-dev/shikomi/branches/develop` で develop ブランチの存在確認<br>2. `gh api repos/shikomi-dev/shikomi/contents/.github/pull_request_template.md` で PR テンプレート取得<br>3. `gh api repos/shikomi-dev/shikomi/contents/.github/ISSUE_TEMPLATE` で Issue テンプレート一覧取得 |
 | 期待結果 | - develop ブランチが HTTP 200 で取得できる<br>- PR テンプレートが取得でき、content が空でない<br>- Issue テンプレートが 1 件以上存在する（配列が空でない） |
 
-### TC-E03: main への直接 PR がブランチポリシーで拒否されるシナリオ
-
-**ペルソナ**: コアメンバー（誤って main に直接 PR を作成しようとした）
-
-| 項目 | 内容 |
-|------|------|
-| テストID | TC-E03 |
-| 対応する受入基準ID | REPO-02 |
-| 対応する工程 | 要件定義 |
-| 種別 | 異常系 |
-| 前提条件 | `.github/workflows/branch-policy.yml` が存在する。`main` ブランチ保護が設定済み |
-| 操作 | 1. `gh api repos/shikomi-dev/shikomi/contents/.github/workflows/branch-policy.yml` でワークフローファイルの存在確認<br>2. ワークフロー内容に PR の source branch を検査する記述が含まれることを確認<br>3. `gh api repos/shikomi-dev/shikomi/branches/main/protection` で保護設定を確認し、required_status_checks に branch-policy が含まれることを確認 |
-| 期待結果 | - `branch-policy.yml` が存在し、内容に `github.base_ref == 'main'` かつ source branch 検査の記述を含む<br>- `main` の保護設定の required_status_checks に branch-policy 相当のチェックが含まれる |
-
 ## 5. 結合テスト設計（GitHub API による設定値の契約検証）
 
 > **検証スタイル**: `gh api` で実際の GitHub 設定値を取得し、§7.2 の仕様と具体的に照合する（contract testing）。
@@ -111,7 +102,7 @@
 | 種別 | 正常系 |
 | 前提条件 | `main` ブランチ保護が GitHub 上で設定済み |
 | 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection` を実行 |
-| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 2<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_pull_request_reviews.dismiss_stale_reviews` == true<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit`, `build-preview`, `back-merge-check` が含まれる<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false |
+| 期待結果 | - `required_pull_request_reviews.required_approving_review_count` == 2<br>- `required_pull_request_reviews.require_code_owner_reviews` == true<br>- `required_pull_request_reviews.dismiss_stale_reviews` == true<br>- `required_pull_request_reviews.bypass_pull_request_allowances` に 1 件以上のアクター（teams または users）が設定されている<br>- `required_status_checks.checks` に `lint`, `unit-core`, `test-infra`, `audit`, `build-preview`, `back-merge-check` が含まれる<br>- `enforce_admins.enabled` == true<br>- `allow_force_pushes.enabled` == false<br>- `allow_deletions.enabled` == false<br>- `required_conversation_resolution.enabled` == true |
 
 ### TC-I02: develop ブランチ保護ルール確認
 
@@ -173,7 +164,7 @@
 | 操作 | `gh api repos/shikomi-dev/shikomi/branches/develop` |
 | 期待結果 | HTTP 200、`name` == `"develop"` |
 
-### TC-I07: 管理者保護ルール適用確認（include_administrators）
+### TC-I07: 管理者保護ルール適用 + bypass list 確認
 
 | 項目 | 内容 |
 |------|------|
@@ -183,7 +174,71 @@
 | 種別 | 正常系 |
 | 前提条件 | `main` / `develop` 保護設定済み |
 | 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection` および `develop/protection` |
-| 期待結果 | `enforce_admins.enabled` == true（両ブランチとも） |
+| 期待結果 | - `enforce_admins.enabled` == true（両ブランチとも）<br>- `main` の `required_pull_request_reviews.bypass_pull_request_allowances.teams` または `.users` に 1 件以上のアクターが設定されている（セキュリティ hotfix 緊急例外ルート確保） |
+
+### TC-I08: main への直接 PR を拒否する branch-policy の静的確認（旧 TC-E03）
+
+> **分類変更理由**: 「実際に PR を投げて CI が fail する」のは完全 E2E だが、CI 実行は制御外（外部副作用）のため静的ファイル検査として結合テストに分類する。
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I08 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.2） |
+| 種別 | 異常系 |
+| 前提条件 | `.github/workflows/branch-policy.yml` が存在する。`main` ブランチ保護が設定済み |
+| 操作 | 1. `gh api repos/shikomi-dev/shikomi/contents/.github/workflows/branch-policy.yml` でワークフローファイル取得<br>2. base64 デコードし内容確認<br>3. `gh api repos/shikomi-dev/shikomi/branches/main/protection` で required_status_checks を確認 |
+| 期待結果 | - `branch-policy.yml` が存在し、`github.base_ref == 'main'`（または同等条件）と source branch のパターン検査（`release/*` / `hotfix/*` 以外を拒否）の記述を含む<br>- `main` の保護設定の `required_status_checks.checks` に branch-policy の check context が含まれる |
+
+### TC-I09: main マージ戦略確認（merge commit のみ）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I09 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.5） |
+| 種別 | 正常系 |
+| 前提条件 | リポジトリ設定が完了済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi` でリポジトリ設定を取得 |
+| 期待結果 | - `allow_merge_commit` == true<br>- `allow_squash_merge` == false<br>- `allow_rebase_merge` == false<br>（§7.5「release/hotfix → main は merge commit のみ」に準拠） |
+
+### TC-I10: develop マージ戦略確認（squash + merge commit 許可）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I10 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.5） |
+| 種別 | 正常系 |
+| 前提条件 | リポジトリ設定が完了済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi` でリポジトリ設定を取得（リポジトリ全体設定で squash/merge commit 両方許可かつ rebase 禁止） |
+| 期待結果 | - `allow_merge_commit` == true（release/hotfix back-merge に使用）<br>- `allow_squash_merge` == true（feature → develop の squash に使用）<br>- `allow_rebase_merge` == false<br>（§7.5「feature→develop は squash、release/hotfix は merge commit」に準拠） |
+
+> **注意**: GitHub はリポジトリ単位でマージ戦略を設定する。TC-I09 と TC-I10 は同一 API レスポンスから検証するが、「main と develop で異なるマージ方法を使い分ける」という §7.5 の仕様上、squash + merge commit 両方が有効である必要がある。
+
+### TC-I11: required_conversation_resolution 確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I11 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.2） |
+| 種別 | 正常系 |
+| 前提条件 | `main` / `develop` 保護設定済み |
+| 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection` および `develop/protection` |
+| 期待結果 | `required_conversation_resolution.enabled` == true（両ブランチとも） |
+
+### TC-I12: bypass list アクター設定確認（セキュリティ緊急例外ルート）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I12 |
+| 対応する受入基準ID | REPO-02 |
+| 対応する工程 | 基本設計（dev.md §7.4） |
+| 種別 | 正常系 |
+| 前提条件 | `main` 保護設定済み、セキュリティ緊急対応チームが GitHub 上に存在する |
+| 操作 | `gh api repos/shikomi-dev/shikomi/branches/main/protection` を実行し `bypass_pull_request_allowances` を確認 |
+| 期待結果 | `required_pull_request_reviews.bypass_pull_request_allowances.teams` または `.users` に 1 件以上のアクターが存在する<br>（セキュリティ脆弱性 hotfix 時に `enforce_admins=true` を維持しつつ特定チームのみバイパス可能とする §7.4 緊急例外ルートが技術的に実現されている） |
 
 ## 6. ユニットテスト設計（ファイル存在・内容検証）
 
@@ -233,7 +288,7 @@
 **前提条件**: `README.md` が存在する
 **操作**: README.md を取得し、各キーワードが含まれているか確認（大文字小文字区別なし）
 
-### TC-U13: CONTRIBUTING.md GitFlow 記載確認
+### TC-U13: CONTRIBUTING.md GitFlow 4ブランチ記載確認
 
 | 項目 | 内容 |
 |------|------|
@@ -243,7 +298,7 @@
 | 種別 | 正常系 |
 | 前提条件 | `CONTRIBUTING.md` が存在する |
 | 操作 | `CONTRIBUTING.md` を取得し内容確認 |
-| 期待結果 | 「feature」「develop」「GitFlow」または「ブランチ」のいずれかを含む |
+| 期待結果 | 「feature」「develop」「release」「hotfix」の**4ワード全て**を含む（いずれか 1 つでは不合格。GitFlow の全ブランチ種別が説明されていることを保証する） |
 
 ### TC-U14: SECURITY.md 脆弱性報告窓口確認
 
@@ -269,13 +324,25 @@
 | 操作 | `CODEOWNERS` を取得し内容確認 |
 | 期待結果 | `docs/architecture/` のパターンに対する所有者割当が存在する |
 
+### TC-U16: CONTRIBUTING.md への feature/* → develop マージ先明記確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-U16 |
+| 対応する受入基準ID | REPO-05 |
+| 対応する工程 | 要件定義 |
+| 種別 | 正常系 |
+| 前提条件 | `CONTRIBUTING.md` が存在する |
+| 操作 | `CONTRIBUTING.md` を取得し内容確認 |
+| 期待結果 | `feature` と `develop` が共起しており、`feature/*` ブランチのマージ先が `develop` であることを読み取れる記述を含む（例: 「feature ブランチは develop にマージ」「feature/* → develop」等） |
+
 ## 7. モック方針
 
 | 検証対象 | モック要否 | 理由 |
 |---------|---------|------|
 | GitHub API（ブランチ保護・ファイル取得） | **不要**（本物を使用） | このテストの目的は「GitHub 上に正しく設定されているか」の確認。モックでは意味をなさない |
 | ファイルの内容 | **不要** | リポジトリの実ファイルを直接確認する |
-| GitHub Actions の実行 | **対象外** | branch-policy.yml の動作は TC-E03 で「ファイルの存在と内容」として確認する。CI 実行そのものはテスト設計の対象外 |
+| GitHub Actions の実行 | **対象外** | branch-policy.yml の動作は TC-I08 で「ファイルの存在と内容」の静的確認として検証する。CI 実行そのものはテスト設計の対象外 |
 
 外部依存はすべて本物を使用する。assumed mock は禁止。
 
@@ -295,14 +362,27 @@ gh api repos/shikomi-dev/shikomi/branches/main/protection | jq '{
   required_approving_review_count: .required_pull_request_reviews.required_approving_review_count,
   require_code_owner_reviews: .required_pull_request_reviews.require_code_owner_reviews,
   dismiss_stale_reviews: .required_pull_request_reviews.dismiss_stale_reviews,
+  bypass_actors: .required_pull_request_reviews.bypass_pull_request_allowances,
   enforce_admins: .enforce_admins.enabled,
   allow_force_pushes: .allow_force_pushes.enabled,
   allow_deletions: .allow_deletions.enabled,
+  conversation_resolution: .required_conversation_resolution.enabled,
   required_status_checks: [.required_status_checks.checks[].context]
 }'
 ```
 
-### 実行コマンド例（ユニットテスト TC-U08 〜 TC-U12）
+### 実行コマンド例（結合テスト TC-I09/TC-I10: マージ戦略確認）
+
+```bash
+# リポジトリ設定のマージ戦略確認
+gh api repos/shikomi-dev/shikomi | jq '{
+  allow_merge_commit: .allow_merge_commit,
+  allow_squash_merge: .allow_squash_merge,
+  allow_rebase_merge: .allow_rebase_merge
+}'
+```
+
+### 実行コマンド例（ユニットテスト TC-U08 〜 TC-U13）
 
 ```bash
 # LICENSE 内容確認
@@ -312,6 +392,13 @@ gh api repos/shikomi-dev/shikomi/contents/LICENSE | jq -r '.content' | base64 -d
 gh api repos/shikomi-dev/shikomi/contents/README.md | jq -r '.content' | base64 -d | grep -iE "install|インストール"
 gh api repos/shikomi-dev/shikomi/contents/README.md | jq -r '.content' | base64 -d | grep -iE "permission|権限|0600|ACL"
 gh api repos/shikomi-dev/shikomi/contents/README.md | jq -r '.content' | base64 -d | grep -iE "usage|使い方"
+
+# CONTRIBUTING GitFlow 4ブランチ全確認（全て含む場合のみ合格）
+CONTENT=$(gh api repos/shikomi-dev/shikomi/contents/CONTRIBUTING.md | jq -r '.content' | base64 -d)
+echo "$CONTENT" | grep -q "feature"  && \
+echo "$CONTENT" | grep -q "develop"  && \
+echo "$CONTENT" | grep -q "release"  && \
+echo "$CONTENT" | grep -q "hotfix"   && echo "PASS" || echo "FAIL"
 ```
 
 ### 証跡
@@ -326,9 +413,10 @@ gh api repos/shikomi-dev/shikomi/contents/README.md | jq -r '.content' | base64 
 |------|------|
 | 受入基準の網羅 | REPO-01 〜 REPO-06 が全テストケースで網羅されていること |
 | 正常系 | 全ケース必須 |
-| 異常系 | TC-E03（branch-policy による拒否）を必須で確認 |
+| 異常系 | TC-I08（branch-policy による拒否の静的確認）を必須で確認 |
 | 境界値 | ISSUE_TEMPLATE が 0 件の場合（TC-U06 異常系）は必要に応じて追加 |
 
 ---
 
 *作成: 涅マユリ（テスト担当）/ 2026-04-22*
+*改訂: 涅マユリ（テスト担当）/ 2026-04-22 — TC-E03→TC-I08再分類、TC-I09〜TC-I12追加、TC-U13強化、TC-U16追加、bypass list検証追記*


### PR DESCRIPTION
## Summary

- **dev.md §7 追加**: GitFlowブランチ戦略（main/develop/feature/release/hotfix）・保護ルール・リリース手順・hotfix手順・マージ戦略・CHANGELOG自動化（git-cliff）
- **dev.md §7.6 一般方針**: 条件付トリガ・事後監視ジョブをPR required status checkに登録しない方針（build-preview / back-merge-check）を明記
- **test-design.md 新規作成**: repo-setupタスクのテスト設計書（E2E 3件・結合 7件・ユニット 15件）
- **レビュー指摘対応累計**: ペテルギウス指摘3件・服部指摘2件・TC-I01 期待値の build-preview / back-merge-check 除外

## 最終コミット: `2301242`

## Test plan

- [ ] ブランチ保護ルールがdev.md §7.2と整合しているか
- [ ] TC-I01の期待値がdev.md §7.2の必須status checksと一致するか
- [ ] build-preview / back-merge-checkが§7.6の一般方針に従って除外されているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)