### PR TITLE
feat(workspace): Cargo workspace 初期化と 5 crate 空スケルトン

### DIFF
--- a/docs/architecture/tech-stack.md
+++ b/docs/architecture/tech-stack.md
@@ -193,8 +193,70 @@ flowchart LR
 | 4 | `target_os = "macos"` | macOS backend（Carbon + Accessibility） |
 | 5 | `target_os = "windows"` | Windows backend（`RegisterHotKey`） |
 
-## 4. クレートバージョンピン方針
+## 4. Cargo workspace 構成と依存管理
+
+### 4.1 workspace 初期設定（実装規約）
+
+§1 の 5 crate を単一 Cargo workspace として管理する。各 crate は `crates/{name}/` 配下に置き、ルートには workspace 定義ファイルのみを置く。
+
+| 設定項目 | 値 | 根拠 |
+|---------|----|------|
+| `resolver` | `"2"` | workspace と feature unification の挙動が v1 と非互換。crate の feature が OS 別に分岐する shikomi では v2 必須（Cargo Book: Features / Feature resolver version 2） |
+| `[workspace.package] edition` | `"2021"` | 全 crate 共通。`2024` は Rust 1.85 以降で安定化したが、Tauri v2 / ashpd 等のエコシステムは 2021 想定のため合わせる |
+| `[workspace.package] rust-version` | `rust-toolchain.toml` と同値 | MSRV を workspace 横断で一元管理 |
+| `[workspace.package] license` | `"MIT"` | `nfr.md` §9 に準拠 |
+| `[workspace.package] authors` / `repository` | workspace 側で定義 | DRY: crate 個別の `Cargo.toml` には書かない |
+| 各 crate の `publish` | `false` | shikomi はデスクトップアプリ本体であり、crate 個別に crates.io へ公開しない |
+| `Cargo.lock` コミット | **必須** | §4.3 参照。バイナリ crate の標準プラクティス |
+
+**crate 配置と依存方向**:
+
+| crate | 配置 | エントリ | 責務境界 | 依存してよい crate |
+|-------|------|---------|---------|------------------|
+| `shikomi-core` | `crates/shikomi-core/` | `lib.rs` | pure Rust / no-I/O ドメイン | なし（最下層） |
+| `shikomi-infra` | `crates/shikomi-infra/` | `lib.rs` | OS 依存アダプタ | `shikomi-core` |
+| `shikomi-daemon` | `crates/shikomi-daemon/` | `main.rs` | 常駐プロセス / IPC サーバ | `shikomi-core`, `shikomi-infra` |
+| `shikomi-cli` | `crates/shikomi-cli/` | `main.rs` | CLI（IPC クライアント） | `shikomi-core`, `shikomi-infra` |
+| `shikomi-gui` | `crates/shikomi-gui/` | `lib.rs`（Tauri 初期化は後続 Issue） | 設定 GUI（IPC クライアント） | `shikomi-core`, `shikomi-infra` |
+
+**依存方向ルール**（Clean Architecture、違反時は `cargo-deny` 相当の検査で fail fast）:
+- `shikomi-core` は他 crate に依存しない
+- `shikomi-infra → shikomi-core` の一方向のみ
+- `daemon` / `cli` / `gui` は相互依存しない
+- 実装 crate（`daemon` / `cli` / `gui`）が `core` を迂回して互いを参照することは禁止
+
+### 4.2 toolchain / lint / format 規約
+
+| ファイル | 項目 | 値 / 方針 |
+|---------|------|----------|
+| `rust-toolchain.toml` | `channel` | `"stable"`（最新安定版、CI と開発環境で統一） |
+| 〃 | `components` | `["rustfmt", "clippy"]` |
+| 〃 | `profile` | `"minimal"`（不要コンポーネントを取らず CI 時間を短縮） |
+| `rustfmt.toml` | 方針 | Rust 公式デフォルトを基本。`edition = "2021"` を明示。意図的な逸脱項目のみ追記 |
+| `.clippy.toml` | 方針 | `msrv` を `rust-toolchain.toml` と一致させる。カテゴリレベル設定は CI コマンド側の `-D warnings` で強制 |
+| CI clippy 呼び出し | コマンド | `cargo clippy --workspace --all-targets -- -D warnings` |
+| CI fmt 呼び出し | コマンド | `cargo fmt --all -- --check` |
+
+### 4.3 `cargo-deny` 初期ポリシー
+
+`deny.toml` は shikomi が「パスワードを扱うデスクトップ OSS」であるため、ライセンス / advisory / 依存の重複を CI で fail fast させる。
+
+| セクション | 初期方針 | 根拠 |
+|----------|---------|------|
+| `[licenses] allow` | `MIT`, `Apache-2.0`, `Apache-2.0 WITH LLVM-exception`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `Unicode-DFS-2016`, `Unicode-3.0`, `Zlib`, `CC0-1.0` | OSS デスクトップ配布で商用互換性を保つ範囲。GPL 系は shikomi 本体のライセンス（MIT）と衝突するため allow しない |
+| `[licenses] confidence-threshold` | `0.93` | デフォルト値。極端に低くすると誤検知が出る |
+| `[advisories] vulnerability` | `deny` | RustSec advisory DB 由来の脆弱性は CI で即 fail |
+| `[advisories] unmaintained` | `warn`（workspace 成熟後に `deny` へ昇格） | 初期は依存 crate の入れ替え猶予のため warn、shikomi-core 確定後に deny 化 |
+| `[advisories] yanked` | `deny` | yanked 版を引いたままのビルドは再現不能 |
+| `[bans] multiple-versions` | `warn` | 同一 crate の multi-version はビルド時間とバイナリサイズを圧迫する。初期は warn、依存が安定したら `deny` 化 |
+| `[bans] wildcards` | `deny` | `*` バージョン指定は Cargo.lock との整合を破壊する |
+| `[sources] unknown-registry` / `unknown-git` | `deny` | crates.io 以外からの取得は明示的に `allow` リストへ追加する運用 |
+
+出典: https://embarkstudios.github.io/cargo-deny/
+
+### 4.4 クレートバージョンピン方針
 
 - Tauri は **v2 系**にピン（major 固定、minor/patch は Dependabot 追従）
 - セキュリティクリティカルな `aes-gcm` / `argon2` / `zeroize` / `secrecy` は minor もピン、patch のみ追従
 - `Cargo.lock` を**リポジトリにコミット**（バイナリ crate の推奨プラクティス、再現ビルド担保）
+- `[workspace.dependencies]` セクションに**外部 crate のバージョンを一元集約**し、各 crate の `Cargo.toml` からは `foo = { workspace = true }` で参照する（DRY、バージョン drift 防止）

--- a/docs/architecture/tech-stack.md
+++ b/docs/architecture/tech-stack.md
@@ -248,29 +248,36 @@ flowchart LR
 | `[licenses] allow` | `MIT`, `Apache-2.0`, `Apache-2.0 WITH LLVM-exception`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `Unicode-DFS-2016`, `Unicode-3.0`, `Zlib`, `CC0-1.0` | OSS デスクトップ配布で商用互換性を保つ範囲。GPL 系は shikomi 本体のライセンス（MIT）と衝突するため allow しない |
 | `[licenses] confidence-threshold` | `0.93` | デフォルト値。極端に低くすると誤検知が出る |
 | `[advisories] vulnerability` | `deny` | RustSec advisory DB 由来の脆弱性は CI で即 fail |
-| `[advisories] unmaintained` | `warn`（Issue #4 時点のみ）→ **#5 shikomi-core ドメイン型定義 PR マージと同時に `deny` 昇格** | §4.3.1 に昇格トリガを厳密化。shikomi-infra（SQLite / `keyring` / `aes-gcm` / `argon2` 等の実 crate 導入）より前に必ず `deny` とする |
+| `[advisories] unmaintained` | **`deny`（Issue #4 時点から）** | 反転方式: 初期から全 crate に `deny` を適用し、どうしても外せない個別 crate のみ `[advisories].ignore` に RustSec advisory ID を登録して**一時的に例外化**する（§4.3.1）。暗号クリティカル crate は **ignore リストへの追加を禁止**（§4.3.2） |
 | `[advisories] yanked` | `deny` | yanked 版を引いたままのビルドは再現不能 |
-| `[bans] multiple-versions` | `warn`（Issue #4 時点のみ）→ **`shikomi-infra` の初回 PR マージ直後に `deny` 昇格** | 外部 crate を本格導入する shikomi-infra の完成時点で version drift を禁止。§4.3.1 参照 |
+| `[bans] multiple-versions` | **`deny`（Issue #4 時点から）** | 反転方式: 初期から `deny`。外せない重複は `[bans].skip` で個別 crate と version を列挙して暫定除外（§4.3.1）。外部 crate を持たない Issue #4 時点では `skip` リストは空 |
 | `[bans] wildcards` | `deny` | `*` バージョン指定は Cargo.lock との整合を破壊する |
 | `[sources] unknown-registry` / `unknown-git` | `deny` | crates.io 以外からの取得は明示的に `allow` リストへ追加する運用 |
 
-**セキュリティクリティカル crate の個別扱い**: 以下は **Issue #4 時点から例外として即 `deny`** を適用する（`[advisories]` の `unmaintained` が workspace 全体で `warn` のときも、この列挙 crate だけは `unmaintained = deny` 相当の扱い）。手段は `deny.toml` の `[bans].deny` リストに「unmaintained になった時点で必ず fail する crate 名」として明示登録するか、`cargo-deny` の `[advisories].unmaintained-ignore` を空に保ったまま「このリストの crate は shikomi-infra 導入と同時に全体 `deny` になるのを先取りする」ポリシーを `deny.toml` の先頭コメントに宣言する方式をとる。
+### 4.3.1 反転方式の運用（`warn` 段階を持たない `deny` + 一時 `ignore` 方式）
+
+**前回ドラフトで検討した「初期 `warn` → 後続 Issue で `deny` 昇格」方式は採用しない**（Boy Scout Rule 違反かつ、後続 Issue での昇格忘れ検知が人間の注意力に依存し Fail Fast でないため）。代わりに **cargo-deny 標準機能である個別 ignore リストで運用する反転方式**を採用する。
+
+| 方向 | 初期値 | 一時例外手段 | 例外解除トリガ |
+|-----|-------|-------------|---------------|
+| `[advisories] unmaintained` | `deny` | `[advisories].ignore` に RustSec advisory ID（例: `"RUSTSEC-2024-XXXX"`）を列挙 | ignore に記載した ID ごとに「代替 crate 移行 Issue」を `gh issue create` で発行。**Issue の acceptance criteria に `deny.toml` から該当 ID 削除を必須項目化** |
+| `[bans] multiple-versions` | `deny` | `[bans].skip = [{ name = "foo", version = "=1.2.3" }]` に個別登録 | 同上。依存元を新しい major に追随した Issue で `skip` エントリを削除 |
+
+**ignore / skip リストは PR 内でインラインコメント必須**（`# RUSTSEC-YYYY-NNNN: <crate>, 解除 Issue #NNN` 等）。コメントなしの匿名 ignore は服部が PR レビュー時に却下する。
+
+**Issue #4 時点の ignore / skip リスト初期値**: いずれも**空**。workspace にはまだ外部 crate が無いため、暫定例外を登録する対象がない。
+
+### 4.3.2 セキュリティクリティカル crate のリスト（ignore 禁止）
+
+下記 crate が将来 `unmaintained` 警告を受けた場合、**`[advisories].ignore` への追加を禁止**する。必ず代替 crate への移行 Issue を優先する（`unmaintained` = `deny` のまま維持、ビルド失敗を受けて即時対応）。
 
 対象 crate: `aes-gcm` / `argon2` / `zeroize` / `secrecy` / `hkdf` / `pbkdf2` / `bip39` / `rand_core` / `subtle`
 
-根拠: 暗号運用（§2.4）は **unmaintained crate を引きずるだけでゼロデイ脆弱性放置と同義**。パスワードを扱うアプリである shikomi は、暗号周辺の unmaintained を「いずれ昇格」では遅い。
+根拠: 暗号運用（§2.4）は **unmaintained crate を引きずるだけでゼロデイ脆弱性放置と同義**。パスワードを扱うアプリである shikomi は、暗号周辺の unmaintained を「一時 ignore」で済ませない。構造的には「workspace 全体で `unmaintained = deny` が有効で、かつこのリストは `ignore` への登録を禁止」の二重防護とする。
 
-### 4.3.1 昇格トリガー一覧（曖昧さ排除）
+**検知手段**: `deny.toml` の `[advisories].ignore` に本リストの crate の RustSec ID が入った場合、服部が PR レビューで却下する。機械的検知を追加するには、CI に「`deny.toml` をパースし、`ignore` 配列に本リスト crate 名を含む advisory ID が登録されていないか」を検査するスクリプトジョブを置く選択肢もあるが、当面は服部の目視レビュー + 本節への明示で運用する（YAGNI: 実被害が出るまで自動化しない）。
 
-| 項目 | 初期値 | 昇格後の値 | 昇格タイミング（PR マージ完了時点） | 昇格責任者 |
-|------|-------|-----------|----------------------------------|----------|
-| `[advisories] unmaintained`（workspace 全体） | `warn` | `deny` | **次の Issue「shikomi-core ドメイン型定義」PR マージ時点** | セキュリティ担当（服部） — 同 Issue のチェックリストに「`deny.toml` の `unmaintained` を `deny` に昇格」を**必須項目**として追加 |
-| `[bans] multiple-versions` | `warn` | `deny` | **`shikomi-infra` の初回 PR マージ直後** | セキュリティ担当（服部） — 同 Issue に同上の必須項目 |
-| 暗号クリティカル crate 列挙 | **既に `deny` 相当** | — | Issue #4 で確定 | 設計担当（セル）が `deny.toml` 初期コミットに明記 |
-
-**昇格を忘れた場合の検知**: 上記の 2 項目は、該当 Issue の acceptance criteria に `deny.toml` 差分行を要求することで PR レビュアが fail fast 判断できる。昇格トリガを跨いで `warn` のまま残っている場合、服部は当該 PR を却下する。
-
-出典: https://embarkstudios.github.io/cargo-deny/
+出典: https://embarkstudios.github.io/cargo-deny/ (`[advisories].ignore` / `[bans].skip` セクション)
 
 ### 4.4 クレートバージョンピン方針
 

--- a/docs/architecture/tech-stack.md
+++ b/docs/architecture/tech-stack.md
@@ -225,6 +225,8 @@ flowchart LR
 - `daemon` / `cli` / `gui` は相互依存しない
 - 実装 crate（`daemon` / `cli` / `gui`）が `core` を迂回して互いを参照することは禁止
 
+**外部 crate の参照方法**: 各 crate の `Cargo.toml` では外部 crate のバージョンを直接書かず、**workspace ルートで一元定義したものを `{ workspace = true }` で参照する**（§4.4）。これにより同一依存の version drift を構造的に防ぐ。ワークスペース内の 5 crate 間参照（`shikomi-infra` → `shikomi-core` 等）も同方式で定義する（path 依存＋バージョン併記）。
+
 ### 4.2 toolchain / lint / format 規約
 
 | ファイル | 項目 | 値 / 方針 |
@@ -246,11 +248,27 @@ flowchart LR
 | `[licenses] allow` | `MIT`, `Apache-2.0`, `Apache-2.0 WITH LLVM-exception`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `Unicode-DFS-2016`, `Unicode-3.0`, `Zlib`, `CC0-1.0` | OSS デスクトップ配布で商用互換性を保つ範囲。GPL 系は shikomi 本体のライセンス（MIT）と衝突するため allow しない |
 | `[licenses] confidence-threshold` | `0.93` | デフォルト値。極端に低くすると誤検知が出る |
 | `[advisories] vulnerability` | `deny` | RustSec advisory DB 由来の脆弱性は CI で即 fail |
-| `[advisories] unmaintained` | `warn`（workspace 成熟後に `deny` へ昇格） | 初期は依存 crate の入れ替え猶予のため warn、shikomi-core 確定後に deny 化 |
+| `[advisories] unmaintained` | `warn`（Issue #4 時点のみ）→ **#5 shikomi-core ドメイン型定義 PR マージと同時に `deny` 昇格** | §4.3.1 に昇格トリガを厳密化。shikomi-infra（SQLite / `keyring` / `aes-gcm` / `argon2` 等の実 crate 導入）より前に必ず `deny` とする |
 | `[advisories] yanked` | `deny` | yanked 版を引いたままのビルドは再現不能 |
-| `[bans] multiple-versions` | `warn` | 同一 crate の multi-version はビルド時間とバイナリサイズを圧迫する。初期は warn、依存が安定したら `deny` 化 |
+| `[bans] multiple-versions` | `warn`（Issue #4 時点のみ）→ **`shikomi-infra` の初回 PR マージ直後に `deny` 昇格** | 外部 crate を本格導入する shikomi-infra の完成時点で version drift を禁止。§4.3.1 参照 |
 | `[bans] wildcards` | `deny` | `*` バージョン指定は Cargo.lock との整合を破壊する |
 | `[sources] unknown-registry` / `unknown-git` | `deny` | crates.io 以外からの取得は明示的に `allow` リストへ追加する運用 |
+
+**セキュリティクリティカル crate の個別扱い**: 以下は **Issue #4 時点から例外として即 `deny`** を適用する（`[advisories]` の `unmaintained` が workspace 全体で `warn` のときも、この列挙 crate だけは `unmaintained = deny` 相当の扱い）。手段は `deny.toml` の `[bans].deny` リストに「unmaintained になった時点で必ず fail する crate 名」として明示登録するか、`cargo-deny` の `[advisories].unmaintained-ignore` を空に保ったまま「このリストの crate は shikomi-infra 導入と同時に全体 `deny` になるのを先取りする」ポリシーを `deny.toml` の先頭コメントに宣言する方式をとる。
+
+対象 crate: `aes-gcm` / `argon2` / `zeroize` / `secrecy` / `hkdf` / `pbkdf2` / `bip39` / `rand_core` / `subtle`
+
+根拠: 暗号運用（§2.4）は **unmaintained crate を引きずるだけでゼロデイ脆弱性放置と同義**。パスワードを扱うアプリである shikomi は、暗号周辺の unmaintained を「いずれ昇格」では遅い。
+
+### 4.3.1 昇格トリガー一覧（曖昧さ排除）
+
+| 項目 | 初期値 | 昇格後の値 | 昇格タイミング（PR マージ完了時点） | 昇格責任者 |
+|------|-------|-----------|----------------------------------|----------|
+| `[advisories] unmaintained`（workspace 全体） | `warn` | `deny` | **次の Issue「shikomi-core ドメイン型定義」PR マージ時点** | セキュリティ担当（服部） — 同 Issue のチェックリストに「`deny.toml` の `unmaintained` を `deny` に昇格」を**必須項目**として追加 |
+| `[bans] multiple-versions` | `warn` | `deny` | **`shikomi-infra` の初回 PR マージ直後** | セキュリティ担当（服部） — 同 Issue に同上の必須項目 |
+| 暗号クリティカル crate 列挙 | **既に `deny` 相当** | — | Issue #4 で確定 | 設計担当（セル）が `deny.toml` 初期コミットに明記 |
+
+**昇格を忘れた場合の検知**: 上記の 2 項目は、該当 Issue の acceptance criteria に `deny.toml` 差分行を要求することで PR レビュアが fail fast 判断できる。昇格トリガを跨いで `warn` のまま残っている場合、服部は当該 PR を却下する。
 
 出典: https://embarkstudios.github.io/cargo-deny/
 

--- a/docs/features/workspace-init/test-design.md
+++ b/docs/features/workspace-init/test-design.md
@@ -20,7 +20,7 @@
 | WS-04 | `cargo clippy --workspace -- -D warnings` が pass する（.clippy.toml 準拠） | 結合 |
 | WS-05 | `cargo deny check` が pass する（deny.toml 初期設定準拠） | 結合 |
 | WS-06 | ライブラリ crate（shikomi-core / infra / gui）が `lib.rs` のみ・バイナリ crate（daemon / cli）が `main.rs` のみの最小構成である | ユニット |
-| WS-07 | 各 crate に公開 API が存在しない（`pub fn` / `pub struct` / `pub enum` / `pub trait` / `pub mod` / `pub use` / `pub const` / `pub static` なし） | ユニット |
+| WS-07 | 各 crate に公開 API が存在しない（`pub fn` / `pub struct` / `pub enum` / `pub trait` / `pub mod` / `pub use` / `pub const` / `pub static` / `pub type` なし） | ユニット |
 | WS-08 | `Cargo.lock` がリポジトリにコミット済みである | ユニット |
 
 ## 3. テストマトリクス（トレーサビリティ）
@@ -32,12 +32,12 @@
 | TC-I03 | WS-03 | `cargo fmt --check --all` の実行成功（差分なし） | 結合 | 正常系 |
 | TC-I04 | WS-04 | `cargo clippy --workspace -- -D warnings` の実行成功（警告ゼロ） | 結合 | 正常系 |
 | TC-I05 | WS-05 | `cargo deny check` の実行成功（ライセンス・advisory・重複 crate 全 pass） | 結合 | 正常系 |
-| TC-U01 | WS-06 | `shikomi-core/src/lib.rs` が存在し、`src/` にはそのファイルのみである（ライブラリ crate） | ユニット | 正常系 |
-| TC-U02 | WS-06 | `shikomi-infra/src/lib.rs` が存在し、`src/` にはそのファイルのみである（ライブラリ crate） | ユニット | 正常系 |
-| TC-U03 | WS-06 | `shikomi-daemon/src/main.rs` が存在し、`src/` にはそのファイルのみである（バイナリ crate） | ユニット | 正常系 |
-| TC-U04 | WS-06 | `shikomi-cli/src/main.rs` が存在し、`src/` にはそのファイルのみである（バイナリ crate） | ユニット | 正常系 |
-| TC-U05 | WS-06 | `shikomi-gui/src/lib.rs` が存在し、`src/` にはそのファイルのみである（ライブラリ crate） | ユニット | 正常系 |
-| TC-U06 | WS-07 | 全 crate のソースファイルに公開 API シンボルが存在しない（検査パターン: `^pub (fn\|struct\|enum\|trait\|mod\|use\|const\|static) `、`pub(crate)` は誤検知対象外） | ユニット | 正常系 |
+| TC-U01 | WS-06 | `crates/shikomi-core/src/lib.rs` が存在し、`src/` にはそのファイルのみである（ライブラリ crate） | ユニット | 正常系 |
+| TC-U02 | WS-06 | `crates/shikomi-infra/src/lib.rs` が存在し、`src/` にはそのファイルのみである（ライブラリ crate） | ユニット | 正常系 |
+| TC-U03 | WS-06 | `crates/shikomi-daemon/src/main.rs` が存在し、`src/` にはそのファイルのみである（バイナリ crate） | ユニット | 正常系 |
+| TC-U04 | WS-06 | `crates/shikomi-cli/src/main.rs` が存在し、`src/` にはそのファイルのみである（バイナリ crate） | ユニット | 正常系 |
+| TC-U05 | WS-06 | `crates/shikomi-gui/src/lib.rs` が存在し、`src/` にはそのファイルのみである（ライブラリ crate） | ユニット | 正常系 |
+| TC-U06 | WS-07 | 全 crate のソースファイルに公開 API シンボルが存在しない（検査パターン: `^pub (fn\|struct\|enum\|trait\|mod\|use\|const\|static\|type) `、`pub(crate)` は誤検知対象外） | ユニット | 正常系 |
 | TC-U07 | WS-08 | `Cargo.lock` がリポジトリルートに存在する | ユニット | 正常系 |
 
 ## 4. E2Eテスト設計
@@ -120,11 +120,11 @@
 
 | テストID | crate | 種別 | 期待エントリポイント | 期待結果 |
 |---------|-------|------|-----------------|---------|
-| TC-U01 | shikomi-core | ライブラリ | `src/lib.rs` | `lib.rs` のみ存在する（他 `.rs` ファイルなし） |
-| TC-U02 | shikomi-infra | ライブラリ | `src/lib.rs` | `lib.rs` のみ存在する |
-| TC-U03 | shikomi-daemon | バイナリ | `src/main.rs` | `main.rs` のみ存在する（`lib.rs` なし） |
-| TC-U04 | shikomi-cli | バイナリ | `src/main.rs` | `main.rs` のみ存在する（`lib.rs` なし） |
-| TC-U05 | shikomi-gui | ライブラリ | `src/lib.rs` | `lib.rs` のみ存在する |
+| TC-U01 | shikomi-core | ライブラリ | `crates/shikomi-core/src/lib.rs` | `lib.rs` のみ存在する（他 `.rs` ファイルなし） |
+| TC-U02 | shikomi-infra | ライブラリ | `crates/shikomi-infra/src/lib.rs` | `lib.rs` のみ存在する |
+| TC-U03 | shikomi-daemon | バイナリ | `crates/shikomi-daemon/src/main.rs` | `main.rs` のみ存在する（`lib.rs` なし） |
+| TC-U04 | shikomi-cli | バイナリ | `crates/shikomi-cli/src/main.rs` | `main.rs` のみ存在する（`lib.rs` なし） |
+| TC-U05 | shikomi-gui | ライブラリ | `crates/shikomi-gui/src/lib.rs` | `lib.rs` のみ存在する |
 
 **前提条件**: workspace 実装コードが `feature/issue-4-workspace-init` ブランチにコミット済み
 **操作**: 各 crate の `src/` を確認
@@ -138,7 +138,7 @@
 | 対応する工程 | 詳細設計（設計原則: 公開 API ゼロ） |
 | 種別 | 正常系 |
 | 前提条件 | 全 crate のソースファイルが存在する |
-| 操作 | 全 `.rs` ファイルに対して `grep -rEn "^pub (fn\|struct\|enum\|trait\|mod\|use\|const\|static) " --include="*.rs"` を実行（`target/` 配下は除外） |
+| 操作 | 全 `.rs` ファイルに対して `grep -rEn "^pub (fn\|struct\|enum\|trait\|mod\|use\|const\|static\|type) " --include="*.rs"` を実行（`target/` 配下は除外） |
 | 期待結果 | マッチ行ゼロ。外部公開 API シンボルが存在しない。なお `pub(crate)` / `pub(super)` は公開 API ではないため検査対象外とする（grep パターンが `pub ` + スペースで区切ることで自動排除） |
 
 ### TC-U07: Cargo.lock コミット確認
@@ -215,11 +215,11 @@ PASS=true
 
 echo "=== TC-U01〜TC-U05: crate ソースファイル構成確認 ==="
 
-# ライブラリ crate: lib.rs のみ
+# ライブラリ crate: lib.rs のみ（crates/ 配下に配置）
 LIB_CRATES=(shikomi-core shikomi-infra shikomi-gui)
 for crate in "${LIB_CRATES[@]}"; do
-    FILES=$(find "$crate/src" -name "*.rs" | sort)
-    EXPECTED="$crate/src/lib.rs"
+    FILES=$(find "crates/$crate/src" -name "*.rs" | sort)
+    EXPECTED="crates/$crate/src/lib.rs"
     if [ "$FILES" = "$EXPECTED" ]; then
         echo "TC: $crate → PASS (lib.rs のみ)"
     else
@@ -228,11 +228,11 @@ for crate in "${LIB_CRATES[@]}"; do
     fi
 done
 
-# バイナリ crate: main.rs のみ
+# バイナリ crate: main.rs のみ（crates/ 配下に配置）
 BIN_CRATES=(shikomi-daemon shikomi-cli)
 for crate in "${BIN_CRATES[@]}"; do
-    FILES=$(find "$crate/src" -name "*.rs" | sort)
-    EXPECTED="$crate/src/main.rs"
+    FILES=$(find "crates/$crate/src" -name "*.rs" | sort)
+    EXPECTED="crates/$crate/src/main.rs"
     if [ "$FILES" = "$EXPECTED" ]; then
         echo "TC: $crate → PASS (main.rs のみ)"
     else
@@ -244,7 +244,7 @@ done
 echo "=== TC-U06: 公開 API 不存在確認 ==="
 # ^pub (fn|struct|enum|trait|mod|use|const|static) で外部公開シンボルを検査
 # pub(crate) / pub(super) は "pub " の後に "(" が来るため自動排除される
-PUB_MATCHES=$(grep -rEn "^pub (fn|struct|enum|trait|mod|use|const|static) " \
+PUB_MATCHES=$(grep -rEn "^pub (fn|struct|enum|trait|mod|use|const|static|type) " \
     --include="*.rs" . \
     --exclude-dir=target || true)
 if [ -z "$PUB_MATCHES" ]; then
@@ -285,4 +285,5 @@ $PASS && echo "=== 全ユニットテスト PASS ===" || { echo "=== FAIL ==="; 
 
 *作成: 涅マユリ（テスト担当）/ 2026-04-22*
 *改訂: 涅マユリ（テスト担当）/ 2026-04-22 — WS-06/TC-U01〜U05 を daemon/cli バイナリ crate（main.rs）・core/infra/gui ライブラリ crate（lib.rs）に区別修正。TC-U06 の grep パターンを `^pub (fn|struct|enum|trait|mod|use|const|static) ` に精密化し pub(crate) 誤検知を排除*
+*改訂: 涅マユリ（テスト担当）/ 2026-04-22 — WS-07/TC-U06 に `pub type` を追加（型エイリアスの見逃し修正）。TC-U01〜U05 の期待パスとbashスクリプトの find/EXPECTED を `crates/{name}/src/` プレフィックスに統一（tech-stack.md §4.1 の crates/ 配置との整合）*
 *対応 Issue: #4 feat(workspace): Cargo workspace 初期化と 5 crate 空スケルトン*

--- a/docs/features/workspace-init/test-design.md
+++ b/docs/features/workspace-init/test-design.md
@@ -19,8 +19,8 @@
 | WS-03 | `cargo fmt --check --all` が pass する（rustfmt.toml 準拠） | 結合 |
 | WS-04 | `cargo clippy --workspace -- -D warnings` が pass する（.clippy.toml 準拠） | 結合 |
 | WS-05 | `cargo deny check` が pass する（deny.toml 初期設定準拠） | 結合 |
-| WS-06 | 各 crate（shikomi-core / infra / daemon / cli / gui）が `lib.rs` のみの最小構成である | ユニット |
-| WS-07 | 各 crate に公開 API が存在しない（`pub fn` / `pub struct` / `pub enum` / `pub trait` なし） | ユニット |
+| WS-06 | ライブラリ crate（shikomi-core / infra / gui）が `lib.rs` のみ・バイナリ crate（daemon / cli）が `main.rs` のみの最小構成である | ユニット |
+| WS-07 | 各 crate に公開 API が存在しない（`pub fn` / `pub struct` / `pub enum` / `pub trait` / `pub mod` / `pub use` / `pub const` / `pub static` なし） | ユニット |
 | WS-08 | `Cargo.lock` がリポジトリにコミット済みである | ユニット |
 
 ## 3. テストマトリクス（トレーサビリティ）
@@ -32,12 +32,12 @@
 | TC-I03 | WS-03 | `cargo fmt --check --all` の実行成功（差分なし） | 結合 | 正常系 |
 | TC-I04 | WS-04 | `cargo clippy --workspace -- -D warnings` の実行成功（警告ゼロ） | 結合 | 正常系 |
 | TC-I05 | WS-05 | `cargo deny check` の実行成功（ライセンス・advisory・重複 crate 全 pass） | 結合 | 正常系 |
-| TC-U01 | WS-06 | `shikomi-core/src/lib.rs` が存在し、ソースファイルがそれのみである | ユニット | 正常系 |
-| TC-U02 | WS-06 | `shikomi-infra/src/lib.rs` が存在し、ソースファイルがそれのみである | ユニット | 正常系 |
-| TC-U03 | WS-06 | `shikomi-daemon/src/lib.rs` が存在し、ソースファイルがそれのみである | ユニット | 正常系 |
-| TC-U04 | WS-06 | `shikomi-cli/src/lib.rs` が存在し、ソースファイルがそれのみである | ユニット | 正常系 |
-| TC-U05 | WS-06 | `shikomi-gui/src/lib.rs` が存在し、ソースファイルがそれのみである | ユニット | 正常系 |
-| TC-U06 | WS-07 | 全 crate の `lib.rs` に公開 API シンボル（`pub fn`/`pub struct`/`pub enum`/`pub trait`）が存在しない | ユニット | 正常系 |
+| TC-U01 | WS-06 | `shikomi-core/src/lib.rs` が存在し、`src/` にはそのファイルのみである（ライブラリ crate） | ユニット | 正常系 |
+| TC-U02 | WS-06 | `shikomi-infra/src/lib.rs` が存在し、`src/` にはそのファイルのみである（ライブラリ crate） | ユニット | 正常系 |
+| TC-U03 | WS-06 | `shikomi-daemon/src/main.rs` が存在し、`src/` にはそのファイルのみである（バイナリ crate） | ユニット | 正常系 |
+| TC-U04 | WS-06 | `shikomi-cli/src/main.rs` が存在し、`src/` にはそのファイルのみである（バイナリ crate） | ユニット | 正常系 |
+| TC-U05 | WS-06 | `shikomi-gui/src/lib.rs` が存在し、`src/` にはそのファイルのみである（ライブラリ crate） | ユニット | 正常系 |
+| TC-U06 | WS-07 | 全 crate のソースファイルに公開 API シンボルが存在しない（検査パターン: `^pub (fn\|struct\|enum\|trait\|mod\|use\|const\|static) `、`pub(crate)` は誤検知対象外） | ユニット | 正常系 |
 | TC-U07 | WS-08 | `Cargo.lock` がリポジトリルートに存在する | ユニット | 正常系 |
 
 ## 4. E2Eテスト設計
@@ -116,13 +116,15 @@
 
 ### TC-U01〜TC-U05: crate ソースファイル構成確認
 
-| テストID | crate | 検証対象 | 期待結果 |
-|---------|-------|---------|---------|
-| TC-U01 | shikomi-core | `src/` 配下のファイル一覧 | `lib.rs` のみ存在する（`main.rs` / その他 `.rs` ファイルなし） |
-| TC-U02 | shikomi-infra | `src/` 配下のファイル一覧 | `lib.rs` のみ存在する |
-| TC-U03 | shikomi-daemon | `src/` 配下のファイル一覧 | `lib.rs` のみ存在する |
-| TC-U04 | shikomi-cli | `src/` 配下のファイル一覧 | `lib.rs` のみ存在する |
-| TC-U05 | shikomi-gui | `src/` 配下のファイル一覧 | `lib.rs` のみ存在する |
+> **crate 種別の区別**: ライブラリ crate（core / infra / gui）は `lib.rs`、バイナリ crate（daemon / cli）は `main.rs` が正しいエントリポイント。daemon は常駐プロセス、cli は実行バイナリであり、将来 `fn main()` を実装する前提の正しい構造（tech-stack.md §4.1 準拠）。
+
+| テストID | crate | 種別 | 期待エントリポイント | 期待結果 |
+|---------|-------|------|-----------------|---------|
+| TC-U01 | shikomi-core | ライブラリ | `src/lib.rs` | `lib.rs` のみ存在する（他 `.rs` ファイルなし） |
+| TC-U02 | shikomi-infra | ライブラリ | `src/lib.rs` | `lib.rs` のみ存在する |
+| TC-U03 | shikomi-daemon | バイナリ | `src/main.rs` | `main.rs` のみ存在する（`lib.rs` なし） |
+| TC-U04 | shikomi-cli | バイナリ | `src/main.rs` | `main.rs` のみ存在する（`lib.rs` なし） |
+| TC-U05 | shikomi-gui | ライブラリ | `src/lib.rs` | `lib.rs` のみ存在する |
 
 **前提条件**: workspace 実装コードが `feature/issue-4-workspace-init` ブランチにコミット済み
 **操作**: 各 crate の `src/` を確認
@@ -135,9 +137,9 @@
 | 対応する受入基準ID | WS-07 |
 | 対応する工程 | 詳細設計（設計原則: 公開 API ゼロ） |
 | 種別 | 正常系 |
-| 前提条件 | 全 crate の `lib.rs` が存在する |
-| 操作 | 全 `lib.rs` に対して `grep -rn "^pub " --include="*.rs"` を実行 |
-| 期待結果 | マッチ行ゼロ。`pub fn` / `pub struct` / `pub enum` / `pub trait` / `pub use` いずれも存在しない |
+| 前提条件 | 全 crate のソースファイルが存在する |
+| 操作 | 全 `.rs` ファイルに対して `grep -rEn "^pub (fn\|struct\|enum\|trait\|mod\|use\|const\|static) " --include="*.rs"` を実行（`target/` 配下は除外） |
+| 期待結果 | マッチ行ゼロ。外部公開 API シンボルが存在しない。なお `pub(crate)` / `pub(super)` は公開 API ではないため検査対象外とする（grep パターンが `pub ` + スペースで区切ることで自動排除） |
 
 ### TC-U07: Cargo.lock コミット確認
 
@@ -209,11 +211,13 @@ set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
-CRATES=(shikomi-core shikomi-infra shikomi-daemon shikomi-cli shikomi-gui)
 PASS=true
 
 echo "=== TC-U01〜TC-U05: crate ソースファイル構成確認 ==="
-for crate in "${CRATES[@]}"; do
+
+# ライブラリ crate: lib.rs のみ
+LIB_CRATES=(shikomi-core shikomi-infra shikomi-gui)
+for crate in "${LIB_CRATES[@]}"; do
     FILES=$(find "$crate/src" -name "*.rs" | sort)
     EXPECTED="$crate/src/lib.rs"
     if [ "$FILES" = "$EXPECTED" ]; then
@@ -224,12 +228,30 @@ for crate in "${CRATES[@]}"; do
     fi
 done
 
+# バイナリ crate: main.rs のみ
+BIN_CRATES=(shikomi-daemon shikomi-cli)
+for crate in "${BIN_CRATES[@]}"; do
+    FILES=$(find "$crate/src" -name "*.rs" | sort)
+    EXPECTED="$crate/src/main.rs"
+    if [ "$FILES" = "$EXPECTED" ]; then
+        echo "TC: $crate → PASS (main.rs のみ)"
+    else
+        echo "TC: $crate → FAIL (想定外ファイルあり: $FILES)"
+        PASS=false
+    fi
+done
+
 echo "=== TC-U06: 公開 API 不存在確認 ==="
-PUB_MATCHES=$(grep -rn "^pub " --include="*.rs" . | grep -v "target/" || true)
+# ^pub (fn|struct|enum|trait|mod|use|const|static) で外部公開シンボルを検査
+# pub(crate) / pub(super) は "pub " の後に "(" が来るため自動排除される
+PUB_MATCHES=$(grep -rEn "^pub (fn|struct|enum|trait|mod|use|const|static) " \
+    --include="*.rs" . \
+    --exclude-dir=target || true)
 if [ -z "$PUB_MATCHES" ]; then
     echo "TC-U06: PASS (公開 API なし)"
 else
-    echo "TC-U06: FAIL (公開 API が存在: $PUB_MATCHES)"
+    echo "TC-U06: FAIL (公開 API が存在します):"
+    echo "$PUB_MATCHES"
     PASS=false
 fi
 
@@ -262,4 +284,5 @@ $PASS && echo "=== 全ユニットテスト PASS ===" || { echo "=== FAIL ==="; 
 ---
 
 *作成: 涅マユリ（テスト担当）/ 2026-04-22*
+*改訂: 涅マユリ（テスト担当）/ 2026-04-22 — WS-06/TC-U01〜U05 を daemon/cli バイナリ crate（main.rs）・core/infra/gui ライブラリ crate（lib.rs）に区別修正。TC-U06 の grep パターンを `^pub (fn|struct|enum|trait|mod|use|const|static) ` に精密化し pub(crate) 誤検知を排除*
 *対応 Issue: #4 feat(workspace): Cargo workspace 初期化と 5 crate 空スケルトン*

--- a/docs/features/workspace-init/test-design.md
+++ b/docs/features/workspace-init/test-design.md
@@ -242,7 +242,7 @@ for crate in "${BIN_CRATES[@]}"; do
 done
 
 echo "=== TC-U06: 公開 API 不存在確認 ==="
-# ^pub (fn|struct|enum|trait|mod|use|const|static) で外部公開シンボルを検査
+# ^pub (fn|struct|enum|trait|mod|use|const|static|type) で外部公開シンボルを検査
 # pub(crate) / pub(super) は "pub " の後に "(" が来るため自動排除される
 PUB_MATCHES=$(grep -rEn "^pub (fn|struct|enum|trait|mod|use|const|static|type) " \
     --include="*.rs" . \

--- a/docs/features/workspace-init/test-design.md
+++ b/docs/features/workspace-init/test-design.md
@@ -1,0 +1,265 @@
+# テスト設計書 — workspace-init（Cargo workspace 初期化）
+
+## 1. 概要
+
+| 項目 | 内容 |
+|------|------|
+| 対象 feature | workspace-init（Cargo workspace 初期化と 5 crate 空スケルトン） |
+| 対象 Issue | [#4](https://github.com/shikomi-dev/shikomi/issues/4) |
+| 対象ブランチ | `feature/issue-4-workspace-init` |
+| 設計根拠 | `docs/architecture/tech-stack.md` §1（全体構成）、§2.1（言語・ランタイム）、§2.2（CI/CD・依存監査） |
+| テスト実行タイミング | `feature/issue-4-workspace-init` → `develop` へのマージ前 |
+
+## 2. テスト対象と受入基準
+
+| 受入基準ID | 受入基準 | 検証レベル |
+|-----------|---------|-----------|
+| WS-01 | `cargo build --workspace` が pass する | 結合 |
+| WS-02 | `cargo test --workspace` が pass する（テストケース 0 件でも可） | 結合 |
+| WS-03 | `cargo fmt --check --all` が pass する（rustfmt.toml 準拠） | 結合 |
+| WS-04 | `cargo clippy --workspace -- -D warnings` が pass する（.clippy.toml 準拠） | 結合 |
+| WS-05 | `cargo deny check` が pass する（deny.toml 初期設定準拠） | 結合 |
+| WS-06 | 各 crate（shikomi-core / infra / daemon / cli / gui）が `lib.rs` のみの最小構成である | ユニット |
+| WS-07 | 各 crate に公開 API が存在しない（`pub fn` / `pub struct` / `pub enum` / `pub trait` なし） | ユニット |
+| WS-08 | `Cargo.lock` がリポジトリにコミット済みである | ユニット |
+
+## 3. テストマトリクス（トレーサビリティ）
+
+| テストID | 受入基準ID | 検証内容 | テストレベル | 種別 |
+|---------|-----------|---------|------------|------|
+| TC-I01 | WS-01 | `cargo build --workspace` の実行成功 | 結合 | 正常系 |
+| TC-I02 | WS-02 | `cargo test --workspace` の実行成功（0 tests でも pass） | 結合 | 正常系 |
+| TC-I03 | WS-03 | `cargo fmt --check --all` の実行成功（差分なし） | 結合 | 正常系 |
+| TC-I04 | WS-04 | `cargo clippy --workspace -- -D warnings` の実行成功（警告ゼロ） | 結合 | 正常系 |
+| TC-I05 | WS-05 | `cargo deny check` の実行成功（ライセンス・advisory・重複 crate 全 pass） | 結合 | 正常系 |
+| TC-U01 | WS-06 | `shikomi-core/src/lib.rs` が存在し、ソースファイルがそれのみである | ユニット | 正常系 |
+| TC-U02 | WS-06 | `shikomi-infra/src/lib.rs` が存在し、ソースファイルがそれのみである | ユニット | 正常系 |
+| TC-U03 | WS-06 | `shikomi-daemon/src/lib.rs` が存在し、ソースファイルがそれのみである | ユニット | 正常系 |
+| TC-U04 | WS-06 | `shikomi-cli/src/lib.rs` が存在し、ソースファイルがそれのみである | ユニット | 正常系 |
+| TC-U05 | WS-06 | `shikomi-gui/src/lib.rs` が存在し、ソースファイルがそれのみである | ユニット | 正常系 |
+| TC-U06 | WS-07 | 全 crate の `lib.rs` に公開 API シンボル（`pub fn`/`pub struct`/`pub enum`/`pub trait`）が存在しない | ユニット | 正常系 |
+| TC-U07 | WS-08 | `Cargo.lock` がリポジトリルートに存在する | ユニット | 正常系 |
+
+## 4. E2Eテスト設計
+
+**省略理由**: workspace-init はエンドユーザーが直接操作する UI / CLI / 公開 API を持たない横断的変更。
+テスト戦略ガイドの方針「エンドユーザー操作がない場合は結合テストで代替」に従い、E2E は設計対象外とする。
+受入基準の検証は §5 の結合テスト（`cargo` コマンド実行）で網羅する。
+
+## 5. 結合テスト設計（cargo コマンドによる CI 検証）
+
+> **ツール選択根拠**: このシステムは Cargo workspace の初期化。インターフェースは `cargo` コマンド群であり、CLIツールとして結合テストに分類する。検証は実際の `cargo` コマンド実行結果（exit code / stderr）で行う。
+
+### TC-I01: cargo build の通過確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I01 |
+| 対応する受入基準ID | WS-01 |
+| 対応する工程 | 基本設計（tech-stack.md §1 Cargo workspace 構成） |
+| 種別 | 正常系 |
+| 前提条件 | Cargo workspace の `Cargo.toml` が存在し、5 crate 全て登録済み |
+| 操作 | `cargo build --workspace` を実行 |
+| 期待結果 | exit code == 0。5 crate（shikomi-core / infra / daemon / cli / gui）全てのコンパイルが成功する |
+
+### TC-I02: cargo test の通過確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I02 |
+| 対応する受入基準ID | WS-02 |
+| 対応する工程 | 基本設計 |
+| 種別 | 正常系 |
+| 前提条件 | TC-I01 通過済み |
+| 操作 | `cargo test --workspace` を実行 |
+| 期待結果 | exit code == 0。`0 passed; 0 failed` または空テストが 5 crate 全てで確認できる |
+
+### TC-I03: cargo fmt --check の通過確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I03 |
+| 対応する受入基準ID | WS-03 |
+| 対応する工程 | 基本設計（tech-stack.md §2.2 CI/CD） |
+| 種別 | 正常系 |
+| 前提条件 | `rustfmt.toml` がリポジトリルートに存在する |
+| 操作 | `cargo fmt --check --all` を実行 |
+| 期待結果 | exit code == 0。フォーマット差分なし（`Diff in ...` 行が出力されない） |
+
+### TC-I04: cargo clippy の通過確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I04 |
+| 対応する受入基準ID | WS-04 |
+| 対応する工程 | 基本設計（tech-stack.md §2.2 CI/CD） |
+| 種別 | 正常系 |
+| 前提条件 | `.clippy.toml` または `Cargo.toml` の `[lints.clippy]` 設定が存在する |
+| 操作 | `cargo clippy --workspace -- -D warnings` を実行 |
+| 期待結果 | exit code == 0。`warning:` / `error:` が出力されない |
+
+### TC-I05: cargo deny check の通過確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-I05 |
+| 対応する受入基準ID | WS-05 |
+| 対応する工程 | 基本設計（tech-stack.md §2.2 依存監査） |
+| 種別 | 正常系 |
+| 前提条件 | `deny.toml` がリポジトリルートに存在し、ライセンス許可リスト初期設定済み |
+| 操作 | `cargo deny check` を実行 |
+| 期待結果 | exit code == 0。`error[` が出力されない（ライセンス / advisory / 重複バージョン / 禁止 crate のいずれも fail しない） |
+
+## 6. ユニットテスト設計（コード構造検証）
+
+> **ツール**: `find` / `grep` によるファイル構造・ソース内容の静的確認。Rust コンパイラ自体がコード構造チェックを担うため、別途テストコードは作成しない。
+
+### TC-U01〜TC-U05: crate ソースファイル構成確認
+
+| テストID | crate | 検証対象 | 期待結果 |
+|---------|-------|---------|---------|
+| TC-U01 | shikomi-core | `src/` 配下のファイル一覧 | `lib.rs` のみ存在する（`main.rs` / その他 `.rs` ファイルなし） |
+| TC-U02 | shikomi-infra | `src/` 配下のファイル一覧 | `lib.rs` のみ存在する |
+| TC-U03 | shikomi-daemon | `src/` 配下のファイル一覧 | `lib.rs` のみ存在する |
+| TC-U04 | shikomi-cli | `src/` 配下のファイル一覧 | `lib.rs` のみ存在する |
+| TC-U05 | shikomi-gui | `src/` 配下のファイル一覧 | `lib.rs` のみ存在する |
+
+**前提条件**: workspace 実装コードが `feature/issue-4-workspace-init` ブランチにコミット済み
+**操作**: 各 crate の `src/` を確認
+
+### TC-U06: 公開 API 不存在確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-U06 |
+| 対応する受入基準ID | WS-07 |
+| 対応する工程 | 詳細設計（設計原則: 公開 API ゼロ） |
+| 種別 | 正常系 |
+| 前提条件 | 全 crate の `lib.rs` が存在する |
+| 操作 | 全 `lib.rs` に対して `grep -rn "^pub " --include="*.rs"` を実行 |
+| 期待結果 | マッチ行ゼロ。`pub fn` / `pub struct` / `pub enum` / `pub trait` / `pub use` いずれも存在しない |
+
+### TC-U07: Cargo.lock コミット確認
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-U07 |
+| 対応する受入基準ID | WS-08 |
+| 対応する工程 | 基本設計 |
+| 種別 | 正常系 |
+| 前提条件 | ブランチがコミット済み |
+| 操作 | `git ls-files Cargo.lock` を実行 |
+| 期待結果 | `Cargo.lock` が出力される（git 管理下にある） |
+
+## 7. モック方針
+
+| 検証対象 | モック要否 | 理由 |
+|---------|---------|------|
+| cargo コマンド | **不要**（本物を使用） | 実際のコンパイル・ビルドツールチェーンを使う。モックでは意味をなさない |
+| ファイル構造確認 | **不要** | リポジトリの実ファイルを直接確認する |
+| 外部 crate（依存 crate） | **対象外** | スケルトンのため外部依存は `deny.toml` の初期許可リスト確認のみ |
+
+外部依存はすべて本物を使用する。assumed mock は禁止。
+
+## 8. 実行手順と証跡
+
+### 実行環境
+
+- Rust toolchain（`rustup`、`cargo`、`rustfmt`、`clippy` インストール済み）
+- `cargo-deny`（`cargo install cargo-deny`）
+- ローカルまたは CI 環境
+
+### 実行コマンド例（結合テスト TC-I01〜TC-I05）
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+echo "=== TC-I01: cargo build ==="
+cargo build --workspace 2>&1
+echo "TC-I01: PASS"
+
+echo "=== TC-I02: cargo test ==="
+cargo test --workspace 2>&1
+echo "TC-I02: PASS"
+
+echo "=== TC-I03: cargo fmt --check ==="
+cargo fmt --check --all 2>&1
+echo "TC-I03: PASS"
+
+echo "=== TC-I04: cargo clippy ==="
+cargo clippy --workspace -- -D warnings 2>&1
+echo "TC-I04: PASS"
+
+echo "=== TC-I05: cargo deny check ==="
+cargo deny check 2>&1
+echo "TC-I05: PASS"
+
+echo "=== 全結合テスト PASS ==="
+```
+
+### 実行コマンド例（ユニットテスト TC-U01〜TC-U07）
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+CRATES=(shikomi-core shikomi-infra shikomi-daemon shikomi-cli shikomi-gui)
+PASS=true
+
+echo "=== TC-U01〜TC-U05: crate ソースファイル構成確認 ==="
+for crate in "${CRATES[@]}"; do
+    FILES=$(find "$crate/src" -name "*.rs" | sort)
+    EXPECTED="$crate/src/lib.rs"
+    if [ "$FILES" = "$EXPECTED" ]; then
+        echo "TC: $crate → PASS (lib.rs のみ)"
+    else
+        echo "TC: $crate → FAIL (想定外ファイルあり: $FILES)"
+        PASS=false
+    fi
+done
+
+echo "=== TC-U06: 公開 API 不存在確認 ==="
+PUB_MATCHES=$(grep -rn "^pub " --include="*.rs" . | grep -v "target/" || true)
+if [ -z "$PUB_MATCHES" ]; then
+    echo "TC-U06: PASS (公開 API なし)"
+else
+    echo "TC-U06: FAIL (公開 API が存在: $PUB_MATCHES)"
+    PASS=false
+fi
+
+echo "=== TC-U07: Cargo.lock コミット確認 ==="
+if git ls-files Cargo.lock | grep -q "Cargo.lock"; then
+    echo "TC-U07: PASS"
+else
+    echo "TC-U07: FAIL (Cargo.lock が git 管理外)"
+    PASS=false
+fi
+
+$PASS && echo "=== 全ユニットテスト PASS ===" || { echo "=== FAIL ==="; exit 1; }
+```
+
+### 証跡
+
+- テスト実行結果（stdout/stderr/exit code）を Markdown で記録する
+- 結果ファイルを `/app/shared/attachments/マユリ/` に保存して Discord に添付する
+- `cargo build` / `cargo clippy` / `cargo deny` の出力ログを証跡として保存する
+
+## 9. カバレッジ基準
+
+| 観点 | 基準 |
+|------|------|
+| 受入基準の網羅 | WS-01 〜 WS-08 が全テストケース（TC-I01〜TC-I05 / TC-U01〜TC-U07）で網羅されていること |
+| 正常系 | 全ケース必須（結合テスト 5 件 + ユニットテスト 7 件 = 合計 12 件） |
+| 異常系 | スケルトン段階のため意図的なエラーパスは設けない（公開 API が誤って追加された場合の検知は TC-U06 で担保） |
+| 境界値 | `cargo deny` で許可リスト外ライセンスの crate が混入した場合に TC-I05 が fail することを確認 |
+
+---
+
+*作成: 涅マユリ（テスト担当）/ 2026-04-22*
+*対応 Issue: #4 feat(workspace): Cargo workspace 初期化と 5 crate 空スケルトン*


### PR DESCRIPTION
## 概要

- Cargo workspace の `Cargo.toml` 作成（`resolver = "2"`, `edition = "2021"`）
- 5 crate 空スケルトン（shikomi-core / shikomi-infra / shikomi-daemon / shikomi-cli / shikomi-gui）
- `rustfmt.toml` / `.clippy.toml` / `deny.toml` 初期設定
- `docs/architecture/tech-stack.md` の Cargo workspace 記述を実装予定と整合させて明文化
- `docs/features/workspace-init/test-design.md` 追加（テスト設計書）

## 対応 Issue

Closes #4

## 変更ファイル

| ファイル | 変更者 | 内容 |
|---------|-------|------|
| `docs/architecture/tech-stack.md` | セル | Cargo workspace 構成・deny.toml 初期ポリシーを明文化 |
| `docs/features/workspace-init/test-design.md` | 涅マユリ | テスト設計書（TC-I01〜TC-I05 / TC-U01〜TC-U07） |

## テスト設計根拠

- **E2E**: エンドユーザー操作なし（ビルドシステム初期化）のため省略、結合テストで代替
- **結合テスト（TC-I01〜TC-I05）**: `cargo build / test / fmt --check / clippy -D warnings / deny check` 全 pass
- **ユニットテスト（TC-U01〜TC-U07）**: 各 crate `lib.rs` のみ構成・公開 API ゼロ・`Cargo.lock` コミット済みの静的確認

## 受入基準チェックリスト

- [ ] `cargo build --workspace` pass
- [ ] `cargo test --workspace` pass（0 tests でも可）
- [ ] `cargo fmt --check --all` pass
- [ ] `cargo clippy --workspace -- -D warnings` pass
- [ ] `cargo deny check` pass
- [ ] 各 crate が `lib.rs` のみの最小構成
- [ ] 公開 API ゼロ
- [ ] `Cargo.lock` コミット済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)