### PR TITLE
feat(core): vault ドメイン型を実装 (#7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,275 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shikomi-cli"
 version = "0.1.0"
 
 [[package]]
 name = "shikomi-core"
 version = "0.1.0"
+dependencies = [
+ "secrecy",
+ "serde",
+ "thiserror",
+ "time",
+ "unicode-segmentation",
+ "uuid",
+ "zeroize",
+]
 
 [[package]]
 name = "shikomi-daemon"
@@ -21,3 +284,311 @@ version = "0.1.0"
 [[package]]
 name = "shikomi-infra"
 version = "0.1.0"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,12 @@ unsafe_code = "forbid"
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
+
+[workspace.dependencies]
+uuid            = { version = "1",    features = ["v7", "serde"] }
+serde           = { version = "1",    features = ["derive"] }
+secrecy         = { version = "0.10" }
+zeroize         = { version = "1",    features = ["derive"] }
+thiserror       = "2"
+time            = { version = "0.3",  features = ["serde", "macros"] }
+unicode-segmentation = "1"

--- a/crates/shikomi-core/Cargo.toml
+++ b/crates/shikomi-core/Cargo.toml
@@ -6,5 +6,14 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[dependencies]
+uuid                 = { workspace = true }
+serde                = { workspace = true }
+secrecy              = { workspace = true }
+zeroize              = { workspace = true }
+thiserror            = { workspace = true }
+time                 = { workspace = true }
+unicode-segmentation = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/shikomi-core/src/error.rs
+++ b/crates/shikomi-core/src/error.rs
@@ -40,7 +40,8 @@ pub enum DomainError {
     InvalidRecordPayload(InvalidRecordPayloadReason),
 
     /// MSG-DEV-004: vault とレコードのモード不整合、または状態遷移違反。
-    #[error("vault and record payload mode mismatch: {0}")]
+    /// 詳細文言は内包する `VaultConsistencyReason` の `Display` に委譲する。
+    #[error("{0}")]
     VaultConsistencyError(VaultConsistencyReason),
 
     /// MSG-DEV-005: `NonceCounter` が上限 (`u32::MAX`) に達した。rekey が必要。
@@ -193,11 +194,30 @@ mod tests {
             record_mode: ProtectionMode::Encrypted,
         });
         let msg = format!("{}", err);
+        // #[error("{0}")] により VaultConsistencyReason の Display が素通しになる。
+        // ModeMismatch の Display: "vault is in ... mode but record payload is ..."
         assert!(
-            msg.contains("vault") && msg.contains("mode mismatch"),
+            msg.contains("vault") && msg.contains("mode"),
             "got: {}",
             msg
         );
+    }
+
+    #[test]
+    fn test_display_vault_consistency_duplicate_id_does_not_contain_mode_mismatch() {
+        use crate::vault::RecordId;
+        use uuid::Uuid;
+        let id = RecordId::new(Uuid::now_v7()).unwrap();
+        let err = DomainError::VaultConsistencyError(VaultConsistencyReason::DuplicateId(id));
+        let msg = format!("{}", err);
+        // 以前は外枠の文言 "vault and record payload mode mismatch" が混入していた。
+        // #[error("{0}")] により DuplicateId の Display だけが出ることを確認する。
+        assert!(
+            !msg.contains("mode mismatch"),
+            "DuplicateId should not contain 'mode mismatch', got: {}",
+            msg
+        );
+        assert!(msg.contains("duplicate"), "got: {}", msg);
     }
 
     #[test]

--- a/crates/shikomi-core/src/error.rs
+++ b/crates/shikomi-core/src/error.rs
@@ -155,3 +155,79 @@ pub enum VaultConsistencyReason {
     #[error("updated_at must not precede created_at")]
     InvalidUpdatedAt,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vault::protection_mode::ProtectionMode;
+
+    #[test]
+    fn test_display_invalid_protection_mode_contains_keyword() {
+        let err = DomainError::InvalidProtectionMode("x".to_string());
+        let msg = format!("{}", err);
+        assert!(msg.contains("unknown protection mode"), "got: {}", msg);
+    }
+
+    #[test]
+    fn test_display_unsupported_vault_version_contains_version_number() {
+        let err = DomainError::UnsupportedVaultVersion(99);
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("unsupported vault version") && msg.contains("99"),
+            "got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_display_invalid_record_label_contains_keyword() {
+        let err = DomainError::InvalidRecordLabel(InvalidRecordLabelReason::Empty);
+        let msg = format!("{}", err);
+        assert!(msg.contains("invalid record label"), "got: {}", msg);
+    }
+
+    #[test]
+    fn test_display_vault_consistency_mode_mismatch_contains_keywords() {
+        let err = DomainError::VaultConsistencyError(VaultConsistencyReason::ModeMismatch {
+            vault_mode: ProtectionMode::Plaintext,
+            record_mode: ProtectionMode::Encrypted,
+        });
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("vault") && msg.contains("mode mismatch"),
+            "got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_display_nonce_overflow_contains_keyword() {
+        let err = DomainError::NonceOverflow;
+        let msg = format!("{}", err);
+        assert!(msg.contains("nonce counter exhausted"), "got: {}", msg);
+    }
+
+    #[test]
+    fn test_display_invalid_record_id_contains_keyword() {
+        let err = DomainError::InvalidRecordId(InvalidRecordIdReason::NilUuid);
+        let msg = format!("{}", err);
+        assert!(msg.contains("invalid record id"), "got: {}", msg);
+    }
+
+    #[test]
+    fn test_display_invalid_record_payload_contains_keyword() {
+        let err = DomainError::InvalidRecordPayload(InvalidRecordPayloadReason::CipherTextEmpty);
+        let msg = format!("{}", err);
+        assert!(msg.contains("invalid record payload"), "got: {}", msg);
+    }
+
+    #[test]
+    fn test_display_invalid_vault_header_contains_keyword() {
+        let err = DomainError::InvalidVaultHeader(InvalidVaultHeaderReason::KdfSaltLength {
+            expected: 16,
+            got: 15,
+        });
+        let msg = format!("{}", err);
+        assert!(msg.contains("invalid vault header"), "got: {}", msg);
+    }
+}

--- a/crates/shikomi-core/src/error.rs
+++ b/crates/shikomi-core/src/error.rs
@@ -1,0 +1,157 @@
+//! ドメインエラー型。
+//!
+//! 全モジュールが返す `DomainError` と、各バリアントの詳細理由を列挙する。
+
+use thiserror::Error;
+
+// -------------------------------------------------------------------
+// DomainError
+// -------------------------------------------------------------------
+
+/// shikomi-core ドメイン層が返す統一エラー型。
+///
+/// 各バリアントは「開発者向けエラー文面（MSG-DEV-001〜008）」を
+/// `Display` として持つ。CLI/GUI 層で i18n 写像を行うこと。
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum DomainError {
+    /// MSG-DEV-001: 未知の保護モード文字列。
+    #[error("unknown protection mode: {0}")]
+    InvalidProtectionMode(String),
+
+    /// MSG-DEV-002: 非対応の vault バージョン。
+    #[error("unsupported vault version: {0}")]
+    UnsupportedVaultVersion(u16),
+
+    /// MSG-DEV-008: vault ヘッダの不整合。
+    #[error("invalid vault header: {0}")]
+    InvalidVaultHeader(#[from] InvalidVaultHeaderReason),
+
+    /// MSG-DEV-006: 不正なレコード ID。
+    #[error("invalid record id: {0}")]
+    InvalidRecordId(InvalidRecordIdReason),
+
+    /// MSG-DEV-003: 不正なレコードラベル。
+    #[error("invalid record label: {0}")]
+    InvalidRecordLabel(InvalidRecordLabelReason),
+
+    /// MSG-DEV-007: 不正なレコードペイロード。
+    #[error("invalid record payload: {0}")]
+    InvalidRecordPayload(InvalidRecordPayloadReason),
+
+    /// MSG-DEV-004: vault とレコードのモード不整合、または状態遷移違反。
+    #[error("vault and record payload mode mismatch: {0}")]
+    VaultConsistencyError(VaultConsistencyReason),
+
+    /// MSG-DEV-005: `NonceCounter` が上限 (`u32::MAX`) に達した。rekey が必要。
+    #[error("nonce counter exhausted; rekey required")]
+    NonceOverflow,
+}
+
+// -------------------------------------------------------------------
+// 付随 Reason 列挙
+// -------------------------------------------------------------------
+
+/// `DomainError::InvalidVaultHeader` の詳細理由。
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum InvalidVaultHeaderReason {
+    /// KDF ソルトのバイト長が期待値と異なる。
+    #[error("kdf_salt length mismatch: expected {expected}, got {got}")]
+    KdfSaltLength { expected: usize, got: usize },
+
+    /// `WrappedVek` が空（0 バイト）。
+    #[error("wrapped_vek is empty")]
+    WrappedVekEmpty,
+
+    /// `WrappedVek` が最小長未満（AES-GCM タグ 16 B 以上必要）。
+    #[error("wrapped_vek is too short")]
+    WrappedVekTooShort,
+}
+
+/// `DomainError::InvalidRecordId` の詳細理由。
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum InvalidRecordIdReason {
+    /// UUID のバージョンが v7 ではない。
+    #[error("expected UUIDv7, got version {actual}")]
+    WrongVersion { actual: u8 },
+
+    /// nil UUID（全ゼロ）は `RecordId` に使用できない。
+    #[error("nil UUID is not allowed as RecordId")]
+    NilUuid,
+
+    /// 文字列の UUID パース失敗。
+    #[error("failed to parse UUID: {0}")]
+    ParseError(String),
+}
+
+/// `DomainError::InvalidRecordLabel` の詳細理由。
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum InvalidRecordLabelReason {
+    /// 空文字列。
+    #[error("label must not be empty")]
+    Empty,
+
+    /// 禁止制御文字を含む（U+0000〜U+001F の \t/\n/\r 以外、または U+007F）。
+    #[error("label contains a forbidden control character at byte position {position}")]
+    ControlChar { position: usize },
+
+    /// grapheme cluster 数が 255 を超える。
+    #[error("label is too long: {grapheme_count} graphemes (max 255)")]
+    TooLong { grapheme_count: usize },
+}
+
+/// `DomainError::InvalidRecordPayload` の詳細理由。
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum InvalidRecordPayloadReason {
+    /// nonce のバイト長が 12 ではない。
+    #[error("nonce length mismatch: expected {expected}, got {got}")]
+    NonceLength { expected: usize, got: usize },
+
+    /// ciphertext が空（0 バイト）。
+    #[error("ciphertext must not be empty")]
+    CipherTextEmpty,
+
+    /// AAD に必要なフィールドが欠けている。
+    #[error("aad missing field: {0}")]
+    AadMissingField(String),
+
+    /// AAD の `record_created_at` を i64 マイクロ秒に変換したとき範囲外。
+    #[error("aad timestamp is out of i64 microseconds range")]
+    AadTimestampOutOfRange,
+}
+
+/// `DomainError::VaultConsistencyError` の詳細理由。
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum VaultConsistencyReason {
+    /// vault の保護モードとレコードペイロードのモードが一致しない。
+    #[error("vault is in {vault_mode:?} mode but record payload is {record_mode:?}")]
+    ModeMismatch {
+        vault_mode: crate::vault::ProtectionMode,
+        record_mode: crate::vault::ProtectionMode,
+    },
+
+    /// 同一 `RecordId` が既に vault に存在する。
+    #[error("duplicate record id: {0:?}")]
+    DuplicateId(crate::vault::RecordId),
+
+    /// 平文 vault に対して rekey を実行しようとした。
+    #[error("rekey is not applicable to a plaintext vault")]
+    RekeyInPlaintextMode,
+
+    /// rekey 中の部分再暗号化失敗（呼び出し元でトランザクションをロールバックすること）。
+    #[error("rekey partially failed; vault is in inconsistent state")]
+    RekeyPartialFailure,
+
+    /// 指定された `RecordId` が vault に存在しない。
+    #[error("record not found: {0:?}")]
+    RecordNotFound(crate::vault::RecordId),
+
+    /// `updated_at` が `created_at` より前の時刻になる更新は拒否。
+    #[error("updated_at must not precede created_at")]
+    InvalidUpdatedAt,
+}

--- a/crates/shikomi-core/src/lib.rs
+++ b/crates/shikomi-core/src/lib.rs
@@ -1,1 +1,29 @@
 //! shikomi-core — ドメインロジック層
+//!
+//! vault ドメイン型・秘密値ラッパ・ドメインエラーを提供する pure Rust / no-I/O クレート。
+//! 外部 API / OS / DB には一切アクセスしない。
+
+pub mod error;
+pub mod secret;
+pub mod vault;
+
+// --- ドメインエラー ---
+pub use error::{
+    DomainError, InvalidRecordIdReason, InvalidRecordLabelReason, InvalidRecordPayloadReason,
+    InvalidVaultHeaderReason, VaultConsistencyReason,
+};
+
+// --- 秘密値ラッパ ---
+pub use secret::{SecretBytes, SecretString};
+
+// --- vault 集約・ヘッダ ---
+pub use vault::{ProtectionMode, Vault, VaultHeader, VaultVersion};
+
+// --- レコード ---
+pub use vault::{Record, RecordId, RecordKind, RecordLabel, RecordPayload, RecordPayloadEncrypted};
+
+// --- 暗号化関連データ型 ---
+pub use vault::{Aad, CipherText, KdfSalt, NonceBytes, NonceCounter, WrappedVek};
+
+// --- VekProvider trait ---
+pub use vault::VekProvider;

--- a/crates/shikomi-core/src/secret/mod.rs
+++ b/crates/shikomi-core/src/secret/mod.rs
@@ -1,0 +1,95 @@
+//! 秘密値ラッパ型。
+//!
+//! `SecretString` / `SecretBytes` は内部を `secrecy::SecretBox` に格納し、
+//! `Debug` / `Display` では `[REDACTED]` のみを出力する。
+//! `serde::Serialize` は意図的に未実装（コンパイル時に誤シリアライズを防ぐ）。
+
+use std::fmt;
+
+use secrecy::{ExposeSecret, SecretBox};
+
+// -------------------------------------------------------------------
+// SecretString
+// -------------------------------------------------------------------
+
+/// ヒープ上の文字列を `secrecy::SecretBox` で保護するラッパ。
+///
+/// - `Debug` は `[REDACTED]` 固定（`Display` は未実装：ログ漏洩リスクを型で排除）
+/// - `Clone` `は内部文字列を再ラップして生成する（SecretBox::clone` は使用不可）
+/// - `serde::Serialize` は未実装
+pub struct SecretString {
+    inner: SecretBox<String>,
+}
+
+impl SecretString {
+    /// `String` を `SecretString` に変換する。入力検証は呼び出し元の責務。
+    #[must_use]
+    pub fn from_string(s: String) -> Self {
+        Self {
+            inner: SecretBox::new(Box::new(s)),
+        }
+    }
+
+    /// 保持している文字列への参照を返す。
+    ///
+    /// 返り値をログや永続化に流さないこと。
+    #[must_use]
+    pub fn expose_secret(&self) -> &str {
+        self.inner.expose_secret().as_str()
+    }
+}
+
+impl Clone for SecretString {
+    fn clone(&self) -> Self {
+        Self::from_string(self.expose_secret().to_owned())
+    }
+}
+
+impl fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+// -------------------------------------------------------------------
+// SecretBytes
+// -------------------------------------------------------------------
+
+/// ヒープ上のバイト列を `secrecy::SecretBox` で保護するラッパ。
+///
+/// - `Debug` は `[REDACTED]` 固定
+/// - `Clone` は内部バイトを再ラップして生成する
+/// - `serde::Serialize` は未実装
+pub struct SecretBytes {
+    inner: SecretBox<Vec<u8>>,
+}
+
+impl SecretBytes {
+    /// `Box<[u8]>` を `SecretBytes` に変換する。
+    #[must_use]
+    pub fn from_boxed_slice(b: Box<[u8]>) -> Self {
+        Self {
+            inner: SecretBox::new(Box::new(b.into_vec())),
+        }
+    }
+
+    /// 保持しているバイト列への参照を返す。
+    ///
+    /// 返り値をログや永続化に流さないこと。
+    #[must_use]
+    pub fn expose_secret(&self) -> &[u8] {
+        self.inner.expose_secret().as_slice()
+    }
+}
+
+impl Clone for SecretBytes {
+    fn clone(&self) -> Self {
+        Self::from_boxed_slice(self.expose_secret().to_vec().into_boxed_slice())
+    }
+}
+
+impl fmt::Debug for SecretBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}

--- a/crates/shikomi-core/src/secret/mod.rs
+++ b/crates/shikomi-core/src/secret/mod.rs
@@ -93,3 +93,52 @@ impl fmt::Debug for SecretBytes {
         f.write_str("[REDACTED]")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_secret_string_from_string_constructs_without_panic() {
+        let _ = SecretString::from_string("password".to_string());
+    }
+
+    #[test]
+    fn test_secret_string_debug_does_not_expose_value() {
+        let s = SecretString::from_string("password".to_string());
+        let debug_output = format!("{:?}", s);
+        assert!(
+            !debug_output.contains("password"),
+            "Debug must not expose the secret"
+        );
+        assert!(debug_output.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn test_secret_string_expose_secret_returns_original_value() {
+        let s = SecretString::from_string("password".to_string());
+        assert_eq!(s.expose_secret(), "password");
+    }
+
+    #[test]
+    fn test_secret_bytes_from_boxed_slice_constructs_without_panic() {
+        let _ = SecretBytes::from_boxed_slice(vec![1u8, 2, 3].into_boxed_slice());
+    }
+
+    #[test]
+    fn test_secret_bytes_debug_does_not_expose_value() {
+        let b = SecretBytes::from_boxed_slice(vec![1u8, 2, 3].into_boxed_slice());
+        let debug_output = format!("{:?}", b);
+        assert!(
+            !debug_output.contains("1, 2, 3"),
+            "Debug must not expose bytes"
+        );
+        assert!(debug_output.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn test_secret_bytes_expose_secret_returns_original_bytes() {
+        let b = SecretBytes::from_boxed_slice(vec![1u8, 2, 3].into_boxed_slice());
+        assert_eq!(b.expose_secret(), &[1u8, 2, 3]);
+    }
+}

--- a/crates/shikomi-core/src/vault/crypto_data.rs
+++ b/crates/shikomi-core/src/vault/crypto_data.rs
@@ -215,6 +215,66 @@ mod tests {
         RecordId::new(Uuid::now_v7()).unwrap()
     }
 
+    // ---------------------------------------------------------------
+    // WrappedVek::try_new 境界値テスト（TC-U06a）
+    // REQ-009 / AC-09（Defense in Depth: 暗号的不正入力のドメイン層排除）
+    // ---------------------------------------------------------------
+
+    /// TC-U06a-01: 空バイト列 → WrappedVekEmpty
+    #[test]
+    fn test_wrapped_vek_try_new_with_empty_bytes_returns_wrapped_vek_empty() {
+        let err = WrappedVek::try_new(vec![].into_boxed_slice()).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                DomainError::InvalidVaultHeader(InvalidVaultHeaderReason::WrappedVekEmpty)
+            ),
+            "Expected WrappedVekEmpty, got: {:?}",
+            err
+        );
+    }
+
+    /// TC-U06a-02: 1 バイト（最小不正値）→ WrappedVekTooShort
+    #[test]
+    fn test_wrapped_vek_try_new_with_1_byte_returns_wrapped_vek_too_short() {
+        let err = WrappedVek::try_new(vec![0u8; 1].into_boxed_slice()).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                DomainError::InvalidVaultHeader(InvalidVaultHeaderReason::WrappedVekTooShort)
+            ),
+            "Expected WrappedVekTooShort for 1-byte input, got: {:?}",
+            err
+        );
+    }
+
+    /// TC-U06a-03: 15 バイト（上限不正値）→ WrappedVekTooShort
+    #[test]
+    fn test_wrapped_vek_try_new_with_15_bytes_returns_wrapped_vek_too_short() {
+        let err = WrappedVek::try_new(vec![0u8; 15].into_boxed_slice()).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                DomainError::InvalidVaultHeader(InvalidVaultHeaderReason::WrappedVekTooShort)
+            ),
+            "Expected WrappedVekTooShort for 15-byte input, got: {:?}",
+            err
+        );
+    }
+
+    /// TC-U06a-04: 16 バイト（最小有効値）→ Ok
+    #[test]
+    fn test_wrapped_vek_try_new_with_16_bytes_ok() {
+        assert!(
+            WrappedVek::try_new(vec![0u8; 16].into_boxed_slice()).is_ok(),
+            "WrappedVek with 16 bytes must succeed"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Aad テスト
+    // ---------------------------------------------------------------
+
     #[test]
     fn test_aad_new_with_valid_args_ok() {
         let id = make_id();

--- a/crates/shikomi-core/src/vault/crypto_data.rs
+++ b/crates/shikomi-core/src/vault/crypto_data.rs
@@ -12,6 +12,10 @@ use crate::vault::version::VaultVersion;
 /// Argon2id KDF ソルト長（16 byte、OWASP 推奨 16 B 以上）。
 const KDF_SALT_LEN: usize = 16;
 
+/// `WrappedVek` に必要な最小バイト長。
+/// AES-GCM 認証タグが 16 B 固定のため、それ以上でなければ暗号的に不正。
+const WRAPPED_VEK_MIN_LEN: usize = 16;
+
 // -------------------------------------------------------------------
 // KdfSalt
 // -------------------------------------------------------------------
@@ -64,11 +68,17 @@ impl WrappedVek {
     /// バイト列から `WrappedVek` を構築する。
     ///
     /// # Errors
-    /// 空の場合 `DomainError::InvalidVaultHeader(WrappedVekEmpty)` を返す。
+    /// - 空の場合 `DomainError::InvalidVaultHeader(WrappedVekEmpty)` を返す。
+    /// - 16 バイト未満の場合 `DomainError::InvalidVaultHeader(WrappedVekTooShort)` を返す。
     pub fn try_new(bytes: Box<[u8]>) -> Result<Self, DomainError> {
         if bytes.is_empty() {
             return Err(DomainError::InvalidVaultHeader(
                 InvalidVaultHeaderReason::WrappedVekEmpty,
+            ));
+        }
+        if bytes.len() < WRAPPED_VEK_MIN_LEN {
+            return Err(DomainError::InvalidVaultHeader(
+                InvalidVaultHeaderReason::WrappedVekTooShort,
             ));
         }
         Ok(Self { inner: bytes })

--- a/crates/shikomi-core/src/vault/crypto_data.rs
+++ b/crates/shikomi-core/src/vault/crypto_data.rs
@@ -1,0 +1,191 @@
+//! 暗号化関連バイト列 newtype 群。
+//!
+//! `KdfSalt` / `WrappedVek` / `CipherText` / `Aad` の 4 型。
+//! いずれも検証済み newtype で、生バイト列の取り違えを型で防ぐ。
+
+use time::OffsetDateTime;
+
+use crate::error::{DomainError, InvalidRecordPayloadReason, InvalidVaultHeaderReason};
+use crate::vault::id::RecordId;
+use crate::vault::version::VaultVersion;
+
+/// Argon2id KDF ソルト長（16 byte、OWASP 推奨 16 B 以上）。
+const KDF_SALT_LEN: usize = 16;
+
+// -------------------------------------------------------------------
+// KdfSalt
+// -------------------------------------------------------------------
+
+/// Argon2id に渡す KDF ソルト（16 byte 固定）。
+#[derive(Debug, Clone)]
+pub struct KdfSalt {
+    inner: [u8; KDF_SALT_LEN],
+}
+
+impl KdfSalt {
+    /// バイトスライスから `KdfSalt` を構築する。
+    ///
+    /// # Errors
+    /// `bytes.len() != 16` の場合 `DomainError::InvalidVaultHeader(KdfSaltLength)` を返す。
+    pub fn try_new(bytes: &[u8]) -> Result<Self, DomainError> {
+        if bytes.len() != KDF_SALT_LEN {
+            return Err(DomainError::InvalidVaultHeader(
+                InvalidVaultHeaderReason::KdfSaltLength {
+                    expected: KDF_SALT_LEN,
+                    got: bytes.len(),
+                },
+            ));
+        }
+        let mut inner = [0u8; KDF_SALT_LEN];
+        inner.copy_from_slice(bytes);
+        Ok(Self { inner })
+    }
+
+    /// 内包する 16 バイト配列への参照を返す。
+    #[must_use]
+    pub fn as_array(&self) -> &[u8; KDF_SALT_LEN] {
+        &self.inner
+    }
+}
+
+// -------------------------------------------------------------------
+// WrappedVek
+// -------------------------------------------------------------------
+
+/// VEK（Vault Encryption Key）を暗号化してラップしたバイト列。
+///
+/// AES-GCM wrap には認証タグ（16 B）が含まれるため、実態は空ではない。
+#[derive(Debug, Clone)]
+pub struct WrappedVek {
+    inner: Box<[u8]>,
+}
+
+impl WrappedVek {
+    /// バイト列から `WrappedVek` を構築する。
+    ///
+    /// # Errors
+    /// 空の場合 `DomainError::InvalidVaultHeader(WrappedVekEmpty)` を返す。
+    pub fn try_new(bytes: Box<[u8]>) -> Result<Self, DomainError> {
+        if bytes.is_empty() {
+            return Err(DomainError::InvalidVaultHeader(
+                InvalidVaultHeaderReason::WrappedVekEmpty,
+            ));
+        }
+        Ok(Self { inner: bytes })
+    }
+
+    /// 内包するバイト列への参照を返す。
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+// -------------------------------------------------------------------
+// CipherText
+// -------------------------------------------------------------------
+
+/// AES-256-GCM 暗号化済みのレコードペイロード。認証タグを含む。
+#[derive(Debug, Clone)]
+pub struct CipherText {
+    inner: Box<[u8]>,
+}
+
+impl CipherText {
+    /// バイト列から `CipherText` を構築する。
+    ///
+    /// # Errors
+    /// 空の場合 `DomainError::InvalidRecordPayload(CipherTextEmpty)` を返す。
+    pub fn try_new(bytes: Box<[u8]>) -> Result<Self, DomainError> {
+        if bytes.is_empty() {
+            return Err(DomainError::InvalidRecordPayload(
+                InvalidRecordPayloadReason::CipherTextEmpty,
+            ));
+        }
+        Ok(Self { inner: bytes })
+    }
+
+    /// 内包するバイト列への参照を返す。
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+// -------------------------------------------------------------------
+// Aad
+// -------------------------------------------------------------------
+
+/// AEAD に渡す追加認証データ（Associated Authenticated Data）。
+///
+/// `to_canonical_bytes()` は 26 バイト固定長の決定論的バイト列を返す。
+/// このレイアウトを破壊する変更は `VaultVersion` のメジャーアップとセットでのみ許可される。
+#[derive(Debug, Clone)]
+pub struct Aad {
+    record_id: RecordId,
+    vault_version: VaultVersion,
+    record_created_at: OffsetDateTime,
+    /// `record_created_at` を Unix epoch 起点のマイクロ秒（i64）に変換済みの値。
+    /// `Aad::new` で検証・格納し、`to_canonical_bytes` でそのまま使用する。
+    record_created_at_micros: i64,
+}
+
+impl Aad {
+    /// `Aad` を構築する。
+    ///
+    /// `record_created_at` は `Record::new` によって既にマイクロ秒精度に切り捨て済みであること。
+    ///
+    /// # Errors
+    /// `record_created_at` を i64 マイクロ秒に変換できない場合
+    /// `DomainError::InvalidRecordPayload(AadTimestampOutOfRange)` を返す。
+    pub fn new(
+        record_id: RecordId,
+        vault_version: VaultVersion,
+        record_created_at: OffsetDateTime,
+    ) -> Result<Self, DomainError> {
+        let nanos: i128 = record_created_at.unix_timestamp_nanos();
+        let micros_i128 = nanos / 1_000;
+        let record_created_at_micros = i64::try_from(micros_i128).map_err(|_| {
+            DomainError::InvalidRecordPayload(InvalidRecordPayloadReason::AadTimestampOutOfRange)
+        })?;
+        Ok(Self {
+            record_id,
+            vault_version,
+            record_created_at,
+            record_created_at_micros,
+        })
+    }
+
+    /// `record_id` への参照を返す。
+    #[must_use]
+    pub fn record_id(&self) -> &RecordId {
+        &self.record_id
+    }
+
+    /// `vault_version` を返す。
+    #[must_use]
+    pub fn vault_version(&self) -> VaultVersion {
+        self.vault_version
+    }
+
+    /// `record_created_at` を返す。
+    #[must_use]
+    pub fn record_created_at(&self) -> OffsetDateTime {
+        self.record_created_at
+    }
+
+    /// AEAD に渡す 26 バイト固定長の決定論的バイト列を返す。
+    ///
+    /// レイアウト:
+    /// - `[0..16]`  : `record_id` の `UUIDv7` バイト列（RFC 4122 バイナリ形式、MSB first）
+    /// - `[16..18]` : `vault_version` の u16 値（big-endian）
+    /// - `[18..26]` : `record_created_at` の Unix epoch 起点マイクロ秒（i64、big-endian two's complement）
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> [u8; 26] {
+        let mut bytes = [0u8; 26];
+        bytes[0..16].copy_from_slice(self.record_id.as_uuid().as_bytes());
+        bytes[16..18].copy_from_slice(&self.vault_version.value().to_be_bytes());
+        bytes[18..26].copy_from_slice(&self.record_created_at_micros.to_be_bytes());
+        bytes
+    }
+}

--- a/crates/shikomi-core/src/vault/crypto_data.rs
+++ b/crates/shikomi-core/src/vault/crypto_data.rs
@@ -189,3 +189,82 @@ impl Aad {
         bytes
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vault::id::RecordId;
+    use crate::vault::version::VaultVersion;
+    use time::OffsetDateTime;
+    use uuid::Uuid;
+
+    fn make_id() -> RecordId {
+        RecordId::new(Uuid::now_v7()).unwrap()
+    }
+
+    #[test]
+    fn test_aad_new_with_valid_args_ok() {
+        let id = make_id();
+        assert!(Aad::new(id, VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).is_ok());
+    }
+
+    #[test]
+    fn test_aad_new_with_out_of_range_timestamp_returns_aad_timestamp_out_of_range() {
+        // TC-U11-02: AadTimestampOutOfRange fires when microseconds overflow i64.
+        // Overflow threshold: seconds > i64::MAX / 1_000_000 ≈ 9_223_372_036_854.
+        // time 0.3 limits representable years to [-9999, 9999]; max unix timestamp
+        // ≈ year 9999 ≈ 2.53×10^11 s → max microseconds ≈ 2.53×10^17 << i64::MAX.
+        // Therefore AadTimestampOutOfRange is unreachable within time 0.3's range.
+        // If time 0.3 cannot represent the threshold timestamp, the test is
+        // vacuously satisfied (defensive path cannot be triggered with this crate).
+        let threshold = i64::MAX / 1_000_000 + 1;
+        if let Ok(far_future) = OffsetDateTime::from_unix_timestamp(threshold) {
+            let id = make_id();
+            let err = Aad::new(id, VaultVersion::CURRENT, far_future).unwrap_err();
+            assert!(matches!(
+                err,
+                DomainError::InvalidRecordPayload(
+                    crate::error::InvalidRecordPayloadReason::AadTimestampOutOfRange
+                )
+            ));
+        }
+        // else: time 0.3 cannot represent this timestamp; the error variant is
+        // dead code in practice — test is vacuously satisfied.
+    }
+
+    #[test]
+    fn test_aad_to_canonical_bytes_returns_26_bytes() {
+        let id = make_id();
+        let aad = Aad::new(id, VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).unwrap();
+        assert_eq!(aad.to_canonical_bytes().len(), 26);
+    }
+
+    #[test]
+    fn test_aad_to_canonical_bytes_golden_value() {
+        // Golden value test: known RecordId + VaultVersion::CURRENT + UNIX_EPOCH
+        // Expected 26 bytes:
+        //   [0..16]: UUID bytes MSB first
+        //   [16..18]: u16=1 big-endian = [0x00, 0x01]
+        //   [18..26]: i64=0 big-endian = [0x00; 8]
+        let uuid_bytes = [
+            0x01u8, 0x8f, 0x12, 0x34, 0x56, 0x78, 0x7a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78,
+            0x90, 0x12,
+        ];
+        let uuid = Uuid::from_bytes(uuid_bytes);
+        let id = RecordId::new(uuid).unwrap();
+        let aad = Aad::new(id, VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).unwrap();
+        let canonical = aad.to_canonical_bytes();
+
+        let expected: [u8; 26] = [
+            0x01, 0x8f, 0x12, 0x34, 0x56, 0x78, 0x7a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78,
+            0x90, 0x12, // UUID bytes [0..16]
+            0x00, 0x01, // u16=1 BE [16..18]
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // i64=0 BE [18..26]
+        ];
+        assert_eq!(
+            canonical, expected,
+            "Golden value mismatch: got {:02x?}, expected {:02x?}",
+            canonical, expected
+        );
+    }
+}

--- a/crates/shikomi-core/src/vault/crypto_data.rs
+++ b/crates/shikomi-core/src/vault/crypto_data.rs
@@ -145,6 +145,9 @@ impl Aad {
     ) -> Result<Self, DomainError> {
         let nanos: i128 = record_created_at.unix_timestamp_nanos();
         let micros_i128 = nanos / 1_000;
+        // SAFETY(到達不能): time 0.3 の `OffsetDateTime` は約 ±9999 年の範囲に収まり、
+        // i64 マイクロ秒（±292,000 年）を超えることは現実的にない。
+        // 将来の time クレートの年範囲拡張に備えた防衛的コードとして維持する。
         let record_created_at_micros = i64::try_from(micros_i128).map_err(|_| {
             DomainError::InvalidRecordPayload(InvalidRecordPayloadReason::AadTimestampOutOfRange)
         })?;

--- a/crates/shikomi-core/src/vault/header.rs
+++ b/crates/shikomi-core/src/vault/header.rs
@@ -164,3 +164,88 @@ impl VaultHeader {
 // InvalidVaultHeaderReason は error.rs にある
 #[allow(unused_imports)]
 use InvalidVaultHeaderReason as _;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::DomainError;
+    use time::OffsetDateTime;
+
+    fn now() -> OffsetDateTime {
+        OffsetDateTime::UNIX_EPOCH
+    }
+
+    fn valid_kdf_salt() -> KdfSalt {
+        KdfSalt::try_new(&[0u8; 16]).unwrap()
+    }
+
+    fn valid_wrapped_vek() -> WrappedVek {
+        WrappedVek::try_new(vec![0u8; 48].into_boxed_slice()).unwrap()
+    }
+
+    #[test]
+    fn test_new_plaintext_with_current_version_ok() {
+        let result = VaultHeader::new_plaintext(VaultVersion::CURRENT, now());
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), VaultHeader::Plaintext(_)));
+    }
+
+    #[test]
+    fn test_new_plaintext_unsupported_version_try_new_returns_error() {
+        // VaultVersion has a private field so we cannot construct VaultVersion(2) directly.
+        // The defensive check in new_plaintext never fires for validly-constructed VaultVersions.
+        // We verify that the only way to get an unsupported version is rejected by VaultVersion::try_new.
+        let err = VaultVersion::try_new(2).unwrap_err();
+        assert!(matches!(err, DomainError::UnsupportedVaultVersion(2)));
+    }
+
+    #[test]
+    fn test_new_encrypted_with_valid_args_ok() {
+        let result = VaultHeader::new_encrypted(
+            VaultVersion::CURRENT,
+            now(),
+            valid_kdf_salt(),
+            valid_wrapped_vek(),
+            valid_wrapped_vek(),
+        );
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), VaultHeader::Encrypted(_)));
+    }
+
+    #[test]
+    fn test_new_encrypted_with_wrong_kdf_salt_length_returns_error() {
+        let salt = KdfSalt::try_new(&[0u8; 15]).unwrap_err();
+        assert!(matches!(salt, DomainError::InvalidVaultHeader(_)));
+    }
+
+    #[test]
+    fn test_new_encrypted_with_empty_wrapped_vek_pw_returns_error() {
+        let err = WrappedVek::try_new(vec![].into_boxed_slice()).unwrap_err();
+        assert!(matches!(err, DomainError::InvalidVaultHeader(_)));
+    }
+
+    #[test]
+    fn test_new_encrypted_with_empty_wrapped_vek_recovery_returns_error() {
+        let err = WrappedVek::try_new(vec![].into_boxed_slice()).unwrap_err();
+        assert!(matches!(err, DomainError::InvalidVaultHeader(_)));
+    }
+
+    #[test]
+    fn test_plaintext_protection_mode_returns_plaintext() {
+        let header = VaultHeader::new_plaintext(VaultVersion::CURRENT, now()).unwrap();
+        assert_eq!(header.protection_mode(), ProtectionMode::Plaintext);
+    }
+
+    #[test]
+    fn test_encrypted_protection_mode_returns_encrypted() {
+        let header = VaultHeader::new_encrypted(
+            VaultVersion::CURRENT,
+            now(),
+            valid_kdf_salt(),
+            valid_wrapped_vek(),
+            valid_wrapped_vek(),
+        )
+        .unwrap();
+        assert_eq!(header.protection_mode(), ProtectionMode::Encrypted);
+    }
+}

--- a/crates/shikomi-core/src/vault/header.rs
+++ b/crates/shikomi-core/src/vault/header.rs
@@ -36,8 +36,8 @@ pub struct VaultHeaderEncrypted {
 }
 
 impl VaultHeaderEncrypted {
-    /// rekey 時に wrapped VEK を更新する（vault/mod.rs 内部からのみ呼び出し）。
-    pub(super) fn replace_wrapped_veks(
+    /// rekey 時に wrapped VEK を更新する（`shikomi-core` クレート内部からのみ呼び出し）。
+    pub(crate) fn replace_wrapped_veks(
         &mut self,
         wrapped_vek_by_pw: WrappedVek,
         wrapped_vek_by_recovery: WrappedVek,

--- a/crates/shikomi-core/src/vault/header.rs
+++ b/crates/shikomi-core/src/vault/header.rs
@@ -1,0 +1,166 @@
+//! vault ヘッダ（平文 / 暗号化バリアント）。
+//!
+//! `VaultHeader` は enum で平文 / 暗号化の 2 バリアントを型レベルで排他する。
+//! 平文ヘッダには暗号フィールドが存在せず、型で不正状態を排除する（Fail Fast）。
+
+use time::OffsetDateTime;
+
+use crate::error::{DomainError, InvalidVaultHeaderReason};
+use crate::vault::crypto_data::{KdfSalt, WrappedVek};
+use crate::vault::protection_mode::ProtectionMode;
+use crate::vault::version::VaultVersion;
+
+// -------------------------------------------------------------------
+// 平文ヘッダ内部型
+// -------------------------------------------------------------------
+
+/// 平文モード用 vault ヘッダの内部データ。
+#[derive(Debug, Clone)]
+pub struct VaultHeaderPlaintext {
+    pub(super) version: VaultVersion,
+    pub(super) created_at: OffsetDateTime,
+}
+
+// -------------------------------------------------------------------
+// 暗号化ヘッダ内部型
+// -------------------------------------------------------------------
+
+/// 暗号化モード用 vault ヘッダの内部データ。
+#[derive(Debug, Clone)]
+pub struct VaultHeaderEncrypted {
+    pub(super) version: VaultVersion,
+    pub(super) created_at: OffsetDateTime,
+    pub(super) kdf_salt: KdfSalt,
+    pub(super) wrapped_vek_by_pw: WrappedVek,
+    pub(super) wrapped_vek_by_recovery: WrappedVek,
+}
+
+impl VaultHeaderEncrypted {
+    /// rekey 時に wrapped VEK を更新する（vault/mod.rs 内部からのみ呼び出し）。
+    pub(super) fn replace_wrapped_veks(
+        &mut self,
+        wrapped_vek_by_pw: WrappedVek,
+        wrapped_vek_by_recovery: WrappedVek,
+    ) {
+        self.wrapped_vek_by_pw = wrapped_vek_by_pw;
+        self.wrapped_vek_by_recovery = wrapped_vek_by_recovery;
+    }
+}
+
+// -------------------------------------------------------------------
+// VaultHeader
+// -------------------------------------------------------------------
+
+/// vault ヘッダ。保護モードごとに異なるフィールドを enum バリアントで排他する。
+#[derive(Debug, Clone)]
+pub enum VaultHeader {
+    /// 平文モードのヘッダ（暗号フィールドなし）。
+    Plaintext(VaultHeaderPlaintext),
+    /// 暗号化モードのヘッダ（KDF ソルト、Wrapped VEK を保持）。
+    Encrypted(VaultHeaderEncrypted),
+}
+
+impl VaultHeader {
+    /// 平文モードのヘッダを構築する。
+    ///
+    /// # Errors
+    /// `version` が対応範囲外の場合 `DomainError::UnsupportedVaultVersion` を返す。
+    pub fn new_plaintext(
+        version: VaultVersion,
+        created_at: OffsetDateTime,
+    ) -> Result<Self, DomainError> {
+        // VaultVersion::try_new で既に検証済みだが防御的にチェック
+        if version < VaultVersion::MIN_SUPPORTED || version > VaultVersion::CURRENT {
+            return Err(DomainError::UnsupportedVaultVersion(version.value()));
+        }
+        Ok(Self::Plaintext(VaultHeaderPlaintext {
+            version,
+            created_at,
+        }))
+    }
+
+    /// 暗号化モードのヘッダを構築する。
+    ///
+    /// `kdf_salt` / `wrapped_vek_by_pw` / `wrapped_vek_by_recovery` は
+    /// それぞれの `try_new` で検証済みの型を渡すこと。
+    ///
+    /// # Errors
+    /// `version` が対応範囲外の場合 `DomainError::UnsupportedVaultVersion` を返す。
+    pub fn new_encrypted(
+        version: VaultVersion,
+        created_at: OffsetDateTime,
+        kdf_salt: KdfSalt,
+        wrapped_vek_by_pw: WrappedVek,
+        wrapped_vek_by_recovery: WrappedVek,
+    ) -> Result<Self, DomainError> {
+        if version < VaultVersion::MIN_SUPPORTED || version > VaultVersion::CURRENT {
+            return Err(DomainError::UnsupportedVaultVersion(version.value()));
+        }
+        Ok(Self::Encrypted(VaultHeaderEncrypted {
+            version,
+            created_at,
+            kdf_salt,
+            wrapped_vek_by_pw,
+            wrapped_vek_by_recovery,
+        }))
+    }
+
+    /// ヘッダが表す保護モードを返す。
+    #[must_use]
+    pub fn protection_mode(&self) -> ProtectionMode {
+        match self {
+            Self::Plaintext(_) => ProtectionMode::Plaintext,
+            Self::Encrypted(_) => ProtectionMode::Encrypted,
+        }
+    }
+
+    /// vault のフォーマットバージョンを返す。
+    #[must_use]
+    pub fn version(&self) -> VaultVersion {
+        match self {
+            Self::Plaintext(h) => h.version,
+            Self::Encrypted(h) => h.version,
+        }
+    }
+
+    /// vault の作成時刻を返す。
+    #[must_use]
+    pub fn created_at(&self) -> OffsetDateTime {
+        match self {
+            Self::Plaintext(h) => h.created_at,
+            Self::Encrypted(h) => h.created_at,
+        }
+    }
+
+    /// 暗号化ヘッダの KDF ソルトへの参照を返す。平文ヘッダの場合は `None`。
+    #[must_use]
+    pub fn kdf_salt(&self) -> Option<&KdfSalt> {
+        match self {
+            Self::Plaintext(_) => None,
+            Self::Encrypted(h) => Some(&h.kdf_salt),
+        }
+    }
+
+    /// 暗号化ヘッダのパスワード経路 Wrapped VEK への参照を返す。平文ヘッダは `None`。
+    #[must_use]
+    pub fn wrapped_vek_by_pw(&self) -> Option<&WrappedVek> {
+        match self {
+            Self::Plaintext(_) => None,
+            Self::Encrypted(h) => Some(&h.wrapped_vek_by_pw),
+        }
+    }
+
+    /// 暗号化ヘッダのリカバリ経路 Wrapped VEK への参照を返す。平文ヘッダは `None`。
+    #[must_use]
+    pub fn wrapped_vek_by_recovery(&self) -> Option<&WrappedVek> {
+        match self {
+            Self::Plaintext(_) => None,
+            Self::Encrypted(h) => Some(&h.wrapped_vek_by_recovery),
+        }
+    }
+}
+
+// 不使用の型のみエクスポート - `DomainError` 構築に必要な場合に備えて
+// InvalidVaultHeaderReason は error.rs にある
+#[allow(unused_imports)]
+use InvalidVaultHeaderReason as _;

--- a/crates/shikomi-core/src/vault/id.rs
+++ b/crates/shikomi-core/src/vault/id.rs
@@ -1,0 +1,76 @@
+//! レコード ID（UUIDv7 newtype）。
+
+use std::fmt;
+use std::str::FromStr;
+
+use uuid::Uuid;
+
+use crate::error::{DomainError, InvalidRecordIdReason};
+
+// -------------------------------------------------------------------
+// RecordId
+// -------------------------------------------------------------------
+
+/// レコードを一意に識別する `UUIDv7` newtype。
+///
+/// `UUIDv7` 以外のバージョン・nil UUID は構築時に拒否される（Fail Fast）。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordId {
+    inner: Uuid,
+}
+
+impl RecordId {
+    /// `Uuid` から `RecordId` を構築する。
+    ///
+    /// # Errors
+    /// - `UUIDv7` でない場合: `DomainError::InvalidRecordId(WrongVersion)`
+    /// - nil UUID の場合: `DomainError::InvalidRecordId(NilUuid)`
+    pub fn new(uuid: Uuid) -> Result<Self, DomainError> {
+        if uuid.is_nil() {
+            return Err(DomainError::InvalidRecordId(InvalidRecordIdReason::NilUuid));
+        }
+        // uuid::Version::SortRand は UUIDv7
+        match uuid.get_version() {
+            Some(uuid::Version::SortRand) => {}
+            other => {
+                let actual = other.map_or(0, |v| v as u8);
+                return Err(DomainError::InvalidRecordId(
+                    InvalidRecordIdReason::WrongVersion { actual },
+                ));
+            }
+        }
+        Ok(Self { inner: uuid })
+    }
+
+    /// UUID 文字列から `RecordId` を構築する。
+    ///
+    /// # Errors
+    /// - パース失敗: `DomainError::InvalidRecordId(ParseError)`
+    /// - `UUIDv7` 以外・nil UUID: 同上の対応バリアント
+    pub fn try_from_str(s: &str) -> Result<Self, DomainError> {
+        let uuid = Uuid::parse_str(s).map_err(|e| {
+            DomainError::InvalidRecordId(InvalidRecordIdReason::ParseError(e.to_string()))
+        })?;
+        Self::new(uuid)
+    }
+
+    /// 内包する `Uuid` への参照を返す。
+    #[must_use]
+    pub fn as_uuid(&self) -> &Uuid {
+        &self.inner
+    }
+}
+
+impl fmt::Display for RecordId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl FromStr for RecordId {
+    type Err = DomainError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from_str(s)
+    }
+}

--- a/crates/shikomi-core/src/vault/id.rs
+++ b/crates/shikomi-core/src/vault/id.rs
@@ -74,3 +74,62 @@ impl FromStr for RecordId {
         Self::try_from_str(s)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn valid_uuid_v7() -> Uuid {
+        Uuid::now_v7()
+    }
+
+    #[test]
+    fn test_new_with_valid_uuidv7_ok() {
+        assert!(RecordId::new(valid_uuid_v7()).is_ok());
+    }
+
+    #[test]
+    fn test_new_with_uuidv4_returns_wrong_version_error() {
+        let uuid_v4 = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let err = RecordId::new(uuid_v4).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordId(crate::error::InvalidRecordIdReason::WrongVersion {
+                actual: 4
+            })
+        ));
+    }
+
+    #[test]
+    fn test_new_with_nil_uuid_returns_nil_uuid_error() {
+        let err = RecordId::new(Uuid::nil()).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordId(crate::error::InvalidRecordIdReason::NilUuid)
+        ));
+    }
+
+    #[test]
+    fn test_try_from_str_with_valid_uuidv7_string_ok() {
+        // A valid UUIDv7 string (version=7, variant=10xx)
+        let result = RecordId::try_from_str("01234567-0123-7000-8000-0123456789ab");
+        assert!(result.is_ok(), "expected Ok but got {:?}", result);
+    }
+
+    #[test]
+    fn test_try_from_str_with_invalid_string_returns_parse_error() {
+        let err = RecordId::try_from_str("not-a-uuid").unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordId(crate::error::InvalidRecordIdReason::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn test_as_uuid_returns_stored_uuid() {
+        let uuid = valid_uuid_v7();
+        let id = RecordId::new(uuid).unwrap();
+        assert_eq!(id.as_uuid(), &uuid);
+    }
+}

--- a/crates/shikomi-core/src/vault/mod.rs
+++ b/crates/shikomi-core/src/vault/mod.rs
@@ -222,3 +222,300 @@ impl Vault {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{DomainError, VaultConsistencyReason};
+    use crate::secret::{SecretBytes, SecretString};
+    use crate::vault::crypto_data::{Aad, CipherText, KdfSalt, WrappedVek};
+    use crate::vault::id::RecordId;
+    use crate::vault::nonce::NonceBytes;
+    use crate::vault::record::{
+        Record, RecordKind, RecordLabel, RecordPayload, RecordPayloadEncrypted,
+    };
+    use crate::vault::version::VaultVersion;
+    use time::OffsetDateTime;
+
+    // --- Helpers ---
+
+    fn make_plaintext_header() -> VaultHeader {
+        VaultHeader::new_plaintext(VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).unwrap()
+    }
+
+    fn make_encrypted_header() -> VaultHeader {
+        let salt = KdfSalt::try_new(&[0u8; 16]).unwrap();
+        let wrapped = WrappedVek::try_new(vec![0u8; 48].into_boxed_slice()).unwrap();
+        VaultHeader::new_encrypted(
+            VaultVersion::CURRENT,
+            OffsetDateTime::UNIX_EPOCH,
+            salt,
+            wrapped.clone(),
+            wrapped,
+        )
+        .unwrap()
+    }
+
+    fn make_id() -> RecordId {
+        RecordId::new(uuid::Uuid::now_v7()).unwrap()
+    }
+
+    fn make_plaintext_record() -> Record {
+        Record::new(
+            make_id(),
+            RecordKind::Text,
+            RecordLabel::try_new("label".to_string()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string("value".to_string())),
+            OffsetDateTime::UNIX_EPOCH,
+        )
+    }
+
+    fn make_encrypted_record(id: Option<RecordId>) -> Record {
+        let record_id = id.unwrap_or_else(make_id);
+        let nonce = NonceBytes::try_new(&[0u8; 12]).unwrap();
+        let cipher = CipherText::try_new(vec![1u8; 32].into_boxed_slice()).unwrap();
+        let aad = Aad::new(
+            record_id.clone(),
+            VaultVersion::CURRENT,
+            OffsetDateTime::UNIX_EPOCH,
+        )
+        .unwrap();
+        let enc = RecordPayloadEncrypted::new(nonce, cipher, aad).unwrap();
+        Record::new(
+            record_id,
+            RecordKind::Secret,
+            RecordLabel::try_new("secret label".to_string()).unwrap(),
+            RecordPayload::Encrypted(enc),
+            OffsetDateTime::UNIX_EPOCH,
+        )
+    }
+
+    // DummyVekProvider for rekey tests
+    struct DummyVekProvider {
+        should_fail: bool,
+        vek: SecretBytes,
+        wrapped: WrappedVek,
+    }
+
+    impl DummyVekProvider {
+        fn new(should_fail: bool) -> Self {
+            Self {
+                should_fail,
+                vek: SecretBytes::from_boxed_slice(vec![0u8; 32].into_boxed_slice()),
+                wrapped: WrappedVek::try_new(vec![0u8; 48].into_boxed_slice()).unwrap(),
+            }
+        }
+    }
+
+    impl VekProvider for DummyVekProvider {
+        fn new_vek(&self) -> &SecretBytes {
+            &self.vek
+        }
+
+        fn reencrypt_all(
+            &mut self,
+            _records: &mut [Record],
+            _new_vek: &SecretBytes,
+        ) -> Result<(), DomainError> {
+            if self.should_fail {
+                Err(DomainError::VaultConsistencyError(
+                    VaultConsistencyReason::RekeyPartialFailure,
+                ))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn derive_new_wrapped_pw(&self, _vek: &SecretBytes) -> Result<WrappedVek, DomainError> {
+            if self.should_fail {
+                Err(DomainError::VaultConsistencyError(
+                    VaultConsistencyReason::RekeyPartialFailure,
+                ))
+            } else {
+                Ok(self.wrapped.clone())
+            }
+        }
+
+        fn derive_new_wrapped_recovery(
+            &self,
+            _vek: &SecretBytes,
+        ) -> Result<WrappedVek, DomainError> {
+            if self.should_fail {
+                Err(DomainError::VaultConsistencyError(
+                    VaultConsistencyReason::RekeyPartialFailure,
+                ))
+            } else {
+                Ok(self.wrapped.clone())
+            }
+        }
+    }
+
+    // --- TC-U07: Vault ---
+
+    #[test]
+    fn test_vault_new_plaintext_has_empty_records() {
+        let vault = Vault::new(make_plaintext_header());
+        assert!(vault.records().is_empty());
+    }
+
+    #[test]
+    fn test_vault_new_encrypted_has_empty_records() {
+        let vault = Vault::new(make_encrypted_header());
+        assert!(vault.records().is_empty());
+    }
+
+    #[test]
+    fn test_add_record_plaintext_to_plaintext_vault_ok() {
+        let mut vault = Vault::new(make_plaintext_header());
+        vault.add_record(make_plaintext_record()).unwrap();
+        assert_eq!(vault.records().len(), 1);
+    }
+
+    #[test]
+    fn test_add_record_encrypted_payload_to_plaintext_vault_returns_mode_mismatch() {
+        let mut vault = Vault::new(make_plaintext_header());
+        let record = make_encrypted_record(None);
+        let err = vault.add_record(record).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::VaultConsistencyError(VaultConsistencyReason::ModeMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn test_add_record_plaintext_payload_to_encrypted_vault_returns_mode_mismatch() {
+        let mut vault = Vault::new(make_encrypted_header());
+        let err = vault.add_record(make_plaintext_record()).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::VaultConsistencyError(VaultConsistencyReason::ModeMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn test_add_record_duplicate_id_returns_duplicate_id_error() {
+        let mut vault = Vault::new(make_plaintext_header());
+        let id = make_id();
+        let r1 = Record::new(
+            id.clone(),
+            RecordKind::Text,
+            RecordLabel::try_new("l1".to_string()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string("v".to_string())),
+            OffsetDateTime::UNIX_EPOCH,
+        );
+        let r2 = Record::new(
+            id,
+            RecordKind::Text,
+            RecordLabel::try_new("l2".to_string()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string("v".to_string())),
+            OffsetDateTime::UNIX_EPOCH,
+        );
+        vault.add_record(r1).unwrap();
+        let err = vault.add_record(r2).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::VaultConsistencyError(VaultConsistencyReason::DuplicateId(_))
+        ));
+    }
+
+    #[test]
+    fn test_remove_record_existing_returns_record_and_vault_is_empty() {
+        let mut vault = Vault::new(make_plaintext_header());
+        let record = make_plaintext_record();
+        let id = record.id().clone();
+        vault.add_record(record).unwrap();
+        let removed = vault.remove_record(&id).unwrap();
+        assert_eq!(removed.id(), &id);
+        assert!(vault.records().is_empty());
+    }
+
+    #[test]
+    fn test_remove_record_nonexistent_returns_record_not_found() {
+        let mut vault = Vault::new(make_plaintext_header());
+        let unknown_id = make_id();
+        let err = vault.remove_record(&unknown_id).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::VaultConsistencyError(VaultConsistencyReason::RecordNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_find_record_existing_returns_some() {
+        let mut vault = Vault::new(make_plaintext_header());
+        let record = make_plaintext_record();
+        let id = record.id().clone();
+        vault.add_record(record).unwrap();
+        assert!(vault.find_record(&id).is_some());
+    }
+
+    #[test]
+    fn test_find_record_nonexistent_returns_none() {
+        let vault = Vault::new(make_plaintext_header());
+        let unknown_id = make_id();
+        assert!(vault.find_record(&unknown_id).is_none());
+    }
+
+    #[test]
+    fn test_protection_mode_plaintext_vault_returns_plaintext() {
+        let vault = Vault::new(make_plaintext_header());
+        assert_eq!(vault.protection_mode(), ProtectionMode::Plaintext);
+    }
+
+    #[test]
+    fn test_records_returns_slice_with_all_records() {
+        let mut vault = Vault::new(make_plaintext_header());
+        vault.add_record(make_plaintext_record()).unwrap();
+        vault.add_record(make_plaintext_record()).unwrap();
+        assert_eq!(vault.records().len(), 2);
+    }
+
+    #[test]
+    fn test_update_record_applies_updater_and_persists_changes() {
+        let mut vault = Vault::new(make_plaintext_header());
+        let record = make_plaintext_record();
+        let id = record.id().clone();
+        vault.add_record(record).unwrap();
+        let new_label = RecordLabel::try_new("updated".to_string()).unwrap();
+        vault
+            .update_record(&id, |r| {
+                r.with_updated_label(new_label, OffsetDateTime::UNIX_EPOCH)
+            })
+            .unwrap();
+        let found = vault.find_record(&id).unwrap();
+        assert_eq!(found.label().as_str(), "updated");
+    }
+
+    #[test]
+    fn test_rekey_with_on_plaintext_vault_returns_rekey_in_plaintext_mode_error() {
+        let mut vault = Vault::new(make_plaintext_header());
+        let mut provider = DummyVekProvider::new(false);
+        let err = vault.rekey_with(&mut provider).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::VaultConsistencyError(VaultConsistencyReason::RekeyInPlaintextMode)
+        ));
+    }
+
+    #[test]
+    fn test_rekey_with_succeeding_provider_on_encrypted_vault_returns_ok() {
+        let mut vault = Vault::new(make_encrypted_header());
+        let record = make_encrypted_record(None);
+        vault.add_record(record).unwrap();
+        let mut provider = DummyVekProvider::new(false);
+        assert!(vault.rekey_with(&mut provider).is_ok());
+    }
+
+    #[test]
+    fn test_rekey_with_failing_provider_returns_rekey_partial_failure() {
+        let mut vault = Vault::new(make_encrypted_header());
+        let record = make_encrypted_record(None);
+        vault.add_record(record).unwrap();
+        let mut provider = DummyVekProvider::new(true);
+        let err = vault.rekey_with(&mut provider).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::VaultConsistencyError(VaultConsistencyReason::RekeyPartialFailure)
+        ));
+    }
+}

--- a/crates/shikomi-core/src/vault/mod.rs
+++ b/crates/shikomi-core/src/vault/mod.rs
@@ -153,8 +153,8 @@ impl Vault {
 
     /// 指定した ID のレコードに `updater` クロージャを適用して更新する。
     ///
-    /// updater が失敗した場合、レコードは vault から失われる。
-    /// 呼び出し元は `SQLite` トランザクションでアトミック更新を担保すること（Fail Fast）。
+    /// `updater` には元レコードの `clone` を渡す。
+    /// `updater` 失敗・モード不一致の場合も `self.records` は変更されない（Fail Fast）。
     ///
     /// # Errors
     /// - 該当 ID が存在しない: `DomainError::VaultConsistencyError(RecordNotFound)`
@@ -174,8 +174,8 @@ impl Vault {
                 ))
             })?;
 
-        let record = self.records.remove(pos);
-        let new_record = updater(record)?;
+        // clone を updater に渡す。updater 失敗・モード不一致でも self.records[pos] は untouched。
+        let new_record = updater(self.records[pos].clone())?;
 
         let vault_mode = self.protection_mode();
         let record_mode = new_record.payload().variant_mode();
@@ -188,7 +188,7 @@ impl Vault {
             ));
         }
 
-        self.records.insert(pos, new_record);
+        self.records[pos] = new_record;
         Ok(())
     }
 

--- a/crates/shikomi-core/src/vault/mod.rs
+++ b/crates/shikomi-core/src/vault/mod.rs
@@ -1,0 +1,224 @@
+//! vault 集約ルートと関連型の公開インターフェース。
+
+pub mod crypto_data;
+pub mod header;
+pub mod id;
+pub mod nonce;
+pub mod protection_mode;
+pub mod record;
+pub mod version;
+
+pub use crypto_data::{Aad, CipherText, KdfSalt, WrappedVek};
+pub use header::{VaultHeader, VaultHeaderEncrypted, VaultHeaderPlaintext};
+pub use id::RecordId;
+pub use nonce::{NonceBytes, NonceCounter};
+pub use protection_mode::ProtectionMode;
+pub use record::{Record, RecordKind, RecordLabel, RecordPayload, RecordPayloadEncrypted};
+pub use version::VaultVersion;
+
+use crate::error::{DomainError, VaultConsistencyReason};
+use crate::secret::SecretBytes;
+
+// -------------------------------------------------------------------
+// VekProvider trait
+// -------------------------------------------------------------------
+
+/// VEK（Vault Encryption Key）の再生成・再暗号化を担うプロバイダ trait。
+///
+/// 実装は `shikomi-infra` に置く（Dependency Inversion）。
+/// `shikomi-core` はこの trait シグネチャのみを所有し、暗号実装に依存しない。
+pub trait VekProvider {
+    /// プロバイダが保持する新 VEK への参照を返す。
+    ///
+    /// `Vault::rekey_with` が呼び出し元（`shikomi-infra`）の提供する VEK を受け取るために使う。
+    fn new_vek(&self) -> &SecretBytes;
+
+    /// 全レコードを新 VEK で再暗号化する（in-place）。
+    ///
+    /// 部分失敗した場合は `DomainError::VaultConsistencyError(RekeyPartialFailure)` を返す。
+    /// 呼び出し元は `SQLite` トランザクションでアトミック更新を保証すること。
+    ///
+    /// # Errors
+    /// 再暗号化失敗時に `DomainError` を返す。
+    fn reencrypt_all(
+        &mut self,
+        records: &mut [Record],
+        new_vek: &SecretBytes,
+    ) -> Result<(), DomainError>;
+
+    /// 新 VEK をパスワード由来の KEK でラップした `WrappedVek` を返す。
+    ///
+    /// # Errors
+    /// KDF / 暗号化失敗時に `DomainError` を返す。
+    fn derive_new_wrapped_pw(&self, vek: &SecretBytes) -> Result<WrappedVek, DomainError>;
+
+    /// 新 VEK をリカバリ由来の KEK でラップした `WrappedVek` を返す。
+    ///
+    /// # Errors
+    /// KDF / 暗号化失敗時に `DomainError` を返す。
+    fn derive_new_wrapped_recovery(&self, vek: &SecretBytes) -> Result<WrappedVek, DomainError>;
+}
+
+// -------------------------------------------------------------------
+// Vault
+// -------------------------------------------------------------------
+
+/// vault 集約ルート。
+///
+/// ヘッダの保護モードと全レコードペイロードの整合性を `add_record` / `update_record`
+/// で常に保証する（Fail Fast）。
+/// レコード ID の一意性も集約自身が強制する。
+pub struct Vault {
+    header: VaultHeader,
+    records: Vec<Record>,
+}
+
+impl Vault {
+    /// 空のレコードリストで `Vault` を構築する。
+    ///
+    /// 空集合はヘッダと常に整合するため、この構築は失敗しない。
+    #[must_use]
+    pub fn new(header: VaultHeader) -> Self {
+        Self {
+            header,
+            records: Vec::new(),
+        }
+    }
+
+    /// ヘッダが表す保護モードを返す。
+    #[must_use]
+    pub fn protection_mode(&self) -> ProtectionMode {
+        self.header.protection_mode()
+    }
+
+    /// vault ヘッダへの参照を返す。
+    #[must_use]
+    pub fn header(&self) -> &VaultHeader {
+        &self.header
+    }
+
+    /// 全レコードのスライスを返す。
+    #[must_use]
+    pub fn records(&self) -> &[Record] {
+        &self.records
+    }
+
+    /// 指定した ID を持つレコードへの参照を返す。存在しない場合は `None`。
+    #[must_use]
+    pub fn find_record(&self, id: &RecordId) -> Option<&Record> {
+        self.records.iter().find(|r| r.id() == id)
+    }
+
+    /// レコードを追加する。
+    ///
+    /// # Errors
+    /// - 保護モードとペイロードが一致しない: `DomainError::VaultConsistencyError(ModeMismatch)`
+    /// - 同一 ID のレコードが既に存在する: `DomainError::VaultConsistencyError(DuplicateId)`
+    pub fn add_record(&mut self, record: Record) -> Result<(), DomainError> {
+        let vault_mode = self.protection_mode();
+        let record_mode = record.payload().variant_mode();
+        if vault_mode != record_mode {
+            return Err(DomainError::VaultConsistencyError(
+                VaultConsistencyReason::ModeMismatch {
+                    vault_mode,
+                    record_mode,
+                },
+            ));
+        }
+        if self.records.iter().any(|r| r.id() == record.id()) {
+            return Err(DomainError::VaultConsistencyError(
+                VaultConsistencyReason::DuplicateId(record.id().clone()),
+            ));
+        }
+        self.records.push(record);
+        Ok(())
+    }
+
+    /// 指定した ID のレコードを削除して返す。
+    ///
+    /// # Errors
+    /// 該当 ID が存在しない場合 `DomainError::VaultConsistencyError(RecordNotFound)` を返す。
+    pub fn remove_record(&mut self, id: &RecordId) -> Result<Record, DomainError> {
+        let pos = self
+            .records
+            .iter()
+            .position(|r| r.id() == id)
+            .ok_or_else(|| {
+                DomainError::VaultConsistencyError(VaultConsistencyReason::RecordNotFound(
+                    id.clone(),
+                ))
+            })?;
+        Ok(self.records.remove(pos))
+    }
+
+    /// 指定した ID のレコードに `updater` クロージャを適用して更新する。
+    ///
+    /// updater が失敗した場合、レコードは vault から失われる。
+    /// 呼び出し元は `SQLite` トランザクションでアトミック更新を担保すること（Fail Fast）。
+    ///
+    /// # Errors
+    /// - 該当 ID が存在しない: `DomainError::VaultConsistencyError(RecordNotFound)`
+    /// - updater が `Err` を返した場合: その `DomainError`
+    /// - 更新後のペイロードモードが vault と不一致: `DomainError::VaultConsistencyError(ModeMismatch)`
+    pub fn update_record<F>(&mut self, id: &RecordId, updater: F) -> Result<(), DomainError>
+    where
+        F: FnOnce(Record) -> Result<Record, DomainError>,
+    {
+        let pos = self
+            .records
+            .iter()
+            .position(|r| r.id() == id)
+            .ok_or_else(|| {
+                DomainError::VaultConsistencyError(VaultConsistencyReason::RecordNotFound(
+                    id.clone(),
+                ))
+            })?;
+
+        let record = self.records.remove(pos);
+        let new_record = updater(record)?;
+
+        let vault_mode = self.protection_mode();
+        let record_mode = new_record.payload().variant_mode();
+        if vault_mode != record_mode {
+            return Err(DomainError::VaultConsistencyError(
+                VaultConsistencyReason::ModeMismatch {
+                    vault_mode,
+                    record_mode,
+                },
+            ));
+        }
+
+        self.records.insert(pos, new_record);
+        Ok(())
+    }
+
+    /// VEK を再生成し、全レコードを再暗号化する（rekey）。
+    ///
+    /// 平文 vault に対しては失敗する。
+    /// 再暗号化は `VekProvider` に委譲し、`shikomi-core` は暗号実装に依存しない。
+    ///
+    /// # Errors
+    /// - 平文 vault に対する rekey: `DomainError::VaultConsistencyError(RekeyInPlaintextMode)`
+    /// - 再暗号化失敗: `DomainError::VaultConsistencyError(RekeyPartialFailure)` 等
+    pub fn rekey_with<P: VekProvider>(&mut self, provider: &mut P) -> Result<(), DomainError> {
+        if self.protection_mode() != ProtectionMode::Encrypted {
+            return Err(DomainError::VaultConsistencyError(
+                VaultConsistencyReason::RekeyInPlaintextMode,
+            ));
+        }
+
+        // VEK を provider から取得（clone で借用競合を回避）
+        let new_vek: SecretBytes = provider.new_vek().clone();
+
+        let new_wrapped_pw = provider.derive_new_wrapped_pw(&new_vek)?;
+        let new_wrapped_recovery = provider.derive_new_wrapped_recovery(&new_vek)?;
+        provider.reencrypt_all(&mut self.records, &new_vek)?;
+
+        // ヘッダの wrapped VEK を更新
+        if let VaultHeader::Encrypted(ref mut enc) = self.header {
+            enc.replace_wrapped_veks(new_wrapped_pw, new_wrapped_recovery);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/shikomi-core/src/vault/nonce.rs
+++ b/crates/shikomi-core/src/vault/nonce.rs
@@ -1,0 +1,113 @@
+//! nonce 管理（NonceBytes / `NonceCounter`）。
+//!
+//! AES-256-GCM の 96-bit IV は「8B CSPRNG prefix + 4B u32 counter (big-endian)」で構成する。
+//! `NonceCounter` は pure Rust / no-I/O：乱数 prefix は構築時に呼び出し側が供給する。
+
+use crate::error::{DomainError, InvalidRecordPayloadReason};
+
+/// `NonceBytes` の固定長（NIST SP 800-38D §5.2.1.1、96 bit）。
+const NONCE_LEN: usize = 12;
+/// CSPRNG prefix の長さ。
+const PREFIX_LEN: usize = 8;
+
+// -------------------------------------------------------------------
+// NonceBytes
+// -------------------------------------------------------------------
+
+/// AES-256-GCM の nonce（96 bit = 12 byte）。
+///
+/// レイアウト: `[0..8]` = CSPRNG prefix、`[8..12]` = u32 counter (big-endian)。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonceBytes {
+    inner: [u8; NONCE_LEN],
+}
+
+impl NonceBytes {
+    /// バイトスライスから `NonceBytes` を構築する。
+    ///
+    /// # Errors
+    /// `bytes.len() != 12` の場合 `DomainError::InvalidRecordPayload(NonceLength)` を返す。
+    pub fn try_new(bytes: &[u8]) -> Result<Self, DomainError> {
+        if bytes.len() != NONCE_LEN {
+            return Err(DomainError::InvalidRecordPayload(
+                InvalidRecordPayloadReason::NonceLength {
+                    expected: NONCE_LEN,
+                    got: bytes.len(),
+                },
+            ));
+        }
+        let mut inner = [0u8; NONCE_LEN];
+        inner.copy_from_slice(bytes);
+        Ok(Self { inner })
+    }
+
+    /// 内包する 12 バイト配列への参照を返す。
+    #[must_use]
+    pub fn as_array(&self) -> &[u8; NONCE_LEN] {
+        &self.inner
+    }
+}
+
+// -------------------------------------------------------------------
+// NonceCounter
+// -------------------------------------------------------------------
+
+/// nonce を単調増加カウンタで管理する。
+///
+/// nonce = `random_prefix` (8B) ‖ `counter` (4B big-endian)。
+/// カウンタが `u32::MAX` に達した次の `next()` 呼び出しで
+/// `DomainError::NonceOverflow` を返し rekey を強制する。
+///
+/// 乱数生成は `shikomi-core` の責務外（pure Rust / no-I/O）。
+/// `random_prefix` は呼び出し側（`shikomi-infra`）が OS CSPRNG から供給する。
+pub struct NonceCounter {
+    counter: u32,
+    random_prefix: [u8; PREFIX_LEN],
+}
+
+impl NonceCounter {
+    /// カウンタを 0 から開始する新規 `NonceCounter` を生成する。
+    ///
+    /// `random_prefix` は 8 バイトの CSPRNG 乱数。
+    #[must_use]
+    pub fn new(random_prefix: [u8; PREFIX_LEN]) -> Self {
+        Self {
+            counter: 0,
+            random_prefix,
+        }
+    }
+
+    /// 永続化したカウンタ値から `NonceCounter` を再開する。
+    ///
+    /// vault をロードして nonce を引き継ぐ際に使用する。
+    #[must_use]
+    pub fn resume(random_prefix: [u8; PREFIX_LEN], counter: u32) -> Self {
+        Self {
+            counter,
+            random_prefix,
+        }
+    }
+
+    /// 現在のカウンタ値から `NonceBytes` を生成し、カウンタをインクリメントする。
+    ///
+    /// # Errors
+    /// カウンタが `u32::MAX` の場合 `DomainError::NonceOverflow` を返す。
+    /// この状態では vault の rekey が必要（NIST SP 800-38D §8.3 準拠）。
+    #[allow(clippy::should_implement_trait)] // 設計で `next()` と命名されており、Iterator は不適切
+    pub fn next(&mut self) -> Result<NonceBytes, DomainError> {
+        if self.counter == u32::MAX {
+            return Err(DomainError::NonceOverflow);
+        }
+        let mut bytes = [0u8; NONCE_LEN];
+        bytes[..PREFIX_LEN].copy_from_slice(&self.random_prefix);
+        bytes[PREFIX_LEN..].copy_from_slice(&self.counter.to_be_bytes());
+        self.counter += 1;
+        Ok(NonceBytes { inner: bytes })
+    }
+
+    /// 現在のカウンタ値を返す（永続化用）。
+    #[must_use]
+    pub fn current_counter(&self) -> u32 {
+        self.counter
+    }
+}

--- a/crates/shikomi-core/src/vault/nonce.rs
+++ b/crates/shikomi-core/src/vault/nonce.rs
@@ -111,3 +111,78 @@ impl NonceCounter {
         self.counter
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nonce_counter_new_starts_at_zero() {
+        let counter = NonceCounter::new([0u8; 8]);
+        assert_eq!(counter.current_counter(), 0u32);
+    }
+
+    #[test]
+    fn test_nonce_counter_next_returns_12_byte_nonce() {
+        let mut counter = NonceCounter::new([0u8; 8]);
+        let nonce = counter.next().unwrap();
+        assert_eq!(nonce.as_array().len(), 12);
+    }
+
+    #[test]
+    fn test_nonce_counter_current_counter_increments_after_next() {
+        let mut counter = NonceCounter::new([0u8; 8]);
+        counter.next().unwrap();
+        assert_eq!(counter.current_counter(), 1u32);
+    }
+
+    #[test]
+    fn test_nonce_counter_resume_starts_at_given_counter() {
+        let counter = NonceCounter::resume([0u8; 8], 42);
+        assert_eq!(counter.current_counter(), 42u32);
+    }
+
+    #[test]
+    fn test_nonce_counter_next_at_max_minus_one_succeeds() {
+        let mut counter = NonceCounter::resume([0u8; 8], u32::MAX - 1);
+        assert!(counter.next().is_ok());
+    }
+
+    #[test]
+    fn test_nonce_counter_next_at_max_returns_nonce_overflow() {
+        let mut counter = NonceCounter::resume([0u8; 8], u32::MAX);
+        let err = counter.next().unwrap_err();
+        assert!(matches!(err, DomainError::NonceOverflow));
+    }
+
+    #[test]
+    fn test_nonce_counter_next_prefix_bytes_match_random_prefix() {
+        let prefix = [0xABu8; 8];
+        let mut counter = NonceCounter::new(prefix);
+        let nonce = counter.next().unwrap();
+        assert_eq!(&nonce.as_array()[0..8], &prefix);
+    }
+
+    #[test]
+    fn test_nonce_counter_next_counter_bytes_are_big_endian() {
+        let mut counter = NonceCounter::new([0u8; 8]);
+        let n1 = counter.next().unwrap();
+        let n2 = counter.next().unwrap();
+        let n3 = counter.next().unwrap();
+        assert_eq!(
+            &n1.as_array()[8..12],
+            &[0x00u8, 0x00, 0x00, 0x00],
+            "1st: counter=0"
+        );
+        assert_eq!(
+            &n2.as_array()[8..12],
+            &[0x00u8, 0x00, 0x00, 0x01],
+            "2nd: counter=1"
+        );
+        assert_eq!(
+            &n3.as_array()[8..12],
+            &[0x00u8, 0x00, 0x00, 0x02],
+            "3rd: counter=2"
+        );
+    }
+}

--- a/crates/shikomi-core/src/vault/protection_mode.rs
+++ b/crates/shikomi-core/src/vault/protection_mode.rs
@@ -39,3 +39,40 @@ impl ProtectionMode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_persisted_str_plaintext_returns_plaintext() {
+        assert_eq!(ProtectionMode::Plaintext.as_persisted_str(), "plaintext");
+    }
+
+    #[test]
+    fn test_as_persisted_str_encrypted_returns_encrypted() {
+        assert_eq!(ProtectionMode::Encrypted.as_persisted_str(), "encrypted");
+    }
+
+    #[test]
+    fn test_try_from_persisted_str_plaintext_ok() {
+        assert_eq!(
+            ProtectionMode::try_from_persisted_str("plaintext").unwrap(),
+            ProtectionMode::Plaintext
+        );
+    }
+
+    #[test]
+    fn test_try_from_persisted_str_encrypted_ok() {
+        assert_eq!(
+            ProtectionMode::try_from_persisted_str("encrypted").unwrap(),
+            ProtectionMode::Encrypted
+        );
+    }
+
+    #[test]
+    fn test_try_from_persisted_str_unknown_returns_invalid_protection_mode() {
+        let err = ProtectionMode::try_from_persisted_str("PLAINTEXT").unwrap_err();
+        assert!(matches!(err, DomainError::InvalidProtectionMode(_)));
+    }
+}

--- a/crates/shikomi-core/src/vault/protection_mode.rs
+++ b/crates/shikomi-core/src/vault/protection_mode.rs
@@ -1,0 +1,41 @@
+//! 保護モード（平文 / 暗号化）の列挙型。
+
+use crate::error::DomainError;
+
+// -------------------------------------------------------------------
+// ProtectionMode
+// -------------------------------------------------------------------
+
+/// vault の保護モード。平文か暗号化かを排他的に表現する。
+///
+/// 永続化は `as_persisted_str()` / `try_from_persisted_str()` 経由で行う。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProtectionMode {
+    /// 平文モード。レコードペイロードを暗号化しない。
+    Plaintext,
+    /// 暗号化モード。レコードペイロードを AES-256-GCM で保護する。
+    Encrypted,
+}
+
+impl ProtectionMode {
+    /// 永続化文字列（`"plaintext"` / `"encrypted"`）を返す。
+    #[must_use]
+    pub fn as_persisted_str(&self) -> &'static str {
+        match self {
+            Self::Plaintext => "plaintext",
+            Self::Encrypted => "encrypted",
+        }
+    }
+
+    /// 永続化文字列から `ProtectionMode` を復元する。
+    ///
+    /// # Errors
+    /// 未知の文字列の場合 `DomainError::InvalidProtectionMode` を返す。
+    pub fn try_from_persisted_str(s: &str) -> Result<Self, DomainError> {
+        match s {
+            "plaintext" => Ok(Self::Plaintext),
+            "encrypted" => Ok(Self::Encrypted),
+            other => Err(DomainError::InvalidProtectionMode(other.to_owned())),
+        }
+    }
+}

--- a/crates/shikomi-core/src/vault/record.rs
+++ b/crates/shikomi-core/src/vault/record.rs
@@ -1,0 +1,305 @@
+//! レコードおよび関連型（RecordKind / `RecordLabel` / `RecordPayload`）。
+
+use time::OffsetDateTime;
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::error::{DomainError, InvalidRecordLabelReason, InvalidRecordPayloadReason};
+use crate::secret::SecretString;
+use crate::vault::crypto_data::{Aad, CipherText};
+use crate::vault::id::RecordId;
+use crate::vault::nonce::NonceBytes;
+use crate::vault::protection_mode::ProtectionMode;
+
+/// `RecordLabel` の grapheme cluster 最大数。
+const LABEL_MAX_GRAPHEMES: usize = 255;
+
+// -------------------------------------------------------------------
+// ユーティリティ
+// -------------------------------------------------------------------
+
+/// `OffsetDateTime` をマイクロ秒精度に切り捨てる（サブマイクロ秒は切り捨て）。
+///
+/// `Record::new` / `Record::with_updated_*` が内部で呼び出す。
+/// 永続化（SQLite RFC3339）と AAD 計算のラウンドトリップを保証するため。
+fn truncate_to_microsecond(dt: OffsetDateTime) -> OffsetDateTime {
+    // nanosecond() は [0, 999_999_999]。% 1_000 でサブマイクロ秒 ns を取り出す。
+    let sub_micro_ns = i64::from(dt.nanosecond() % 1_000);
+    dt - time::Duration::nanoseconds(sub_micro_ns)
+}
+
+// -------------------------------------------------------------------
+// RecordKind
+// -------------------------------------------------------------------
+
+/// レコードの種別。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordKind {
+    /// テキストレコード（URL・メモ等、機密度が低い）。
+    Text,
+    /// シークレットレコード（パスワード・鍵等、機密度が高い）。
+    Secret,
+}
+
+// -------------------------------------------------------------------
+// RecordLabel
+// -------------------------------------------------------------------
+
+/// レコードの表示名。
+///
+/// 以下の条件を満たす文字列のみ `try_new` を通過できる（Fail Fast）：
+/// - 非空
+/// - 禁止制御文字なし（U+0000〜U+001F のうち `\t`/`\n`/`\r` は許可、U+007F は禁止）
+/// - grapheme cluster 数 ≤ 255
+#[derive(Debug, Clone)]
+pub struct RecordLabel {
+    inner: String,
+}
+
+impl RecordLabel {
+    /// 文字列から `RecordLabel` を構築する。
+    ///
+    /// # Errors
+    /// - 空文字列: `DomainError::InvalidRecordLabel(Empty)`
+    /// - 禁止制御文字: `DomainError::InvalidRecordLabel(ControlChar { position })`
+    /// - 256 grapheme 以上: `DomainError::InvalidRecordLabel(TooLong { grapheme_count })`
+    pub fn try_new(raw: String) -> Result<Self, DomainError> {
+        if raw.is_empty() {
+            return Err(DomainError::InvalidRecordLabel(
+                InvalidRecordLabelReason::Empty,
+            ));
+        }
+
+        // 禁止制御文字チェック
+        for (pos, ch) in raw.char_indices() {
+            if is_forbidden_control(ch) {
+                return Err(DomainError::InvalidRecordLabel(
+                    InvalidRecordLabelReason::ControlChar { position: pos },
+                ));
+            }
+        }
+
+        // grapheme cluster 数チェック
+        let grapheme_count = raw.graphemes(true).count();
+        if grapheme_count > LABEL_MAX_GRAPHEMES {
+            return Err(DomainError::InvalidRecordLabel(
+                InvalidRecordLabelReason::TooLong { grapheme_count },
+            ));
+        }
+
+        Ok(Self { inner: raw })
+    }
+
+    /// 内包する文字列への参照を返す。
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+}
+
+/// 禁止制御文字かどうかを判定する。
+///
+/// U+0000〜U+001F のうち `\t`(U+0009) / `\n`(U+000A) / `\r`(U+000D) は許可。
+/// U+007F (DEL) は禁止。
+fn is_forbidden_control(ch: char) -> bool {
+    match ch {
+        '\t' | '\n' | '\r' => false,
+        c if c <= '\u{001F}' => true,
+        '\u{007F}' => true,
+        _ => false,
+    }
+}
+
+// -------------------------------------------------------------------
+// RecordPayloadEncrypted
+// -------------------------------------------------------------------
+
+/// 暗号化バリアントのペイロード内部データ。
+#[derive(Debug, Clone)]
+pub struct RecordPayloadEncrypted {
+    nonce: NonceBytes,
+    ciphertext: CipherText,
+    aad: Aad,
+}
+
+impl RecordPayloadEncrypted {
+    /// 暗号化ペイロードを構築する。
+    ///
+    /// `nonce` / `ciphertext` / `aad` はそれぞれの `try_new` / `new` で検証済みの型を渡す。
+    ///
+    /// # Errors
+    /// 現時点では `nonce` / `ciphertext` の検証は各型の `try_new` で行うため、
+    /// この関数自体は `Ok` を返す。将来の追加検証のために `Result` を維持する。
+    pub fn new(nonce: NonceBytes, ciphertext: CipherText, aad: Aad) -> Result<Self, DomainError> {
+        Ok(Self {
+            nonce,
+            ciphertext,
+            aad,
+        })
+    }
+
+    /// nonce への参照を返す。
+    #[must_use]
+    pub fn nonce(&self) -> &NonceBytes {
+        &self.nonce
+    }
+
+    /// ciphertext への参照を返す。
+    #[must_use]
+    pub fn ciphertext(&self) -> &CipherText {
+        &self.ciphertext
+    }
+
+    /// AAD への参照を返す。
+    #[must_use]
+    pub fn aad(&self) -> &Aad {
+        &self.aad
+    }
+}
+
+// -------------------------------------------------------------------
+// RecordPayload
+// -------------------------------------------------------------------
+
+/// レコードのペイロード。平文と暗号化を enum バリアントで排他する。
+#[derive(Debug, Clone)]
+pub enum RecordPayload {
+    /// 平文ペイロード。SecretString に保持する。
+    Plaintext(SecretString),
+    /// 暗号化ペイロード（nonce + ciphertext + AAD）。
+    Encrypted(RecordPayloadEncrypted),
+}
+
+impl RecordPayload {
+    /// このペイロードが対応する `ProtectionMode` を返す。
+    #[must_use]
+    pub fn variant_mode(&self) -> ProtectionMode {
+        match self {
+            Self::Plaintext(_) => ProtectionMode::Plaintext,
+            Self::Encrypted(_) => ProtectionMode::Encrypted,
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// Record
+// -------------------------------------------------------------------
+
+/// vault 内のレコードエンティティ。
+///
+/// `Record::new` に渡す引数は全て検証済み型のみ受け付けるため、
+/// 構築自体は失敗しない（Fail Fast は各引数の型構築時に行われる）。
+#[derive(Debug, Clone)]
+pub struct Record {
+    id: RecordId,
+    kind: RecordKind,
+    label: RecordLabel,
+    payload: RecordPayload,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+}
+
+impl Record {
+    /// レコードを構築する。
+    ///
+    /// `created_at = updated_at = now`（マイクロ秒精度に切り捨て済み）。
+    #[must_use]
+    pub fn new(
+        id: RecordId,
+        kind: RecordKind,
+        label: RecordLabel,
+        payload: RecordPayload,
+        now: OffsetDateTime,
+    ) -> Self {
+        let ts = truncate_to_microsecond(now);
+        Self {
+            id,
+            kind,
+            label,
+            payload,
+            created_at: ts,
+            updated_at: ts,
+        }
+    }
+
+    /// レコード ID への参照を返す。
+    #[must_use]
+    pub fn id(&self) -> &RecordId {
+        &self.id
+    }
+
+    /// レコード種別を返す。
+    #[must_use]
+    pub fn kind(&self) -> RecordKind {
+        self.kind
+    }
+
+    /// ラベルへの参照を返す。
+    #[must_use]
+    pub fn label(&self) -> &RecordLabel {
+        &self.label
+    }
+
+    /// ペイロードへの参照を返す。
+    #[must_use]
+    pub fn payload(&self) -> &RecordPayload {
+        &self.payload
+    }
+
+    /// 作成時刻を返す（マイクロ秒精度）。
+    #[must_use]
+    pub fn created_at(&self) -> OffsetDateTime {
+        self.created_at
+    }
+
+    /// 最終更新時刻を返す（マイクロ秒精度）。
+    #[must_use]
+    pub fn updated_at(&self) -> OffsetDateTime {
+        self.updated_at
+    }
+
+    /// ラベルを更新した新しい `Record` を返す（self を消費）。
+    ///
+    /// # Errors
+    /// `now < self.created_at` の場合 `DomainError::VaultConsistencyError(InvalidUpdatedAt)` を返す。
+    pub fn with_updated_label(
+        mut self,
+        label: RecordLabel,
+        now: OffsetDateTime,
+    ) -> Result<Self, DomainError> {
+        let ts = truncate_to_microsecond(now);
+        if ts < self.created_at {
+            return Err(DomainError::VaultConsistencyError(
+                crate::error::VaultConsistencyReason::InvalidUpdatedAt,
+            ));
+        }
+        self.label = label;
+        self.updated_at = ts;
+        Ok(self)
+    }
+
+    /// ペイロードを更新した新しい `Record` を返す（self を消費）。
+    ///
+    /// 内部で `updated_at` をマイクロ秒精度に切り捨てる。
+    ///
+    /// # Errors
+    /// `now < self.created_at` の場合 `DomainError::VaultConsistencyError(InvalidUpdatedAt)` を返す。
+    pub fn with_updated_payload(
+        mut self,
+        payload: RecordPayload,
+        now: OffsetDateTime,
+    ) -> Result<Self, DomainError> {
+        let ts = truncate_to_microsecond(now);
+        if ts < self.created_at {
+            return Err(DomainError::VaultConsistencyError(
+                crate::error::VaultConsistencyReason::InvalidUpdatedAt,
+            ));
+        }
+        self.payload = payload;
+        self.updated_at = ts;
+        Ok(self)
+    }
+}
+
+// 使われていない import を suppres するための re-export
+#[allow(unused_imports)]
+use InvalidRecordPayloadReason as _;

--- a/crates/shikomi-core/src/vault/record.rs
+++ b/crates/shikomi-core/src/vault/record.rs
@@ -303,3 +303,195 @@ impl Record {
 // 使われていない import を suppres するための re-export
 #[allow(unused_imports)]
 use InvalidRecordPayloadReason as _;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{DomainError, InvalidRecordLabelReason, InvalidRecordPayloadReason};
+    use crate::secret::SecretString;
+    use crate::vault::crypto_data::{Aad, CipherText};
+    use crate::vault::id::RecordId;
+    use crate::vault::nonce::NonceBytes;
+    use crate::vault::version::VaultVersion;
+    use time::OffsetDateTime;
+
+    fn make_id() -> RecordId {
+        RecordId::new(uuid::Uuid::now_v7()).unwrap()
+    }
+
+    fn make_aad() -> Aad {
+        let id = make_id();
+        Aad::new(id, VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).unwrap()
+    }
+
+    // --- TC-U05: RecordLabel ---
+
+    #[test]
+    fn test_record_label_try_new_one_char_ok() {
+        assert!(RecordLabel::try_new("A".to_string()).is_ok());
+    }
+
+    #[test]
+    fn test_record_label_try_new_255_graphemes_ok() {
+        let s = "あ".repeat(255);
+        assert!(RecordLabel::try_new(s).is_ok());
+    }
+
+    #[test]
+    fn test_record_label_try_new_256_graphemes_returns_too_long() {
+        let s = "あ".repeat(256);
+        let err = RecordLabel::try_new(s).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordLabel(InvalidRecordLabelReason::TooLong {
+                grapheme_count: 256
+            })
+        ));
+    }
+
+    #[test]
+    fn test_record_label_try_new_empty_returns_empty_error() {
+        let err = RecordLabel::try_new("".to_string()).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordLabel(InvalidRecordLabelReason::Empty)
+        ));
+    }
+
+    #[test]
+    fn test_record_label_try_new_nul_char_returns_control_char_error() {
+        let err = RecordLabel::try_new("\x00A".to_string()).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordLabel(InvalidRecordLabelReason::ControlChar { position: 0 })
+        ));
+    }
+
+    #[test]
+    fn test_record_label_try_new_us1f_returns_control_char_error() {
+        let err = RecordLabel::try_new("\x1FA".to_string()).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordLabel(InvalidRecordLabelReason::ControlChar { .. })
+        ));
+    }
+
+    #[test]
+    fn test_record_label_try_new_del_returns_control_char_error() {
+        let err = RecordLabel::try_new("\x7FA".to_string()).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordLabel(InvalidRecordLabelReason::ControlChar { .. })
+        ));
+    }
+
+    #[test]
+    fn test_record_label_try_new_tab_is_allowed() {
+        assert!(RecordLabel::try_new("A\tB".to_string()).is_ok());
+    }
+
+    #[test]
+    fn test_record_label_try_new_newline_is_allowed() {
+        assert!(RecordLabel::try_new("A\nB".to_string()).is_ok());
+    }
+
+    #[test]
+    fn test_record_label_try_new_carriage_return_is_allowed() {
+        assert!(RecordLabel::try_new("A\rB".to_string()).is_ok());
+    }
+
+    #[test]
+    fn test_record_label_as_str_returns_stored_string() {
+        let label = RecordLabel::try_new("Test".to_string()).unwrap();
+        assert_eq!(label.as_str(), "Test");
+    }
+
+    // --- TC-U06: RecordPayload ---
+
+    #[test]
+    fn test_record_payload_plaintext_holds_secret_string() {
+        let payload = RecordPayload::Plaintext(SecretString::from_string("s".to_string()));
+        assert!(matches!(payload, RecordPayload::Plaintext(_)));
+        assert_eq!(payload.variant_mode(), ProtectionMode::Plaintext);
+    }
+
+    #[test]
+    fn test_record_payload_encrypted_new_with_valid_args_ok() {
+        let nonce = NonceBytes::try_new(&[0u8; 12]).unwrap();
+        let cipher = CipherText::try_new(vec![1u8; 32].into_boxed_slice()).unwrap();
+        let aad = make_aad();
+        assert!(RecordPayloadEncrypted::new(nonce, cipher, aad).is_ok());
+    }
+
+    #[test]
+    fn test_nonce_bytes_try_new_with_11_bytes_returns_nonce_length_error() {
+        // RecordPayloadEncrypted requires NonceBytes; NonceBytes rejects 11-byte input
+        let err = NonceBytes::try_new(&[0u8; 11]).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordPayload(InvalidRecordPayloadReason::NonceLength {
+                expected: 12,
+                got: 11
+            })
+        ));
+    }
+
+    #[test]
+    fn test_cipher_text_try_new_with_empty_bytes_returns_cipher_text_empty_error() {
+        let err = CipherText::try_new(vec![].into_boxed_slice()).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordPayload(InvalidRecordPayloadReason::CipherTextEmpty)
+        ));
+    }
+
+    #[test]
+    fn test_record_payload_plaintext_variant_mode_is_plaintext() {
+        let payload = RecordPayload::Plaintext(SecretString::from_string("s".to_string()));
+        assert_eq!(payload.variant_mode(), ProtectionMode::Plaintext);
+    }
+
+    #[test]
+    fn test_record_payload_encrypted_variant_mode_is_encrypted() {
+        let nonce = NonceBytes::try_new(&[0u8; 12]).unwrap();
+        let cipher = CipherText::try_new(vec![1u8; 32].into_boxed_slice()).unwrap();
+        let aad = make_aad();
+        let enc = RecordPayloadEncrypted::new(nonce, cipher, aad).unwrap();
+        let payload = RecordPayload::Encrypted(enc);
+        assert_eq!(payload.variant_mode(), ProtectionMode::Encrypted);
+    }
+
+    // --- TC-U12: Record timestamp subsecond rounding ---
+
+    #[test]
+    fn test_record_new_truncates_created_at_to_microseconds() {
+        // 123_456_789 ns = 0.123456789s → 789ns sub-µs component should be truncated
+        let now = OffsetDateTime::from_unix_timestamp_nanos(123_456_789).unwrap();
+        let record = Record::new(
+            make_id(),
+            RecordKind::Text,
+            RecordLabel::try_new("label".to_string()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string("value".to_string())),
+            now,
+        );
+        assert_eq!(
+            record.created_at().nanosecond() % 1_000,
+            0,
+            "789ns sub-µs should have been truncated to 000ns"
+        );
+    }
+
+    #[test]
+    fn test_record_new_updated_at_equals_created_at_and_is_microsecond_precision() {
+        let now = OffsetDateTime::from_unix_timestamp_nanos(123_456_789).unwrap();
+        let record = Record::new(
+            make_id(),
+            RecordKind::Text,
+            RecordLabel::try_new("label".to_string()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string("value".to_string())),
+            now,
+        );
+        assert_eq!(record.updated_at().nanosecond() % 1_000, 0);
+        assert_eq!(record.updated_at(), record.created_at());
+    }
+}

--- a/crates/shikomi-core/src/vault/version.rs
+++ b/crates/shikomi-core/src/vault/version.rs
@@ -37,3 +37,31 @@ impl VaultVersion {
         self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_new_current_version_ok() {
+        assert!(VaultVersion::try_new(1).is_ok());
+    }
+
+    #[test]
+    fn test_try_new_below_min_supported_returns_error() {
+        let err = VaultVersion::try_new(0).unwrap_err();
+        assert!(matches!(err, DomainError::UnsupportedVaultVersion(0)));
+    }
+
+    #[test]
+    fn test_try_new_above_current_returns_error() {
+        let err = VaultVersion::try_new(2).unwrap_err();
+        assert!(matches!(err, DomainError::UnsupportedVaultVersion(2)));
+    }
+
+    #[test]
+    fn test_value_returns_inner_u16() {
+        let v = VaultVersion::try_new(1).unwrap();
+        assert_eq!(v.value(), 1u16);
+    }
+}

--- a/crates/shikomi-core/src/vault/version.rs
+++ b/crates/shikomi-core/src/vault/version.rs
@@ -1,0 +1,39 @@
+//! vault フォーマットバージョン管理。
+
+use crate::error::DomainError;
+
+// -------------------------------------------------------------------
+// VaultVersion
+// -------------------------------------------------------------------
+
+/// vault ファイルフォーマットのバージョンを表す newtype。
+///
+/// `CURRENT` (1) と `MIN_SUPPORTED` (1) の範囲でのみ有効。
+/// 現時点では 1 のみが有効なバージョン。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VaultVersion(u16);
+
+impl VaultVersion {
+    /// 現在サポートする最新バージョン。新規 vault 作成時はこの値を使う。
+    pub const CURRENT: Self = Self(1);
+
+    /// 読み込みに対応する最小バージョン。これより古い vault は拒否する。
+    pub const MIN_SUPPORTED: Self = Self(1);
+
+    /// `u16` 値から `VaultVersion` を生成する。
+    ///
+    /// # Errors
+    /// `MIN_SUPPORTED..=CURRENT` の範囲外の場合 `DomainError::UnsupportedVaultVersion` を返す。
+    pub fn try_new(value: u16) -> Result<Self, DomainError> {
+        if value < Self::MIN_SUPPORTED.0 || value > Self::CURRENT.0 {
+            return Err(DomainError::UnsupportedVaultVersion(value));
+        }
+        Ok(Self(value))
+    }
+
+    /// 内包する `u16` 値を返す。
+    #[must_use]
+    pub fn value(self) -> u16 {
+        self.0
+    }
+}

--- a/crates/shikomi-core/tests/deny_toml_check.rs
+++ b/crates/shikomi-core/tests/deny_toml_check.rs
@@ -1,0 +1,55 @@
+//! 静的確認テスト: deny.toml の暗号クリティカル crate 登録確認（TC-I07）
+//! REQ-009 / AC-09
+//!
+//! deny.toml の [advisories] コメントに secrecy / zeroize が明記され、
+//! かつ ignore = [] リストに含まれていないことを検証する。
+
+use std::fs;
+
+/// TC-I07: deny.toml に secrecy / zeroize がコメントに明記されている
+#[test]
+fn test_deny_toml_lists_secrecy_and_zeroize_as_crypto_critical_in_comments() {
+    // deny.toml はリポジトリルートに存在する
+    // integration test は crates/shikomi-core/ から実行されるため、
+    // ../../deny.toml が相対パス
+    let deny_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../deny.toml");
+    let content = fs::read_to_string(deny_path).expect("deny.toml should exist at repository root");
+
+    // secrecy / zeroize がコメント行に登場することを確認
+    let has_secrecy_in_comment = content
+        .lines()
+        .any(|line| line.trim_start().starts_with('#') && line.contains("secrecy"));
+    let has_zeroize_in_comment = content
+        .lines()
+        .any(|line| line.trim_start().starts_with('#') && line.contains("zeroize"));
+
+    assert!(
+        has_secrecy_in_comment,
+        "deny.toml must mention 'secrecy' in a comment line (crypto-critical crate prohibition)"
+    );
+    assert!(
+        has_zeroize_in_comment,
+        "deny.toml must mention 'zeroize' in a comment line (crypto-critical crate prohibition)"
+    );
+}
+
+/// TC-I07: deny.toml の ignore リストに secrecy / zeroize が含まれていない
+#[test]
+fn test_deny_toml_ignore_list_does_not_contain_secrecy_or_zeroize() {
+    let deny_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../deny.toml");
+    let content = fs::read_to_string(deny_path).expect("deny.toml should exist at repository root");
+
+    // ignore = [...] セクション内に secrecy / zeroize が含まれないことを確認
+    // （コメント行を除いた実際の ignore 値部分のみチェック）
+    let in_ignore_block = content
+        .lines()
+        .skip_while(|line| !line.contains("ignore = ["))
+        .take_while(|line| !line.contains(']') || line.contains("ignore = ["))
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .any(|line| line.contains("secrecy") || line.contains("zeroize"));
+
+    assert!(
+        !in_ignore_block,
+        "deny.toml ignore list must NOT contain secrecy or zeroize advisory IDs"
+    );
+}

--- a/crates/shikomi-core/tests/nonce_overflow.rs
+++ b/crates/shikomi-core/tests/nonce_overflow.rs
@@ -1,0 +1,26 @@
+//! 結合テスト: NonceCounter オーバーフロー検知（TC-I05）
+//! REQ-010 / AC-05, AC-06
+
+use shikomi_core::{DomainError, NonceCounter};
+
+/// TC-I05: NonceCounter が u32::MAX 到達で NonceOverflow を返す
+#[test]
+fn test_nonce_counter_overflow_at_max_from_public_api() {
+    let mut counter = NonceCounter::resume([0u8; 8], u32::MAX);
+    let err = counter.next().unwrap_err();
+    assert!(
+        matches!(err, DomainError::NonceOverflow),
+        "Expected NonceOverflow, got: {:?}",
+        err
+    );
+}
+
+/// TC-I05 補足: u32::MAX - 1 では成功する（境界値直前）
+#[test]
+fn test_nonce_counter_next_at_max_minus_one_succeeds_from_public_api() {
+    let mut counter = NonceCounter::resume([0u8; 8], u32::MAX - 1);
+    assert!(
+        counter.next().is_ok(),
+        "next() at u32::MAX - 1 must succeed"
+    );
+}

--- a/crates/shikomi-core/tests/record_label_boundary.rs
+++ b/crates/shikomi-core/tests/record_label_boundary.rs
@@ -1,0 +1,54 @@
+//! 結合テスト: RecordLabel 境界値（TC-I03）
+//! REQ-005 / AC-03, AC-06
+
+use shikomi_core::{DomainError, InvalidRecordLabelReason, RecordLabel};
+
+/// TC-I03: RecordLabel 境界値を外部 API から検証
+#[test]
+fn test_record_label_boundaries_from_public_api() {
+    // (a) empty -> Err(Empty)
+    assert!(matches!(
+        RecordLabel::try_new("".to_string()).unwrap_err(),
+        DomainError::InvalidRecordLabel(InvalidRecordLabelReason::Empty)
+    ));
+
+    // (b) 1 char -> Ok
+    assert!(RecordLabel::try_new("A".to_string()).is_ok());
+
+    // (c) 255 graphemes -> Ok
+    let s255 = "あ".repeat(255);
+    assert!(RecordLabel::try_new(s255).is_ok());
+
+    // (d) 256 graphemes -> Err(TooLong)
+    let s256 = "あ".repeat(256);
+    assert!(matches!(
+        RecordLabel::try_new(s256).unwrap_err(),
+        DomainError::InvalidRecordLabel(InvalidRecordLabelReason::TooLong {
+            grapheme_count: 256
+        })
+    ));
+
+    // (e) NUL (U+0000) -> Err(ControlChar)
+    assert!(matches!(
+        RecordLabel::try_new("\x00X".to_string()).unwrap_err(),
+        DomainError::InvalidRecordLabel(InvalidRecordLabelReason::ControlChar { .. })
+    ));
+
+    // (f) U+001F -> Err(ControlChar)
+    assert!(matches!(
+        RecordLabel::try_new("\x1FX".to_string()).unwrap_err(),
+        DomainError::InvalidRecordLabel(InvalidRecordLabelReason::ControlChar { .. })
+    ));
+
+    // (g) DEL (U+007F) -> Err(ControlChar)
+    assert!(matches!(
+        RecordLabel::try_new("\x7FX".to_string()).unwrap_err(),
+        DomainError::InvalidRecordLabel(InvalidRecordLabelReason::ControlChar { .. })
+    ));
+
+    // (h) TAB (\t) -> Ok (permitted)
+    assert!(RecordLabel::try_new("A\tB".to_string()).is_ok());
+
+    // (i) LF (\n) -> Ok (permitted)
+    assert!(RecordLabel::try_new("A\nB".to_string()).is_ok());
+}

--- a/crates/shikomi-core/tests/secret_no_leak.rs
+++ b/crates/shikomi-core/tests/secret_no_leak.rs
@@ -1,0 +1,39 @@
+//! 結合テスト: SecretString / SecretBytes の非リーク確認（TC-I04）
+//! REQ-008 / AC-04, AC-06
+
+use shikomi_core::{SecretBytes, SecretString};
+
+/// TC-I04: SecretString Debug フォーマットで秘密値が露出しない
+#[test]
+fn test_secret_string_debug_does_not_leak_value() {
+    let s = SecretString::from_string("my-password".to_string());
+    let debug_output = format!("{:?}", s);
+    assert!(
+        !debug_output.contains("my-password"),
+        "SecretString::Debug must not contain the secret. Got: {}",
+        debug_output
+    );
+    assert!(
+        debug_output.contains("[REDACTED]"),
+        "SecretString::Debug must contain [REDACTED]. Got: {}",
+        debug_output
+    );
+}
+
+/// TC-I04: SecretBytes Debug フォーマットで生バイトが露出しない
+#[test]
+fn test_secret_bytes_debug_does_not_leak_value() {
+    let b = SecretBytes::from_boxed_slice(b"secret".to_vec().into_boxed_slice());
+    let debug_output = format!("{:?}", b);
+    // 生バイト値 "secret" や数値リテラルが含まれないことを確認
+    assert!(
+        !debug_output.contains("115"), // 's' = 115
+        "SecretBytes::Debug must not contain raw byte values. Got: {}",
+        debug_output
+    );
+    assert!(
+        debug_output.contains("[REDACTED]"),
+        "SecretBytes::Debug must contain [REDACTED]. Got: {}",
+        debug_output
+    );
+}

--- a/crates/shikomi-core/tests/vault_lifecycle.rs
+++ b/crates/shikomi-core/tests/vault_lifecycle.rs
@@ -1,0 +1,84 @@
+//! 結合テスト: vault ライフサイクル (TC-I01, TC-I02)
+//! REQ-007 / AC-01, AC-02, AC-06
+
+use shikomi_core::{
+    DomainError, Record, RecordId, RecordKind, RecordLabel, RecordPayload, SecretString, Vault,
+    VaultConsistencyReason, VaultHeader, VaultVersion,
+};
+use time::OffsetDateTime;
+
+fn make_id() -> RecordId {
+    RecordId::new(uuid::Uuid::now_v7()).unwrap()
+}
+
+fn make_plaintext_header() -> VaultHeader {
+    VaultHeader::new_plaintext(VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).unwrap()
+}
+
+fn make_plaintext_record(label: &str) -> Record {
+    Record::new(
+        make_id(),
+        RecordKind::Text,
+        RecordLabel::try_new(label.to_string()).unwrap(),
+        RecordPayload::Plaintext(SecretString::from_string("value".to_string())),
+        OffsetDateTime::UNIX_EPOCH,
+    )
+}
+
+/// TC-I01: Plaintext vault ライフサイクル
+#[test]
+fn test_plaintext_vault_lifecycle_add_find_remove() {
+    let mut vault = Vault::new(make_plaintext_header());
+
+    let r1 = make_plaintext_record("record-1");
+    let r2 = make_plaintext_record("record-2");
+    let id1 = r1.id().clone();
+    let id2 = r2.id().clone();
+
+    // add 2 records
+    vault.add_record(r1).unwrap();
+    vault.add_record(r2).unwrap();
+    assert_eq!(vault.records().len(), 2);
+
+    // find existing
+    let found = vault.find_record(&id1);
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().label().as_str(), "record-1");
+
+    // remove one
+    vault.remove_record(&id2).unwrap();
+    assert_eq!(vault.records().len(), 1);
+    assert!(vault.find_record(&id2).is_none());
+}
+
+/// TC-I02: Vault モード不整合検知
+#[test]
+fn test_plaintext_vault_rejects_encrypted_payload() {
+    use shikomi_core::{Aad, CipherText, NonceBytes, RecordPayloadEncrypted};
+
+    let mut vault = Vault::new(make_plaintext_header());
+
+    let id = make_id();
+    let nonce = NonceBytes::try_new(&[0u8; 12]).unwrap();
+    let cipher = CipherText::try_new(vec![1u8; 32].into_boxed_slice()).unwrap();
+    let aad = Aad::new(
+        id.clone(),
+        VaultVersion::CURRENT,
+        OffsetDateTime::UNIX_EPOCH,
+    )
+    .unwrap();
+    let enc = RecordPayloadEncrypted::new(nonce, cipher, aad).unwrap();
+    let record = Record::new(
+        id,
+        RecordKind::Secret,
+        RecordLabel::try_new("enc".to_string()).unwrap(),
+        RecordPayload::Encrypted(enc),
+        OffsetDateTime::UNIX_EPOCH,
+    );
+
+    let err = vault.add_record(record).unwrap_err();
+    assert!(matches!(
+        err,
+        DomainError::VaultConsistencyError(VaultConsistencyReason::ModeMismatch { .. })
+    ));
+}

--- a/deny.toml
+++ b/deny.toml
@@ -37,7 +37,13 @@ deny = []
 # 初期状態は空（外部 crate 未導入のため）
 # NOTE: 以下の暗号クリティカル crate は skip / skip-tree への登録を禁止する
 # aes-gcm / argon2 / zeroize / secrecy / hkdf / pbkdf2 / bip39 / rand_core / subtle
-skip = []
+skip = [
+    # wit-bindgen 0.51.0 / 0.57.1 が getrandom v0.4 → uuid v1 の間接依存で共存する。
+    # Issue #7 で導入した uuid/getrandom による一時例外。
+    # uuid のバージョン更新時に再評価すること。
+    { name = "wit-bindgen", version = "0.51.0" },
+    { name = "wit-bindgen", version = "0.57.1" },
+]
 skip-tree = []
 
 [sources]

--- a/docs/features/vault/requirements.md
+++ b/docs/features/vault/requirements.md
@@ -149,7 +149,7 @@
 | MSG-DEV-001 | 開発者エラー | `unknown protection mode: {0}` | `InvalidProtectionMode` |
 | MSG-DEV-002 | 開発者エラー | `unsupported vault version: {0}` | `UnsupportedVaultVersion` |
 | MSG-DEV-003 | 開発者エラー | `invalid record label: {0}` | `InvalidRecordLabel` |
-| MSG-DEV-004 | 開発者エラー | `vault and record payload mode mismatch: {0}` | `VaultConsistencyError` |
+| MSG-DEV-004 | 開発者エラー | 内包 `VaultConsistencyReason` の `Display` を素通し（`#[error("{0}")]`、各バリアント文言は `error.rs` の `VaultConsistencyReason` 定義を参照。`DuplicateId` 等は mode mismatch 文言を含まない） | `VaultConsistencyError` |
 | MSG-DEV-005 | 開発者エラー | `nonce counter exhausted; rekey required` | `NonceOverflow` |
 | MSG-DEV-006 | 開発者エラー | `invalid record id: {0}` | `InvalidRecordId` |
 | MSG-DEV-007 | 開発者エラー | `invalid record payload: {0}` | `InvalidRecordPayload` |

--- a/docs/features/vault/test-design/appendix.md
+++ b/docs/features/vault/test-design/appendix.md
@@ -85,7 +85,7 @@ cargo deny check
 |------|------|
 | 受入基準の網羅 | AC-01〜AC-09 が全テストケースで網羅されていること |
 | 行カバレッジ | `cargo test -p shikomi-core` で 80% 以上（受入基準 AC-06）。計測は `cargo llvm-cov` 等で行う |
-| 正常系 | 全ケース必須（ユニット 84 件 + 結合 7 件 = 合計 91 件） |
+| 正常系 | 全ケース必須（ユニット 85 件 + 結合 7 件 = 合計 92 件） |
 | 異常系 | エラーバリアントの種別まで検証（`assert!(matches!(err, DomainError::Xxx))` レベル） |
 | 境界値 | `RecordLabel`（0/1/254/255/256 grapheme）、`NonceCounter`（u32::MAX-1 / u32::MAX）、`VaultVersion`（0/1/2）を必須とする |
 
@@ -97,4 +97,5 @@ cargo deny check
 *改訂: 涅マユリ（テスト担当）/ 2026-04-22 — ペテルギウス第3ラウンド指摘対応: TC-U11-04（Aad黄金値テスト・26byte完全一致）追加。TC-U10-08（NonceCounter下位4B big-endianバイトオーダー検証）追加。TC-U12（Record::new サブ秒丸めround-trip 2件）追加。合計 75件→91件（ユニット84件+結合7件。旧「79件」はサブケース集計漏れによる誤記）*
 *改訂: 涅マユリ（テスト担当）/ 2026-04-22 — ペガサス指摘対応: test-design.md（507行）を test-design/ ディレクトリに分割。overview.md / integration.md / unit.md / appendix.md の4ファイル構成に再編。*
 *改訂: 涅マユリ（テスト担当）/ 2026-04-22 — ペテルギウス指摘対応: §10 カバレッジ基準の件数を「72+7=79件」から「84+7=91件」に訂正（マトリクス実数との乖離解消）。*
+*改訂: 涅マユリ（テスト担当）/ 2026-04-22 — ペテルギウス指摘対応（Boy Scout Rule）: MSG-DEV-004 改訂対応で TC-U09-04b（DuplicateId 不混入確認）追加。§10 件数を「84+7=91件」から「85+7=92件」に訂正。テストケース追加時は必ず appendix 件数を同時更新すること。*
 *対応 Issue: #7 feat(shikomi-core): vault ドメイン型定義*

--- a/docs/features/vault/test-design/overview.md
+++ b/docs/features/vault/test-design/overview.md
@@ -105,7 +105,8 @@
 | TC-U09-01 | REQ-009 | AC-01 | `DomainError::InvalidProtectionMode("x")` の `Display` が `"unknown protection mode: x"` を含む（MSG-DEV-001） | 正常系 |
 | TC-U09-02 | REQ-009 | AC-01 | `DomainError::UnsupportedVaultVersion(99)` の `Display` が `"unsupported vault version: 99"` を含む（MSG-DEV-002） | 正常系 |
 | TC-U09-03 | REQ-009 | AC-01 | `DomainError::InvalidRecordLabel(Empty)` の `Display` が `"invalid record label"` を含む（MSG-DEV-003） | 正常系 |
-| TC-U09-04 | REQ-009 | AC-01 | `DomainError::VaultConsistencyError(ModeMismatch { .. })` の `Display` が `"vault and record payload mode mismatch"` を含む（MSG-DEV-004） | 正常系 |
+| TC-U09-04 | REQ-009 | AC-01 | `DomainError::VaultConsistencyError(ModeMismatch { .. })` の `Display` が `"vault"` かつ `"mode"` を含む（MSG-DEV-004 改訂: `#[error("{0}")]` により内包 `VaultConsistencyReason` の Display に委譲） | 正常系 |
+| TC-U09-04b | REQ-009 | AC-01 | `DomainError::VaultConsistencyError(DuplicateId(..))` の `Display` が `"duplicate"` を含み `"mode mismatch"` を含まない（旧実装で混入していた文言の不混入確認） | 異常系 |
 | TC-U09-05 | REQ-009 | AC-01 | `DomainError::NonceOverflow` の `Display` が `"nonce counter exhausted"` を含む（MSG-DEV-005） | 正常系 |
 | TC-U09-06 | REQ-009 | AC-01 | `DomainError::InvalidRecordId(NilUuid)` の `Display` が `"invalid record id"` を含む（MSG-DEV-006） | 正常系 |
 | TC-U09-07 | REQ-009 | AC-01 | `DomainError::InvalidRecordPayload(CipherTextEmpty)` の `Display` が `"invalid record payload"` を含む（MSG-DEV-007） | 正常系 |

--- a/docs/features/vault/test-design/unit.md
+++ b/docs/features/vault/test-design/unit.md
@@ -139,7 +139,8 @@
 | TC-U09-01 | — | `format!("{}", DomainError::InvalidProtectionMode("x".into()))` | `"unknown protection mode"` を含む（MSG-DEV-001） |
 | TC-U09-02 | — | `format!("{}", DomainError::UnsupportedVaultVersion(99))` | `"unsupported vault version"` かつ `"99"` を含む（MSG-DEV-002） |
 | TC-U09-03 | — | `format!("{}", DomainError::InvalidRecordLabel(Empty))` | `"invalid record label"` を含む（MSG-DEV-003） |
-| TC-U09-04 | — | `format!("{}", DomainError::VaultConsistencyError(ModeMismatch { .. }))` | `"vault"` かつ `"mode mismatch"` を含む（MSG-DEV-004） |
+| TC-U09-04 | — | `format!("{}", DomainError::VaultConsistencyError(ModeMismatch { vault_mode: Plaintext, record_mode: Encrypted }))` | `"vault"` かつ `"mode"` を含む（MSG-DEV-004 改訂: `#[error("{0}")]` により `VaultConsistencyReason::ModeMismatch` の Display `"vault is in ... mode but record payload is ..."` が素通しされる） |
+| TC-U09-04b | — | `format!("{}", DomainError::VaultConsistencyError(DuplicateId(..)))` | `"duplicate"` を含み `"mode mismatch"` を含まない（旧 `#[error("vault and record payload mode mismatch: {0}")]` で混入していた文言が除去されたことの確認） |
 | TC-U09-05 | — | `format!("{}", DomainError::NonceOverflow)` | `"nonce counter exhausted"` を含む（MSG-DEV-005） |
 | TC-U09-06 | — | `format!("{}", DomainError::InvalidRecordId(NilUuid))` | `"invalid record id"` を含む（MSG-DEV-006） |
 | TC-U09-07 | — | `format!("{}", DomainError::InvalidRecordPayload(CipherTextEmpty))` | `"invalid record payload"` を含む（MSG-DEV-007） |


### PR DESCRIPTION
## Summary

- `shikomi-core` に vault ドメイン型を全実装（Issue #7 工程3）
- 設計書 `docs/features/vault/` に厳密に従い、pure Rust / no-I/O で構築
- `cargo build` + `cargo fmt --check` + `cargo clippy -D warnings` 全通過確認済み

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `Cargo.toml` | `[workspace.dependencies]` に 7 crate 追加 |
| `crates/shikomi-core/Cargo.toml` | workspace 依存を参照 |
| `crates/shikomi-core/src/lib.rs` | 公開 API 再エクスポート |
| `src/error.rs` | `DomainError` + Reason 列挙 8 バリアント（MSG-DEV-001〜008）|
| `src/secret/mod.rs` | `SecretString` / `SecretBytes`（`secrecy::SecretBox` + `Debug=[REDACTED]`）|
| `src/vault/protection_mode.rs` | `ProtectionMode` enum + 永続化変換 |
| `src/vault/version.rs` | `VaultVersion`（CURRENT=1, MIN_SUPPORTED=1）|
| `src/vault/header.rs` | `VaultHeader` enum（Plaintext/Encrypted 排他）|
| `src/vault/id.rs` | `RecordId`（UUIDv7 newtype, Display/FromStr）|
| `src/vault/record.rs` | `Record` / `RecordKind` / `RecordLabel` / `RecordPayload`（grapheme 検証）|
| `src/vault/crypto_data.rs` | `KdfSalt` / `WrappedVek` / `CipherText` / `Aad`（26-byte バイナリ正規形）|
| `src/vault/nonce.rs` | `NonceBytes` / `NonceCounter`（u32::MAX overflow → NonceOverflow）|
| `src/vault/mod.rs` | `Vault` 集約ルート + `VekProvider` trait（DI for shikomi-infra）|

## 設計上の判断・補足

- **`VekProvider::new_vek()`**: 詳細設計書に明示されていないが、`rekey_with` が pure Rust で新 VEK を参照するために必要な追加メソッド。設計書「新 VEK を入手（実装は shikomi-infra）」の解釈として追加した。レビューで妥当性を確認してほしい
- **`unicode-segmentation`**: requirements.md の依存リストに記載なし。「255 grapheme ベース」要件を満たすために追加。deny.toml の allow リストにあるライセンス（MIT/Apache-2.0）に適合済み
- **`secrecy 0.10` の `CloneableSecret`**: `String`/`Vec<u8>` は実装していないため、`Clone` は手動実装（expose → clone → re-wrap）
- **`hashbrown` 複数バージョン**: transitive dependency で 0.15.5 と 0.17.0 が共存。deny.toml の `multiple-versions = "deny"` に抵触する可能性あり。CI で確認してほしい

## テスト担当への確認観点

- `TC-U05`: `RecordLabel` grapheme cluster 検証（255境界・制御文字・\t/\n/\r 許可）
- `TC-U10`: `NonceCounter::next()` の counter big-endian 配置、u32::MAX boundary
- `TC-U11`: `Aad::to_canonical_bytes()` golden value（26-byte 固定長レイアウト）
- `TC-U12`: `Record::new` のタイムスタンプ nanosecond 切り捨て（microsecond精度）
- `TC-I06`: CI コマンド（cargo build/fmt/clippy）の通過確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)