### PR TITLE
feat(shikomi-cli): implement list/add/edit/remove subcommands (cli-vault-commands Phase 1)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,3 +21,6 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories licenses bans sources
+
+      - name: Secret path audit (TC-CI-012/013/014/015)
+        run: bash scripts/ci/audit-secret-paths.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,16 +24,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -58,6 +140,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +195,12 @@ dependencies = [
  "powerfmt",
  "serde_core",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dirs"
@@ -127,6 +262,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -243,6 +387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +409,23 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -357,6 +524,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,10 +545,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -423,6 +611,36 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -479,6 +697,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +724,27 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "rusqlite"
@@ -658,6 +909,24 @@ dependencies = [
 [[package]]
 name = "shikomi-cli"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap",
+ "dirs",
+ "is-terminal",
+ "predicates",
+ "rpassword",
+ "serial_test",
+ "shikomi-core",
+ "shikomi-infra",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
 
 [[package]]
 name = "shikomi-core"
@@ -718,6 +987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +1015,22 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -922,6 +1213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1247,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,18 @@ rusqlite        = { version = "0.31", features = ["bundled"] }
 fs4             = { version = "0.9",  default-features = false, features = ["sync"] }
 cfg-if          = "1"
 tracing         = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 dirs            = "5"
 shikomi-core    = { path = "crates/shikomi-core", version = "0.1.0" }
+shikomi-infra   = { path = "crates/shikomi-infra", version = "0.1.0" }
+# CLI 層の依存（cli-vault-commands feature で追加）
+clap            = { version = "4",    features = ["derive", "env", "wrap_help"] }
+anyhow          = "1"
+is-terminal     = "0.4"
+rpassword       = "7"
+# テスト用
 tempfile        = "3"
 tracing-test    = "0.2"
 serial_test     = "3"
+assert_cmd      = "2"
+predicates      = "3"

--- a/crates/shikomi-cli/Cargo.toml
+++ b/crates/shikomi-cli/Cargo.toml
@@ -37,6 +37,9 @@ tempfile      = { workspace = true }
 assert_cmd    = { workspace = true }
 predicates    = { workspace = true }
 serial_test   = { workspace = true }
+# 暗号化 vault フィクスチャ helper (tests/common/fixtures.rs) で SQLite を直接書き出すため。
+# CLI 本体は rusqlite を参照しない（`shikomi-infra` 経由）。本依存はテスト限定。
+rusqlite      = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/shikomi-cli/Cargo.toml
+++ b/crates/shikomi-cli/Cargo.toml
@@ -6,9 +6,37 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
+# lib + bin の 2 ターゲット構成
+# - lib: UseCase / Presenter 等の内部公開 Rust API を提供。結合テスト（tests/）から直接呼び出す目的
+# - bin: `shikomi_cli::run()` を呼ぶ 3 行ラッパ。コンポジションルートは lib 側
+# 設計根拠: docs/features/cli-vault-commands/detailed-design/public-api.md §前提: crate 構成
+[lib]
+name = "shikomi_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "shikomi"
 path = "src/main.rs"
+
+[dependencies]
+shikomi-core  = { workspace = true }
+shikomi-infra = { workspace = true }
+clap          = { workspace = true }
+anyhow        = { workspace = true }
+is-terminal   = { workspace = true }
+rpassword     = { workspace = true }
+time          = { workspace = true }
+uuid          = { workspace = true }
+tracing       = { workspace = true }
+tracing-subscriber = { workspace = true }
+thiserror     = { workspace = true }
+dirs          = { workspace = true }
+
+[dev-dependencies]
+tempfile      = { workspace = true }
+assert_cmd    = { workspace = true }
+predicates    = { workspace = true }
+serial_test   = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/shikomi-cli/src/cli.rs
+++ b/crates/shikomi-cli/src/cli.rs
@@ -1,0 +1,221 @@
+//! clap 派生型の置き場。
+//!
+//! `run()` の肥大化を避けるため、`#[derive(Parser)]` 構造体群を本モジュールに集約。
+//! コマンド分岐は `lib.rs::run()` 側の `match` に残す。
+//!
+//! 設計根拠: docs/features/cli-vault-commands/detailed-design/clap-config.md
+
+use std::path::PathBuf;
+
+use clap::{Args, Parser, Subcommand as ClapSubcommand, ValueEnum};
+use shikomi_core::RecordKind;
+
+/// vault ディレクトリを上書きする環境変数名。clap の `env` attribute から参照する。
+pub const ENV_VAR_VAULT_DIR: &str = "SHIKOMI_VAULT_DIR";
+
+// -------------------------------------------------------------------
+// CliArgs
+// -------------------------------------------------------------------
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "shikomi",
+    version,
+    about = "shikomi — a local encrypted credential vault (CLI Phase 1: plaintext only)",
+    long_about = None,
+)]
+pub struct CliArgs {
+    /// vault ディレクトリ上書き。env `SHIKOMI_VAULT_DIR` も自動吸収する（clap `env` attribute、
+    /// 真実源の二重化防止のためアプリ層では env を読まない）。
+    #[arg(long = "vault-dir", global = true, env = ENV_VAR_VAULT_DIR, value_name = "PATH")]
+    pub vault_dir: Option<PathBuf>,
+
+    /// 成功出力を抑止する（stderr は通常通り）。
+    #[arg(long, short, global = true)]
+    pub quiet: bool,
+
+    /// tracing を debug レベルへ上げる。
+    #[arg(long, short, global = true)]
+    pub verbose: bool,
+
+    #[command(subcommand)]
+    pub subcommand: Subcommand,
+}
+
+impl CliArgs {
+    /// `clap::Parser::try_parse` の薄ラッパ（run 側の import 削減）。
+    ///
+    /// # Errors
+    /// clap が返す任意の `clap::Error` を透過する。
+    pub fn try_parse() -> Result<Self, clap::Error> {
+        <Self as Parser>::try_parse()
+    }
+}
+
+// -------------------------------------------------------------------
+// Subcommand
+// -------------------------------------------------------------------
+
+#[derive(ClapSubcommand, Debug)]
+pub enum Subcommand {
+    /// vault 内のレコード一覧を表示する。
+    #[command(about = "List all records")]
+    List,
+    /// 新しいレコードを追加する。
+    #[command(about = "Add a new record")]
+    Add(AddArgs),
+    /// 既存レコードを編集する。
+    #[command(about = "Edit an existing record")]
+    Edit(EditArgs),
+    /// レコードを削除する。
+    #[command(about = "Remove a record", visible_alias = "rm")]
+    Remove(RemoveArgs),
+}
+
+// -------------------------------------------------------------------
+// AddArgs
+// -------------------------------------------------------------------
+
+#[derive(Args, Debug)]
+pub struct AddArgs {
+    /// レコード種別（`text` / `secret`）。
+    #[arg(long, value_enum)]
+    pub kind: KindArg,
+
+    /// レコードラベル。
+    #[arg(long, value_name = "STRING")]
+    pub label: String,
+
+    /// 値を直接指定する（secret の場合は shell 履歴に残るため `--stdin` 推奨）。
+    /// `--stdin` と併用不可。
+    #[arg(long, value_name = "STRING")]
+    pub value: Option<String>,
+
+    /// 値を stdin から読み取る。secret 入力時は TTY なら非エコー読取。
+    #[arg(long)]
+    pub stdin: bool,
+}
+
+// -------------------------------------------------------------------
+// EditArgs
+// -------------------------------------------------------------------
+
+#[derive(Args, Debug)]
+pub struct EditArgs {
+    /// 対象レコード ID（UUIDv7 全長 36 文字）。
+    #[arg(long, value_name = "UUID")]
+    pub id: String,
+
+    /// 新しいラベル（任意）。
+    #[arg(long, value_name = "STRING")]
+    pub label: Option<String>,
+
+    /// 新しい値（任意）。
+    #[arg(long, value_name = "STRING")]
+    pub value: Option<String>,
+
+    /// 値を stdin から読み取る。`--value` と併用不可。
+    #[arg(long)]
+    pub stdin: bool,
+    // NOTE: `--kind` フィールドは定義しない（Phase 1 スコープ外、requirements.md REQ-CLI-003）。
+}
+
+// -------------------------------------------------------------------
+// RemoveArgs
+// -------------------------------------------------------------------
+
+#[derive(Args, Debug)]
+pub struct RemoveArgs {
+    /// 対象レコード ID（UUIDv7 全長 36 文字）。
+    #[arg(long, value_name = "UUID")]
+    pub id: String,
+
+    /// 対話確認をスキップする。非 TTY 環境では必須（`CliError::NonInteractiveRemove` 回避）。
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+}
+
+// -------------------------------------------------------------------
+// KindArg
+// -------------------------------------------------------------------
+
+#[derive(ValueEnum, Clone, Copy, Debug)]
+#[value(rename_all = "snake_case")]
+pub enum KindArg {
+    /// テキスト（URL / メモ等、機密度が低い）
+    Text,
+    /// シークレット（パスワード / 鍵等、機密度が高い）
+    Secret,
+}
+
+impl From<KindArg> for RecordKind {
+    fn from(k: KindArg) -> Self {
+        match k {
+            KindArg::Text => RecordKind::Text,
+            KindArg::Secret => RecordKind::Secret,
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// テスト
+// -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kind_arg_text_maps_to_record_kind_text() {
+        assert!(matches!(RecordKind::from(KindArg::Text), RecordKind::Text));
+    }
+
+    #[test]
+    fn test_kind_arg_secret_maps_to_record_kind_secret() {
+        assert!(matches!(
+            RecordKind::from(KindArg::Secret),
+            RecordKind::Secret
+        ));
+    }
+
+    #[test]
+    fn test_cli_args_parses_list_subcommand() {
+        let args = CliArgs::try_parse_from(["shikomi", "list"]).unwrap();
+        assert!(matches!(args.subcommand, Subcommand::List));
+    }
+
+    #[test]
+    fn test_cli_args_parses_add_subcommand_with_kind_label_value() {
+        let args = CliArgs::try_parse_from([
+            "shikomi", "add", "--kind", "text", "--label", "l", "--value", "v",
+        ])
+        .unwrap();
+        assert!(matches!(args.subcommand, Subcommand::Add(_)));
+    }
+
+    #[test]
+    fn test_cli_args_remove_alias_rm_accepted() {
+        let args = CliArgs::try_parse_from([
+            "shikomi",
+            "rm",
+            "--id",
+            "01234567-0123-7000-8000-0123456789ab",
+        ])
+        .unwrap();
+        assert!(matches!(args.subcommand, Subcommand::Remove(_)));
+    }
+
+    #[test]
+    fn test_cli_args_edit_kind_flag_is_unknown_arg() {
+        // Phase 1 スコープ外のため `edit --kind` は clap のエラーになる
+        let result = CliArgs::try_parse_from([
+            "shikomi",
+            "edit",
+            "--id",
+            "01234567-0123-7000-8000-0123456789ab",
+            "--kind",
+            "text",
+        ]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/shikomi-cli/src/error.rs
+++ b/crates/shikomi-cli/src/error.rs
@@ -58,7 +58,18 @@ pub enum CliError {
 
 impl From<PersistenceError> for CliError {
     fn from(e: PersistenceError) -> Self {
-        Self::Persistence(e)
+        // 暗号化 vault 検出は `PersistenceError::UnsupportedYet { feature: "encrypted vault persistence", .. }`
+        // の形で infra 層から返る（`shikomi-infra::persistence::repository.rs` の
+        // `load_inner` / `save_inner` が Encrypted モードで Fail Fast）。
+        // CLI 層はこれを専用の `EncryptionUnsupported` バリアントへ写像し、
+        // `ExitCode::EncryptionUnsupported (3)` に繋げる（REQ-CLI-009 / 受入基準 8）。
+        match e {
+            PersistenceError::UnsupportedYet {
+                feature: "encrypted vault persistence",
+                ..
+            } => Self::EncryptionUnsupported,
+            other => Self::Persistence(other),
+        }
     }
 }
 
@@ -146,5 +157,31 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("invalid label"));
         assert!(!msg.contains("SECRET_TEST_VALUE"));
+    }
+
+    /// BUG-001 回帰: `PersistenceError::UnsupportedYet { feature: "encrypted vault persistence", .. }`
+    /// は `CliError::EncryptionUnsupported`（exit 3）に写像されなければならない。
+    /// 以前は無条件に `CliError::Persistence(...)` に包まれ、exit 2 になっていた。
+    #[test]
+    fn test_from_persistence_encrypted_vault_maps_to_encryption_unsupported() {
+        let pe = PersistenceError::UnsupportedYet {
+            feature: "encrypted vault persistence",
+            tracking_issue: None,
+        };
+        let cli_err: CliError = pe.into();
+        assert!(matches!(cli_err, CliError::EncryptionUnsupported));
+        assert_eq!(ExitCode::from(&cli_err), ExitCode::EncryptionUnsupported);
+    }
+
+    /// 他の `UnsupportedYet`（将来の未実装機能）は `CliError::Persistence` に留める。
+    #[test]
+    fn test_from_persistence_other_unsupported_maps_to_persistence() {
+        let pe = PersistenceError::UnsupportedYet {
+            feature: "some other future feature",
+            tracking_issue: None,
+        };
+        let cli_err: CliError = pe.into();
+        assert!(matches!(cli_err, CliError::Persistence(_)));
+        assert_eq!(ExitCode::from(&cli_err), ExitCode::SystemError);
     }
 }

--- a/crates/shikomi-cli/src/error.rs
+++ b/crates/shikomi-cli/src/error.rs
@@ -1,0 +1,150 @@
+//! CLI 層のエラー型と終了コード。
+//!
+//! 設計根拠: docs/features/cli-vault-commands/detailed-design/data-structures.md
+//! §`CliError` バリアント詳細、§`CliError` の `From` 実装
+
+use std::path::PathBuf;
+
+use shikomi_core::{DomainError, RecordId};
+use shikomi_infra::persistence::PersistenceError;
+use thiserror::Error;
+
+// -------------------------------------------------------------------
+// CliError
+// -------------------------------------------------------------------
+
+/// CLI 全体が返すエラー型。
+///
+/// i18n 併記は `presenter::error::render_error` の責務。`Display` は英語原文のみ。
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CliError {
+    /// clap usage error / フラグ併用違反（人間可読の英文を保持）
+    #[error("{0}")]
+    UsageError(String),
+
+    /// `RecordLabel::try_new` 失敗
+    #[error("invalid label: {0}")]
+    InvalidLabel(DomainError),
+
+    /// `RecordId::try_from_str` 失敗
+    #[error("invalid record id: {0}")]
+    InvalidId(DomainError),
+
+    /// 対象レコードが vault に存在しない
+    #[error("record not found: {0}")]
+    RecordNotFound(RecordId),
+
+    /// vault 未初期化（`list` / `edit` / `remove` のみ。`add` は自動作成）
+    #[error("vault not initialized at {0}")]
+    VaultNotInitialized(PathBuf),
+
+    /// 非 TTY で `remove --yes` 未指定
+    #[error("refusing to delete without --yes in non-interactive mode")]
+    NonInteractiveRemove,
+
+    /// 永続化層のエラー
+    #[error("persistence error: {0}")]
+    Persistence(PersistenceError),
+
+    /// 予期しないドメインエラー（集約整合性等）
+    #[error("domain error: {0}")]
+    Domain(DomainError),
+
+    /// 暗号化 vault 検出（Phase 1 未対応）
+    #[error("this vault is encrypted; encryption is not yet supported in this CLI version")]
+    EncryptionUnsupported,
+}
+
+impl From<PersistenceError> for CliError {
+    fn from(e: PersistenceError) -> Self {
+        Self::Persistence(e)
+    }
+}
+
+// -------------------------------------------------------------------
+// ExitCode
+// -------------------------------------------------------------------
+
+/// CLI の終了コード。`std::process::Termination` を実装し、`main() -> ExitCode` から返せる。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ExitCode {
+    /// 成功
+    Success = 0,
+    /// ユーザ入力エラー（フラグ不足・不正値・vault 未作成 等）
+    UserError = 1,
+    /// システムエラー（I/O / 権限 / SQLite / 内部バグ）
+    SystemError = 2,
+    /// 暗号化 vault 検出（Phase 1 未対応）
+    EncryptionUnsupported = 3,
+}
+
+impl std::process::Termination for ExitCode {
+    fn report(self) -> std::process::ExitCode {
+        std::process::ExitCode::from(self as u8)
+    }
+}
+
+impl From<&CliError> for ExitCode {
+    fn from(err: &CliError) -> Self {
+        match err {
+            CliError::UsageError(_)
+            | CliError::InvalidLabel(_)
+            | CliError::InvalidId(_)
+            | CliError::RecordNotFound(_)
+            | CliError::VaultNotInitialized(_)
+            | CliError::NonInteractiveRemove => Self::UserError,
+            CliError::Persistence(_) | CliError::Domain(_) => Self::SystemError,
+            CliError::EncryptionUnsupported => Self::EncryptionUnsupported,
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// テスト
+// -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::error::InvalidRecordLabelReason;
+
+    #[test]
+    fn test_exit_code_usage_error_maps_to_user_error() {
+        let err = CliError::UsageError("x".to_owned());
+        assert_eq!(ExitCode::from(&err), ExitCode::UserError);
+    }
+
+    #[test]
+    fn test_exit_code_invalid_label_maps_to_user_error() {
+        let err = CliError::InvalidLabel(DomainError::InvalidRecordLabel(
+            InvalidRecordLabelReason::Empty,
+        ));
+        assert_eq!(ExitCode::from(&err), ExitCode::UserError);
+    }
+
+    #[test]
+    fn test_exit_code_non_interactive_remove_maps_to_user_error() {
+        assert_eq!(
+            ExitCode::from(&CliError::NonInteractiveRemove),
+            ExitCode::UserError
+        );
+    }
+
+    #[test]
+    fn test_exit_code_encryption_unsupported_maps_to_exit_3() {
+        assert_eq!(ExitCode::from(&CliError::EncryptionUnsupported) as u8, 3);
+    }
+
+    #[test]
+    fn test_display_invalid_label_does_not_contain_secret_marker() {
+        // CliError::Display はラベル検証エラー文を英語で返す。secret 値は含まれない。
+        let err = CliError::InvalidLabel(DomainError::InvalidRecordLabel(
+            InvalidRecordLabelReason::Empty,
+        ));
+        let msg = err.to_string();
+        assert!(msg.contains("invalid label"));
+        assert!(!msg.contains("SECRET_TEST_VALUE"));
+    }
+}

--- a/crates/shikomi-cli/src/input.rs
+++ b/crates/shikomi-cli/src/input.rs
@@ -1,0 +1,85 @@
+//! UseCase への入力 DTO。
+//!
+//! clap 派生型（生 `String` / `bool` を持つ）とは分離し、ドメイン検証済み型のみを保持する。
+//! `run()` のみが両者の変換役を担い、UseCase 層には検証済みの DTO を渡す（Parse, don't validate）。
+//!
+//! 設計根拠: docs/features/cli-vault-commands/detailed-design/public-api.md
+//! §`shikomi_cli::input`
+
+use shikomi_core::{RecordId, RecordKind, RecordLabel, SecretString};
+
+// -------------------------------------------------------------------
+// AddInput
+// -------------------------------------------------------------------
+
+/// `add` UseCase の入力 DTO。
+#[derive(Debug)]
+pub struct AddInput {
+    pub kind: RecordKind,
+    pub label: RecordLabel,
+    pub value: SecretString,
+}
+
+// -------------------------------------------------------------------
+// EditInput
+// -------------------------------------------------------------------
+
+/// `edit` UseCase の入力 DTO。
+///
+/// `label` / `value` は少なくとも 1 つが `Some` である必要がある（呼び出し側の事前条件、
+/// `run_edit` で検証）。`kind` フィールドは持たない（Phase 1 スコープ外）。
+#[derive(Debug)]
+pub struct EditInput {
+    pub id: RecordId,
+    pub label: Option<RecordLabel>,
+    pub value: Option<SecretString>,
+}
+
+// -------------------------------------------------------------------
+// ConfirmedRemoveInput
+// -------------------------------------------------------------------
+
+/// `remove` UseCase の入力 DTO。**型の存在そのものが「確認済み」を表す**。
+///
+/// `confirmed: bool` フィールドは持たない。`ConfirmedRemoveInput::new(id)` を呼べるのは
+/// `run_remove` の TTY プロンプト or `--yes` 経路のみ。非 TTY + `--yes` 未指定は
+/// `CliError::NonInteractiveRemove` で Fail Fast されて UseCase 到達前に return する。
+///
+/// 設計根拠: docs/features/cli-vault-commands/basic-design/error.md
+/// §確認強制の型レベル実装
+#[derive(Debug)]
+pub struct ConfirmedRemoveInput {
+    id: RecordId,
+}
+
+impl ConfirmedRemoveInput {
+    /// 確認経路を経たことを呼び出し側責任で宣言しながら入力を構築する。
+    #[must_use]
+    pub fn new(id: RecordId) -> Self {
+        Self { id }
+    }
+
+    /// 内包する `RecordId` への参照を返す。
+    #[must_use]
+    pub fn id(&self) -> &RecordId {
+        &self.id
+    }
+}
+
+// -------------------------------------------------------------------
+// テスト
+// -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::RecordId;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_confirmed_remove_input_new_constructs_from_record_id() {
+        let id = RecordId::new(Uuid::now_v7()).unwrap();
+        let input = ConfirmedRemoveInput::new(id.clone());
+        assert_eq!(input.id(), &id);
+    }
+}

--- a/crates/shikomi-cli/src/io/mod.rs
+++ b/crates/shikomi-cli/src/io/mod.rs
@@ -1,0 +1,6 @@
+//! TTY / path 系の副作用を持つ IO ヘルパ。
+//!
+//! UseCase 層からは呼ばれず、`run()` が薄く wrap して呼び出す。
+
+pub mod paths;
+pub mod terminal;

--- a/crates/shikomi-cli/src/io/paths.rs
+++ b/crates/shikomi-cli/src/io/paths.rs
@@ -1,0 +1,42 @@
+//! OS デフォルトの vault dir を解決する薄いヘルパ。
+//!
+//! env 参照は clap attribute（`#[arg(env = "SHIKOMI_VAULT_DIR")]`）に一任し、
+//! 本モジュールでは `std::env::var` を呼ばない（真実源の二重化防止）。
+//!
+//! 設計根拠: docs/features/cli-vault-commands/detailed-design/public-api.md
+//! §`shikomi_cli::io::paths`、data-structures.md §env の真実源は clap のみ
+
+use std::path::PathBuf;
+
+use crate::error::CliError;
+
+/// OS データディレクトリ直下の `shikomi/` を返す。
+///
+/// env は見ない。`dirs::data_dir()` が `None` のとき `CliError::Persistence`
+/// （`CannotResolveVaultDir`）で Fail Fast。
+///
+/// # Errors
+/// `dirs::data_dir()` が `None` を返した場合、または `PersistenceError` 包み。
+pub fn resolve_os_default_vault_dir() -> Result<PathBuf, CliError> {
+    dirs::data_dir()
+        .ok_or_else(|| {
+            CliError::Persistence(
+                shikomi_infra::persistence::PersistenceError::CannotResolveVaultDir,
+            )
+        })
+        .map(|base| base.join("shikomi"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_os_default_vault_dir_returns_shikomi_subdir_when_data_dir_available() {
+        // dirs::data_dir() が Some を返す環境では Ok(PathBuf) を得る。
+        // 末尾が "shikomi" であることだけ検証（環境依存の親 path は検証しない）。
+        if let Ok(path) = resolve_os_default_vault_dir() {
+            assert_eq!(path.file_name().and_then(|s| s.to_str()), Some("shikomi"));
+        }
+    }
+}

--- a/crates/shikomi-cli/src/io/terminal.rs
+++ b/crates/shikomi-cli/src/io/terminal.rs
@@ -1,0 +1,52 @@
+//! TTY 判定 / 通常 readline / 非エコー入力。
+//!
+//! テスト差し替えのための trait 化は行わず（YAGNI）、関数ベースで薄く wrap する。
+//! 返却する秘密値は即座に `SecretString` で包み、平文 String が返値に漏れないようにする。
+
+use std::io::{self, BufRead, Write};
+
+use is_terminal::IsTerminal;
+use shikomi_core::SecretString;
+
+/// stdin が TTY 接続かどうかを返す。
+#[must_use]
+pub fn is_stdin_tty() -> bool {
+    std::io::stdin().is_terminal()
+}
+
+/// プロンプトを stdout に出し、stdin から 1 行読む。末尾の `\n` / `\r\n` を trim。
+///
+/// # Errors
+/// stdin / stdout の IO エラーを透過する。
+pub fn read_line(prompt: &str) -> io::Result<String> {
+    if !prompt.is_empty() {
+        let mut out = io::stdout().lock();
+        out.write_all(prompt.as_bytes())?;
+        out.flush()?;
+    }
+    let stdin = io::stdin();
+    let mut buf = String::new();
+    stdin.lock().read_line(&mut buf)?;
+    // 末尾改行の除去
+    if buf.ends_with('\n') {
+        buf.pop();
+        if buf.ends_with('\r') {
+            buf.pop();
+        }
+    }
+    Ok(buf)
+}
+
+/// 非エコー入力で Secret 値を得る（Unix: `termios` / Windows: `SetConsoleMode`）。
+///
+/// TTY でない場合 `rpassword` は通常 readline にフォールバックする。返り値は即座に
+/// `SecretString` に包んで返す。中間 String はスタックに短期間存在するが、`rpassword`
+/// の内部実装上 zeroize は保証しない（`docs/.../basic-design/security.md §依存 crate`
+/// の §1 参照）。
+///
+/// # Errors
+/// `rpassword::prompt_password` が返した IO エラーを透過する。
+pub fn read_password(prompt: &str) -> io::Result<SecretString> {
+    let raw = rpassword::prompt_password(prompt)?;
+    Ok(SecretString::from_string(raw))
+}

--- a/crates/shikomi-cli/src/lib.rs
+++ b/crates/shikomi-cli/src/lib.rs
@@ -1,0 +1,413 @@
+//! `shikomi_cli` — CLI 内部公開 API（lib target）。
+//!
+//! 本 crate は `[lib] + [[bin]]` の 2 ターゲット構成。lib の公開項目は全て
+//! `#[doc(hidden)]` で `cargo doc` から隠し、外部契約化しない（`publish = false`）。
+//! 結合テスト（`tests/`）からは通常通り参照可能（`#[doc(hidden)]` は可視性を制限しない）。
+//!
+//! 設計根拠: docs/features/cli-vault-commands/detailed-design/public-api.md
+//! §前提: crate 構成、composition-root.md §処理順序
+
+#[doc(hidden)]
+pub mod cli;
+#[doc(hidden)]
+pub mod error;
+#[doc(hidden)]
+pub mod input;
+#[doc(hidden)]
+pub mod io;
+#[doc(hidden)]
+pub mod presenter;
+#[doc(hidden)]
+pub mod usecase;
+#[doc(hidden)]
+pub mod view;
+
+pub use error::{CliError, ExitCode};
+
+use std::io::Write;
+use std::sync::OnceLock;
+
+use shikomi_infra::persistence::SqliteVaultRepository;
+use time::OffsetDateTime;
+
+use cli::{AddArgs, CliArgs, EditArgs, RemoveArgs, Subcommand};
+use input::{AddInput, ConfirmedRemoveInput, EditInput};
+use presenter::Locale;
+use shikomi_core::{RecordId, RecordKind, RecordLabel, SecretString};
+use shikomi_infra::persistence::VaultRepository;
+
+// -------------------------------------------------------------------
+// グローバル Locale キャッシュ（panic hook から参照される）
+// -------------------------------------------------------------------
+
+/// `run()` 起動時に 1 度だけ設定される Locale。
+///
+/// panic hook 内で `Locale` を参照するために用いる。`Locale` は `Copy + Clone` な
+/// 単純列挙のため、hook 内での副作用なし参照が成立する。
+///
+/// 設計根拠: docs/features/cli-vault-commands/basic-design/error.md §i18n 扱い、
+/// detailed-design/composition-root.md §`static LOCALE_CACHE: OnceLock<Locale>` の配置
+#[doc(hidden)]
+pub static LOCALE_CACHE: OnceLock<Locale> = OnceLock::new();
+
+// -------------------------------------------------------------------
+// panic hook（secret 漏洩経路の遮断）
+// -------------------------------------------------------------------
+
+/// Secret 混入リスクを避けるため、panic 情報を一切参照せず固定文言のみを
+/// stderr に出力する panic hook。
+///
+/// - `info.payload()` / `info.message()` / `info.location()` を参照しない（契約）
+/// - `tracing::*` マクロを呼ばない（契約）
+/// - `Locale` は `LOCALE_CACHE` から読取（未設定なら English にフォールバック）
+///
+/// 設計根拠: docs/features/cli-vault-commands/basic-design/security.md
+/// §panic hook と secret 漏洩経路の遮断
+// MSRV 1.80 のため `PanicInfo` を使用（`PanicHookInfo` は 1.81 stable）。
+// どちらも `info.payload()` / `info.message()` / `info.location()` を非参照とする契約は同じ。
+#[allow(deprecated)]
+fn panic_hook(_info: &std::panic::PanicInfo<'_>) {
+    let locale = LOCALE_CACHE.get().copied().unwrap_or(Locale::English);
+    let mut stderr = std::io::stderr().lock();
+    // 固定文言（MSG-CLI-109）。payload / message / location は一切参照しない。
+    let _ = writeln!(stderr, "error: internal bug");
+    let _ = writeln!(
+        stderr,
+        "hint: please report this issue to https://github.com/shikomi-dev/shikomi/issues"
+    );
+    if matches!(locale, Locale::JapaneseEn) {
+        let _ = writeln!(stderr, "error: 内部バグが発生しました");
+        let _ = writeln!(
+            stderr,
+            "hint: https://github.com/shikomi-dev/shikomi/issues に報告してください"
+        );
+    }
+}
+
+// -------------------------------------------------------------------
+// run() — コンポジションルート
+// -------------------------------------------------------------------
+
+/// CLI 全体のエントリ関数。
+///
+/// 処理順序（詳細設計 `composition-root.md §処理順序`）:
+/// 1. panic hook 登録
+/// 2. Locale 決定 + `LOCALE_CACHE` 格納
+/// 3. clap パース（失敗時は clap エラー扱い）
+/// 4. `tracing_subscriber` 初期化
+/// 5. Repository 構築（`--vault-dir` > env (clap attribute) > OS デフォルト）
+/// 6. サブコマンド分岐 → `run_*` 関数 → `Result<(), CliError>`
+/// 7. `Err` は `render_error` で stderr 出力 + `ExitCode::from(&err)` 写像
+#[must_use]
+pub fn run() -> ExitCode {
+    std::panic::set_hook(Box::new(panic_hook));
+
+    let locale = Locale::detect_from_env();
+    // set は初回のみ成功。テスト中の再入は無視してよい。
+    let _ = LOCALE_CACHE.set(locale);
+
+    let args = match CliArgs::try_parse() {
+        Ok(a) => a,
+        Err(e) => return handle_clap_error(e),
+    };
+
+    init_tracing(args.verbose);
+
+    let repo = match build_repo(args.vault_dir.as_deref()) {
+        Ok(r) => r,
+        Err(err) => return emit_error_and_exit(&err, locale),
+    };
+    let vault_dir = repo.paths().dir().to_path_buf();
+
+    let quiet = args.quiet;
+    let result = match args.subcommand {
+        Subcommand::List => run_list(&repo, &vault_dir, locale, quiet),
+        Subcommand::Add(a) => run_add(&repo, &a, &vault_dir, locale, quiet),
+        Subcommand::Edit(a) => run_edit(&repo, &a, &vault_dir, locale, quiet),
+        Subcommand::Remove(a) => run_remove(&repo, &a, &vault_dir, locale, quiet),
+    };
+
+    match result {
+        Ok(()) => ExitCode::Success,
+        Err(err) => emit_error_and_exit(&err, locale),
+    }
+}
+
+// -------------------------------------------------------------------
+// 補助関数
+// -------------------------------------------------------------------
+
+/// clap エラーを CLI 終了コード方針に合わせて整形する。
+///
+/// - `DisplayHelp` / `DisplayVersion` → stdout + exit 0
+/// - その他 usage 系 → stderr + exit 1（clap デフォルトの exit 2 を上書き）
+/// - `Io` / `Format` → stderr + exit 2
+fn handle_clap_error(err: clap::Error) -> ExitCode {
+    use clap::error::ErrorKind;
+    match err.kind() {
+        ErrorKind::DisplayHelp
+        | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        | ErrorKind::DisplayVersion => {
+            let _ = err.print();
+            ExitCode::Success
+        }
+        ErrorKind::Io | ErrorKind::Format => {
+            let _ = err.print();
+            ExitCode::SystemError
+        }
+        _ => {
+            let _ = err.print();
+            ExitCode::UserError
+        }
+    }
+}
+
+fn init_tracing(verbose: bool) {
+    use tracing_subscriber::EnvFilter;
+    let default = if verbose { "debug" } else { "info" };
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new(format!("shikomi_cli={default},shikomi_infra={default}"))
+    });
+    // 二重初期化はテスト等で起こり得るため、結果は握り潰す（try_init）
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init();
+}
+
+/// `--vault-dir` フラグ（clap attribute で env `SHIKOMI_VAULT_DIR` も吸収済み）があれば
+/// その path で、なければ OS デフォルトで Repository を構築する。
+fn build_repo(vault_dir: Option<&std::path::Path>) -> Result<SqliteVaultRepository, CliError> {
+    let path = match vault_dir {
+        Some(p) => p.to_path_buf(),
+        None => io::paths::resolve_os_default_vault_dir()?,
+    };
+    SqliteVaultRepository::from_directory(&path).map_err(CliError::from)
+}
+
+fn emit_error_and_exit(err: &CliError, locale: Locale) -> ExitCode {
+    let rendered = presenter::error::render_error(err, locale);
+    let mut stderr = std::io::stderr().lock();
+    let _ = stderr.write_all(rendered.as_bytes());
+    ExitCode::from(err)
+}
+
+// -------------------------------------------------------------------
+// サブコマンドごとの dispatcher
+// -------------------------------------------------------------------
+
+fn run_list(
+    repo: &dyn VaultRepository,
+    vault_dir: &std::path::Path,
+    locale: Locale,
+    quiet: bool,
+) -> Result<(), CliError> {
+    let views = usecase::list::list_records(repo, vault_dir)?;
+    if !quiet {
+        let rendered = presenter::list::render_list(&views, locale);
+        print_stdout(&rendered);
+    }
+    Ok(())
+}
+
+fn run_add(
+    repo: &dyn VaultRepository,
+    args: &AddArgs,
+    vault_dir: &std::path::Path,
+    locale: Locale,
+    quiet: bool,
+) -> Result<(), CliError> {
+    // 値指定フラグの相互排他検証（Fail Fast）
+    let value = resolve_secret_value(args.value.as_deref(), args.stdin, args.kind.into())?;
+
+    // shell 履歴警告: `--kind secret && --value` 指定時
+    if matches!(args.kind, cli::KindArg::Secret) && args.value.is_some() {
+        let warning = presenter::warning::render_shell_history_warning(locale);
+        eprint_stderr(&warning);
+    }
+
+    let label = RecordLabel::try_new(args.label.clone()).map_err(CliError::InvalidLabel)?;
+
+    let input = AddInput {
+        kind: args.kind.into(),
+        label,
+        value,
+    };
+
+    let initially_existed = repo.exists().map_err(CliError::from)?;
+
+    let now = OffsetDateTime::now_utc();
+    let id = usecase::add::add_record(repo, input, now)?;
+
+    if !quiet {
+        if !initially_existed {
+            let init_msg = presenter::success::render_initialized_vault(vault_dir, locale);
+            print_stdout(&init_msg);
+        }
+        let added = presenter::success::render_added(&id, locale);
+        print_stdout(&added);
+    }
+    Ok(())
+}
+
+fn run_edit(
+    repo: &dyn VaultRepository,
+    args: &EditArgs,
+    vault_dir: &std::path::Path,
+    locale: Locale,
+    quiet: bool,
+) -> Result<(), CliError> {
+    // 「最低 1 つの更新フラグ必須」検証
+    if args.label.is_none() && args.value.is_none() && !args.stdin {
+        return Err(CliError::UsageError(
+            "at least one of --label/--value/--stdin is required".to_owned(),
+        ));
+    }
+
+    let id = RecordId::try_from_str(&args.id).map_err(CliError::InvalidId)?;
+
+    let label = match args.label.as_ref() {
+        Some(s) => Some(RecordLabel::try_new(s.clone()).map_err(CliError::InvalidLabel)?),
+        None => None,
+    };
+
+    // value の取得。`--value` と `--stdin` の相互排他も `resolve_*` 側でチェック。
+    // edit では kind 非指定のため、非エコー入力（secret 用）は選ばない（通常 readline）。
+    let value = if args.value.is_some() || args.stdin {
+        Some(resolve_secret_value(
+            args.value.as_deref(),
+            args.stdin,
+            // edit では既存 kind が不明なので Text 扱い（非エコーしない）で統一
+            RecordKind::Text,
+        )?)
+    } else {
+        None
+    };
+
+    // shell 履歴警告は add と同条件（`--value` かつ Secret kind）で判定できないため、edit では警告しない
+    // （既存 kind を load する副作用を避ける方針、composition-root.md §run_edit）
+    let _ = locale; // 将来警告追加時に利用
+
+    let input = EditInput {
+        id: id.clone(),
+        label,
+        value,
+    };
+
+    let now = OffsetDateTime::now_utc();
+    let id = usecase::edit::edit_record(repo, input, now, vault_dir)?;
+
+    if !quiet {
+        let rendered = presenter::success::render_updated(&id, locale);
+        print_stdout(&rendered);
+    }
+    Ok(())
+}
+
+fn run_remove(
+    repo: &dyn VaultRepository,
+    args: &RemoveArgs,
+    vault_dir: &std::path::Path,
+    locale: Locale,
+    quiet: bool,
+) -> Result<(), CliError> {
+    let id = RecordId::try_from_str(&args.id).map_err(CliError::InvalidId)?;
+
+    let confirmed = if args.yes {
+        true
+    } else if io::terminal::is_stdin_tty() {
+        // プロンプト表示用の label を取得するために load して find_record
+        let label = repo
+            .load()
+            .map_err(CliError::from)
+            .ok()
+            .and_then(|v| v.find_record(&id).map(|r| r.label().as_str().to_owned()));
+        let prompt = presenter::prompt::render_remove_prompt(&id, label.as_deref(), locale);
+        match io::terminal::read_line(&prompt) {
+            Ok(line) => matches!(line.trim(), "y" | "Y"),
+            Err(e) => {
+                return Err(CliError::Persistence(
+                    shikomi_infra::persistence::PersistenceError::Io {
+                        path: std::path::PathBuf::from("<stdin>"),
+                        source: e,
+                    },
+                ));
+            }
+        }
+    } else {
+        return Err(CliError::NonInteractiveRemove);
+    };
+
+    if !confirmed {
+        if !quiet {
+            print_stdout(&presenter::success::render_cancelled(locale));
+        }
+        return Ok(());
+    }
+
+    let input = ConfirmedRemoveInput::new(id);
+    let id = usecase::remove::remove_record(repo, input, vault_dir)?;
+
+    if !quiet {
+        print_stdout(&presenter::success::render_removed(&id, locale));
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------
+// 値取得ヘルパ
+// -------------------------------------------------------------------
+
+/// `--value` / `--stdin` の 4 パターンを評価して `SecretString` を得る。
+fn resolve_secret_value(
+    value: Option<&str>,
+    stdin: bool,
+    kind: RecordKind,
+) -> Result<SecretString, CliError> {
+    match (value, stdin) {
+        (Some(_), true) => Err(CliError::UsageError(
+            "--value and --stdin cannot be used together".to_owned(),
+        )),
+        (None, false) => Err(CliError::UsageError(
+            "either --value or --stdin is required".to_owned(),
+        )),
+        (Some(v), false) => Ok(SecretString::from_string(v.to_owned())),
+        (None, true) => read_value_from_stdin(kind),
+    }
+}
+
+fn read_value_from_stdin(kind: RecordKind) -> Result<SecretString, CliError> {
+    let buf = if matches!(kind, RecordKind::Secret) && io::terminal::is_stdin_tty() {
+        // 非エコー入力（Secret + TTY）
+        io::terminal::read_password("value: ").map_err(|e| {
+            CliError::Persistence(shikomi_infra::persistence::PersistenceError::Io {
+                path: std::path::PathBuf::from("<stdin>"),
+                source: e,
+            })
+        })?
+    } else {
+        // 通常 readline。末尾 \n / \r を trim。
+        let line = io::terminal::read_line("").map_err(|e| {
+            CliError::Persistence(shikomi_infra::persistence::PersistenceError::Io {
+                path: std::path::PathBuf::from("<stdin>"),
+                source: e,
+            })
+        })?;
+        SecretString::from_string(line)
+    };
+    Ok(buf)
+}
+
+// -------------------------------------------------------------------
+// I/O 薄ラッパ
+// -------------------------------------------------------------------
+
+fn print_stdout(s: &str) {
+    let mut out = std::io::stdout().lock();
+    let _ = out.write_all(s.as_bytes());
+}
+
+fn eprint_stderr(s: &str) {
+    let mut err = std::io::stderr().lock();
+    let _ = err.write_all(s.as_bytes());
+}

--- a/crates/shikomi-cli/src/lib.rs
+++ b/crates/shikomi-cli/src/lib.rs
@@ -271,22 +271,48 @@ fn run_edit(
         None => None,
     };
 
-    // value の取得。`--value` と `--stdin` の相互排他も `resolve_*` 側でチェック。
-    // edit では kind 非指定のため、非エコー入力（secret 用）は選ばない（通常 readline）。
-    let value = if args.value.is_some() || args.stdin {
+    // 既存 kind を事前 load で取得（value 入力時の非エコー判定 + shell 履歴警告に使う）。
+    // 設計書 composition-root.md §run_edit L59-62: 「値取得は run_add と同様（kind に応じて
+    // `read_password` / `read_line`）」「警告判定は load 後の既存 kind と照合するかは実装時判断」
+    // ここでは load 2 回を許容して既存 kind を参照する（run_remove と同方針、ペテルギウス指摘
+    // ①への対応）。load 失敗は Fail Fast（`?` でユーザに伝搬）。
+    let needs_value_input = args.value.is_some() || args.stdin;
+    let existing_kind = if needs_value_input {
+        if !repo.exists()? {
+            return Err(CliError::VaultNotInitialized(vault_dir.to_path_buf()));
+        }
+        let vault = repo.load()?;
+        if vault.protection_mode() == shikomi_core::ProtectionMode::Encrypted {
+            return Err(CliError::EncryptionUnsupported);
+        }
+        Some(
+            vault
+                .find_record(&id)
+                .map(shikomi_core::Record::kind)
+                .ok_or_else(|| CliError::RecordNotFound(id.clone()))?,
+        )
+    } else {
+        None
+    };
+
+    let value = if needs_value_input {
+        // 既存が Secret ならエコーしない、Text なら通常 readline。
+        // `--value` と `--stdin` の相互排他は resolve_secret_value 側で検出。
+        let kind_for_input = existing_kind.unwrap_or(RecordKind::Text);
         Some(resolve_secret_value(
             args.value.as_deref(),
             args.stdin,
-            // edit では既存 kind が不明なので Text 扱い（非エコーしない）で統一
-            RecordKind::Text,
+            kind_for_input,
         )?)
     } else {
         None
     };
 
-    // shell 履歴警告は add と同条件（`--value` かつ Secret kind）で判定できないため、edit では警告しない
-    // （既存 kind を load する副作用を避ける方針、composition-root.md §run_edit）
-    let _ = locale; // 将来警告追加時に利用
+    // shell 履歴警告: 既存 kind が Secret で `--value` 直接指定（= shell 履歴残留リスク）なら警告
+    if matches!(existing_kind, Some(RecordKind::Secret)) && args.value.is_some() {
+        let warning = presenter::warning::render_shell_history_warning(locale);
+        eprint_stderr(&warning);
+    }
 
     let input = EditInput {
         id: id.clone(),
@@ -316,12 +342,19 @@ fn run_remove(
     let confirmed = if args.yes {
         true
     } else if io::terminal::is_stdin_tty() {
-        // プロンプト表示用の label を取得するために load して find_record
-        let label = repo
-            .load()
-            .map_err(CliError::from)
-            .ok()
-            .and_then(|v| v.find_record(&id).map(|r| r.label().as_str().to_owned()));
+        // プロンプト表示用の label を取得するために load して find_record。
+        // load 失敗は Fail Fast で return（`.ok()` で握り潰さない — ペテルギウス指摘②）。
+        // これによりユーザは「load に失敗したのに y を押してしまう」欺き構造を踏まない。
+        if !repo.exists()? {
+            return Err(CliError::VaultNotInitialized(vault_dir.to_path_buf()));
+        }
+        let vault = repo.load()?;
+        if vault.protection_mode() == shikomi_core::ProtectionMode::Encrypted {
+            return Err(CliError::EncryptionUnsupported);
+        }
+        let label = vault
+            .find_record(&id)
+            .map(|r| r.label().as_str().to_owned());
         let prompt = presenter::prompt::render_remove_prompt(&id, label.as_deref(), locale);
         match io::terminal::read_line(&prompt) {
             Ok(line) => matches!(line.trim(), "y" | "Y"),

--- a/crates/shikomi-cli/src/main.rs
+++ b/crates/shikomi-cli/src/main.rs
@@ -1,3 +1,13 @@
-//! shikomi-cli — CLIエントリポイント
+//! shikomi CLI バイナリエントリポイント。
+//!
+//! コンポジションルート本体は `shikomi_cli::run()` にある。本 main 関数は
+//! プロセス起動 → `run()` 呼び出し → 終了コード返却のみを担う（3 行ラッパ）。
+//!
+//! 設計根拠: docs/features/cli-vault-commands/detailed-design/composition-root.md
+//! §`run()` の外側（`main.rs`）
 
-fn main() {}
+use shikomi_cli::ExitCode;
+
+fn main() -> ExitCode {
+    shikomi_cli::run()
+}

--- a/crates/shikomi-cli/src/presenter/error.rs
+++ b/crates/shikomi-cli/src/presenter/error.rs
@@ -11,7 +11,10 @@ use super::Locale;
 /// `CliError` を 2 行（English）または 4 行（JapaneseEn）形式で整形する。
 #[must_use]
 pub fn render_error(err: &CliError, locale: Locale) -> String {
-    let (error_en, hint_en, error_ja, hint_ja) = lines_for(err);
+    // `lines_for` の戻り値は `(error 英, error 日, hint 英, hint 日)` 順。
+    // 変数束縛もこの順に揃える（以前は `(error_en, hint_en, error_ja, hint_ja)` と
+    // 入れ替えてしまい、LANG=C 環境の hint 行に日本語が漏れていた — BUG-002）。
+    let (error_en, error_ja, hint_en, hint_ja) = lines_for(err);
     let mut out = format!("error: {error_en}\n");
     if matches!(locale, Locale::JapaneseEn) {
         out.push_str(&format!("error: {error_ja}\n"));
@@ -164,5 +167,20 @@ mod tests {
     fn test_render_error_non_interactive_remove_mentions_yes() {
         let out = render_error(&CliError::NonInteractiveRemove, Locale::English);
         assert!(out.contains("--yes"));
+    }
+
+    /// BUG-002 回帰: English モードの出力には日本語文字を一切含まないこと。
+    /// 以前は `lines_for` の戻り値と受取側変数の順序がずれており hint 行に
+    /// 日本語カタログが漏出していた。
+    #[test]
+    fn test_render_error_english_mode_never_contains_japanese() {
+        let err = CliError::InvalidLabel(DomainError::InvalidRecordLabel(
+            InvalidRecordLabelReason::Empty,
+        ));
+        let out = render_error(&err, Locale::English);
+        assert!(
+            out.is_ascii() || out.chars().all(|c| c.is_ascii() || c == '…'),
+            "English render_error should be ASCII-only, got: {out:?}"
+        );
     }
 }

--- a/crates/shikomi-cli/src/presenter/error.rs
+++ b/crates/shikomi-cli/src/presenter/error.rs
@@ -1,0 +1,168 @@
+//! `CliError` を `MSG-CLI-100〜109` 仕様に則って stderr 用文字列に整形する。
+//!
+//! Presenter は pure。出力（stderr への書き出し）は `run()` の責務。
+
+use shikomi_infra::persistence::PersistenceError;
+
+use crate::error::CliError;
+
+use super::Locale;
+
+/// `CliError` を 2 行（English）または 4 行（JapaneseEn）形式で整形する。
+#[must_use]
+pub fn render_error(err: &CliError, locale: Locale) -> String {
+    let (error_en, hint_en, error_ja, hint_ja) = lines_for(err);
+    let mut out = format!("error: {error_en}\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!("error: {error_ja}\n"));
+    }
+    out.push_str(&format!("hint: {hint_en}\n"));
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!("hint: {hint_ja}\n"));
+    }
+    out
+}
+
+/// 4 段（error 英 / error 日 / hint 英 / hint 日）を返す。
+fn lines_for(err: &CliError) -> (String, String, String, String) {
+    match err {
+        CliError::UsageError(msg) => (
+            msg.clone(),
+            usage_error_ja(msg),
+            "choose one, or see --help".to_owned(),
+            "どちらか一方を指定するか --help を参照してください".to_owned(),
+        ),
+        CliError::InvalidLabel(domain) => (
+            format!("invalid label: {domain}"),
+            format!("不正なラベル: {domain}"),
+            "labels must be non-empty and at most 255 graphemes; control chars except \\t\\n\\r are not allowed"
+                .to_owned(),
+            "ラベルは 1 文字以上 255 grapheme 以下で、\\t\\n\\r 以外の制御文字は禁止です".to_owned(),
+        ),
+        CliError::InvalidId(domain) => (
+            format!("invalid record id: {domain}"),
+            format!("不正なレコード ID: {domain}"),
+            "use the uuid shown by \"shikomi list\"".to_owned(),
+            "\"shikomi list\" で表示された UUID を指定してください".to_owned(),
+        ),
+        CliError::RecordNotFound(id) => (
+            format!("record not found: {id}"),
+            format!("レコードが見つかりません: {id}"),
+            "check with \"shikomi list\"".to_owned(),
+            "\"shikomi list\" で確認してください".to_owned(),
+        ),
+        CliError::VaultNotInitialized(path) => (
+            format!("vault not initialized at {}", path.display()),
+            format!("vault が初期化されていません: {}", path.display()),
+            "run \"shikomi add\" to create a plaintext vault".to_owned(),
+            "\"shikomi add\" で平文 vault を初期化できます".to_owned(),
+        ),
+        CliError::NonInteractiveRemove => (
+            "refusing to delete without --yes in non-interactive mode".to_owned(),
+            "非対話モードでは --yes なしの削除を拒否します".to_owned(),
+            "re-run with --yes to confirm deletion".to_owned(),
+            "削除を確認するには --yes を付けて再実行してください".to_owned(),
+        ),
+        CliError::Persistence(pe) => render_persistence_lines(pe),
+        CliError::Domain(domain) => (
+            format!("internal bug: {domain}"),
+            format!("内部バグ: {domain}"),
+            "please report this issue to https://github.com/shikomi-dev/shikomi/issues".to_owned(),
+            "https://github.com/shikomi-dev/shikomi/issues に報告してください".to_owned(),
+        ),
+        CliError::EncryptionUnsupported => (
+            "this vault is encrypted; encryption is not yet supported in this CLI version"
+                .to_owned(),
+            "この vault は暗号化されています。本バージョンの CLI は暗号化モード未対応です"
+                .to_owned(),
+            "future \"shikomi vault decrypt\" will convert it; for now, use a plaintext vault"
+                .to_owned(),
+            "将来の \"shikomi vault decrypt\" で変換可能になります。暫定的には平文 vault をご利用ください"
+                .to_owned(),
+        ),
+    }
+}
+
+/// usage error の日本語文は機械訳ではなく代表的な英語メッセージをカタログ引きする。
+/// カタログに無い場合は英文をそのまま返す（secret を含まない前提）。
+fn usage_error_ja(msg: &str) -> String {
+    match msg {
+        "--value and --stdin cannot be used together" => {
+            "--value と --stdin は同時に使えません".to_owned()
+        }
+        "either --value or --stdin is required" => {
+            "--value または --stdin のどちらかが必要です".to_owned()
+        }
+        "at least one of --label/--value/--stdin is required" => {
+            "--label / --value / --stdin のいずれかを指定してください".to_owned()
+        }
+        other => other.to_owned(),
+    }
+}
+
+fn render_persistence_lines(pe: &PersistenceError) -> (String, String, String, String) {
+    match pe {
+        PersistenceError::Corrupted { .. } => (
+            format!("vault is corrupted: {pe}"),
+            format!("vault が破損しています: {pe}"),
+            "restore from backup or start a new vault".to_owned(),
+            "バックアップから復元するか、新規 vault を作成してください".to_owned(),
+        ),
+        _ => (
+            format!("failed to access vault: {pe}"),
+            format!("vault へのアクセスに失敗しました: {pe}"),
+            "check permissions and re-run".to_owned(),
+            "パーミッションを確認して再実行してください".to_owned(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::error::InvalidRecordLabelReason;
+    use shikomi_core::DomainError;
+
+    #[test]
+    fn test_render_error_english_has_two_lines_for_usage_error() {
+        let err = CliError::UsageError("--value and --stdin cannot be used together".to_owned());
+        let out = render_error(&err, Locale::English);
+        let count = out.matches('\n').count();
+        assert_eq!(
+            count, 2,
+            "English render_error should be 2 lines, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn test_render_error_japanese_en_has_four_lines() {
+        let err = CliError::UsageError("--value and --stdin cannot be used together".to_owned());
+        let out = render_error(&err, Locale::JapaneseEn);
+        let count = out.matches('\n').count();
+        assert_eq!(
+            count, 4,
+            "JapaneseEn render_error should be 4 lines, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn test_render_error_invalid_label_contains_label_keyword() {
+        let err = CliError::InvalidLabel(DomainError::InvalidRecordLabel(
+            InvalidRecordLabelReason::Empty,
+        ));
+        let out = render_error(&err, Locale::English);
+        assert!(out.contains("invalid label"));
+    }
+
+    #[test]
+    fn test_render_error_encryption_unsupported_mentions_encryption() {
+        let out = render_error(&CliError::EncryptionUnsupported, Locale::English);
+        assert!(out.contains("encrypted"));
+    }
+
+    #[test]
+    fn test_render_error_non_interactive_remove_mentions_yes() {
+        let out = render_error(&CliError::NonInteractiveRemove, Locale::English);
+        assert!(out.contains("--yes"));
+    }
+}

--- a/crates/shikomi-cli/src/presenter/list.rs
+++ b/crates/shikomi-cli/src/presenter/list.rs
@@ -1,0 +1,174 @@
+//! `list` の表出力整形。
+//!
+//! 設計根拠: docs/features/cli-vault-commands/detailed-design/public-api.md
+//! §`shikomi_cli::presenter::list`
+//!
+//! - ID カラムは UUIDv7 全長 36 文字（トランケートしない、
+//!   basic-design/index.md §UX設計 の案 A 採用）
+//! - label / value は 40 char で切り詰め。超過時に `…` を付与
+
+use super::Locale;
+use crate::view::{RecordView, ValueView, LIST_VALUE_PREVIEW_MAX};
+
+const ID_WIDTH: usize = 36;
+const KIND_WIDTH: usize = 6;
+const LABEL_WIDTH: usize = 40;
+const TRUNCATION_SUFFIX: &str = "…";
+const MASKED_STR: &str = "****";
+
+/// `list` 結果を表形式に整形する。
+#[must_use]
+pub fn render_list(views: &[RecordView], locale: Locale) -> String {
+    if views.is_empty() {
+        return render_empty(locale);
+    }
+
+    let mut out = String::new();
+    // ヘッダ
+    out.push_str(&format!(
+        "{:<id$}  {:<kind$}  {:<label$}  VALUE\n",
+        "ID",
+        "KIND",
+        "LABEL",
+        id = ID_WIDTH,
+        kind = KIND_WIDTH,
+        label = LABEL_WIDTH,
+    ));
+    out.push_str(&format!(
+        "{:<id$}  {:<kind$}  {:<label$}  -----\n",
+        "--",
+        "----",
+        "-----",
+        id = ID_WIDTH,
+        kind = KIND_WIDTH,
+        label = LABEL_WIDTH,
+    ));
+
+    for view in views {
+        let kind = kind_str(view);
+        let label = truncate_chars(view.label.as_str(), LABEL_WIDTH);
+        let value = match &view.value {
+            ValueView::Masked => MASKED_STR.to_owned(),
+            ValueView::Plain(s) => truncate_chars(s, LIST_VALUE_PREVIEW_MAX),
+        };
+        out.push_str(&format!(
+            "{:<id$}  {:<kind$}  {:<label$}  {}\n",
+            view.id,
+            kind,
+            label,
+            value,
+            id = ID_WIDTH,
+            kind = KIND_WIDTH,
+            label = LABEL_WIDTH,
+        ));
+    }
+    out
+}
+
+/// 空 vault の出力。
+#[must_use]
+pub fn render_empty(locale: Locale) -> String {
+    let mut out = String::from("no records\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str("レコードはありません\n");
+    }
+    out
+}
+
+fn kind_str(view: &RecordView) -> &'static str {
+    match view.kind {
+        shikomi_core::RecordKind::Text => "text",
+        shikomi_core::RecordKind::Secret => "secret",
+    }
+}
+
+/// char 単位で `max` まで切り詰める。超過した場合は末尾に `…` を付ける（そのぶん 1 char 減らす）。
+fn truncate_chars(s: &str, max: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count <= max {
+        return s.to_owned();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    let taken: String = s.chars().take(max.saturating_sub(1)).collect();
+    format!("{taken}{TRUNCATION_SUFFIX}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::{Record, RecordId, RecordKind, RecordLabel, RecordPayload, SecretString};
+    use time::OffsetDateTime;
+    use uuid::Uuid;
+
+    fn make_record(kind: RecordKind, label: &str, value: &str) -> Record {
+        Record::new(
+            RecordId::new(Uuid::now_v7()).unwrap(),
+            kind,
+            RecordLabel::try_new(label.to_owned()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string(value.to_owned())),
+            OffsetDateTime::UNIX_EPOCH,
+        )
+    }
+
+    #[test]
+    fn test_render_empty_english() {
+        assert_eq!(render_empty(Locale::English), "no records\n");
+    }
+
+    #[test]
+    fn test_render_list_empty_falls_back_to_render_empty() {
+        assert_eq!(render_list(&[], Locale::English), "no records\n");
+    }
+
+    #[test]
+    fn test_render_list_single_secret_value_is_masked() {
+        let rec = make_record(RecordKind::Secret, "pw", "SUPER-SECRET-VALUE");
+        let view = RecordView::from_record(&rec);
+        let rendered = render_list(&[view], Locale::English);
+        assert!(rendered.contains("secret"));
+        assert!(rendered.contains("****"));
+        assert!(!rendered.contains("SUPER-SECRET-VALUE"));
+    }
+
+    #[test]
+    fn test_render_list_text_value_rendered_verbatim_when_short() {
+        let rec = make_record(RecordKind::Text, "url", "https://x");
+        let view = RecordView::from_record(&rec);
+        let rendered = render_list(&[view], Locale::English);
+        assert!(rendered.contains("https://x"));
+    }
+
+    #[test]
+    fn test_render_list_id_column_width_is_full_uuid_length() {
+        let rec = make_record(RecordKind::Text, "l", "v");
+        let uuid_len = rec.id().to_string().chars().count();
+        assert_eq!(uuid_len, 36, "UUIDv7 display should be 36 chars");
+        let view = RecordView::from_record(&rec);
+        let rendered = render_list(&[view], Locale::English);
+        // 出力にそのまま 36 文字 UUID が含まれ、トランケートされていないこと
+        assert!(rendered.contains(&rec.id().to_string()));
+    }
+
+    #[test]
+    fn test_truncate_chars_under_limit_returns_original() {
+        assert_eq!(truncate_chars("abc", 10), "abc");
+    }
+
+    #[test]
+    fn test_truncate_chars_over_limit_appends_ellipsis() {
+        let out = truncate_chars("abcdefghij", 5);
+        assert_eq!(out.chars().count(), 5);
+        assert!(out.ends_with(TRUNCATION_SUFFIX));
+    }
+
+    #[test]
+    fn test_render_list_label_exceeding_40_chars_is_truncated_with_ellipsis() {
+        let long_label = "a".repeat(60);
+        let rec = make_record(RecordKind::Text, &long_label, "v");
+        let view = RecordView::from_record(&rec);
+        let rendered = render_list(&[view], Locale::English);
+        assert!(rendered.contains(TRUNCATION_SUFFIX));
+    }
+}

--- a/crates/shikomi-cli/src/presenter/mod.rs
+++ b/crates/shikomi-cli/src/presenter/mod.rs
@@ -1,0 +1,102 @@
+//! 出力整形層（pure function、副作用なし）。
+//!
+//! `Locale` を明示引数で受け取る Dependency Injection 形式。`std::env::var("LANG")` を
+//! presenter 内部で呼ばない（テスト再現性維持、`run()` 起動時に 1 度だけ `detect_from_env`）。
+
+pub mod error;
+pub mod list;
+pub mod prompt;
+pub mod success;
+pub mod warning;
+
+// -------------------------------------------------------------------
+// Locale
+// -------------------------------------------------------------------
+
+/// i18n ロケール。`LANG` 環境変数の先頭 2 文字を大文字小文字無視で判定する。
+///
+/// 設計根拠: docs/features/cli-vault-commands/detailed-design/data-structures.md
+/// §`Locale` 検出ルール
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Locale {
+    /// 英語のみ（`LANG=C` / `en_*` / 未設定 / 空）
+    English,
+    /// 英語 + 日本語併記（`LANG=ja_*` / `ja` / `JA_*`）
+    JapaneseEn,
+}
+
+impl Locale {
+    /// `LANG` 環境変数から Locale を決定する（副作用あり、`run()` 起動時に 1 度だけ呼ぶ）。
+    #[must_use]
+    pub fn detect_from_env() -> Self {
+        let raw = std::env::var("LANG").ok();
+        Self::detect_from_lang_env_value(raw.as_deref())
+    }
+
+    /// pure 版：`LANG` の値（`Option<&str>`）から Locale を決定する。
+    #[must_use]
+    pub fn detect_from_lang_env_value(value: Option<&str>) -> Self {
+        match value {
+            Some(s) if s.len() >= 2 && s[..2].eq_ignore_ascii_case("ja") => Self::JapaneseEn,
+            _ => Self::English,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_from_lang_env_value_ja_jp_utf8_maps_to_japanese_en() {
+        assert_eq!(
+            Locale::detect_from_lang_env_value(Some("ja_JP.UTF-8")),
+            Locale::JapaneseEn
+        );
+    }
+
+    #[test]
+    fn test_detect_from_lang_env_value_ja_short_maps_to_japanese_en() {
+        assert_eq!(
+            Locale::detect_from_lang_env_value(Some("ja")),
+            Locale::JapaneseEn
+        );
+    }
+
+    #[test]
+    fn test_detect_from_lang_env_value_upper_ja_maps_to_japanese_en() {
+        assert_eq!(
+            Locale::detect_from_lang_env_value(Some("JA_JP")),
+            Locale::JapaneseEn
+        );
+    }
+
+    #[test]
+    fn test_detect_from_lang_env_value_en_us_maps_to_english() {
+        assert_eq!(
+            Locale::detect_from_lang_env_value(Some("en_US.UTF-8")),
+            Locale::English
+        );
+    }
+
+    #[test]
+    fn test_detect_from_lang_env_value_c_locale_maps_to_english() {
+        assert_eq!(
+            Locale::detect_from_lang_env_value(Some("C")),
+            Locale::English
+        );
+    }
+
+    #[test]
+    fn test_detect_from_lang_env_value_none_maps_to_english() {
+        assert_eq!(Locale::detect_from_lang_env_value(None), Locale::English);
+    }
+
+    #[test]
+    fn test_detect_from_lang_env_value_empty_maps_to_english() {
+        assert_eq!(
+            Locale::detect_from_lang_env_value(Some("")),
+            Locale::English
+        );
+    }
+}

--- a/crates/shikomi-cli/src/presenter/prompt.rs
+++ b/crates/shikomi-cli/src/presenter/prompt.rs
@@ -1,0 +1,38 @@
+//! 対話プロンプト文言。`remove` の確認プロンプトに使う。
+
+use shikomi_core::RecordId;
+
+use super::Locale;
+
+/// `remove` の確認プロンプト文字列を返す（改行は含まない。readline 側で stdin からの入力を継承）。
+#[must_use]
+pub fn render_remove_prompt(id: &RecordId, label: Option<&str>, locale: Locale) -> String {
+    let label_display = label.unwrap_or("<unknown>");
+    match locale {
+        Locale::English => format!("Delete record {id} ({label_display})? [y/N]: "),
+        Locale::JapaneseEn => {
+            format!("レコード {id} ({label_display}) を削除しますか? [y/N]: ")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_render_remove_prompt_english_contains_delete_record() {
+        let id = RecordId::new(Uuid::now_v7()).unwrap();
+        let prompt = render_remove_prompt(&id, Some("label"), Locale::English);
+        assert!(prompt.starts_with("Delete record "));
+        assert!(prompt.contains("(label)"));
+    }
+
+    #[test]
+    fn test_render_remove_prompt_japanese_en_contains_japanese_text() {
+        let id = RecordId::new(Uuid::now_v7()).unwrap();
+        let prompt = render_remove_prompt(&id, Some("lbl"), Locale::JapaneseEn);
+        assert!(prompt.contains("削除しますか"));
+    }
+}

--- a/crates/shikomi-cli/src/presenter/success.rs
+++ b/crates/shikomi-cli/src/presenter/success.rs
@@ -1,0 +1,89 @@
+//! 成功時の stdout メッセージ整形。
+//!
+//! MSG-CLI-001〜005 に対応。pure function、`String` を返すのみ。
+
+use std::path::Path;
+
+use shikomi_core::RecordId;
+
+use super::Locale;
+
+/// `added: {id}` / `追加しました: {id}` を改行付きで返す。
+#[must_use]
+pub fn render_added(id: &RecordId, locale: Locale) -> String {
+    let mut out = format!("added: {id}\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!("追加しました: {id}\n"));
+    }
+    out
+}
+
+/// `updated: {id}` / `更新しました: {id}` を返す。
+#[must_use]
+pub fn render_updated(id: &RecordId, locale: Locale) -> String {
+    let mut out = format!("updated: {id}\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!("更新しました: {id}\n"));
+    }
+    out
+}
+
+/// `removed: {id}` / `削除しました: {id}` を返す。
+#[must_use]
+pub fn render_removed(id: &RecordId, locale: Locale) -> String {
+    let mut out = format!("removed: {id}\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!("削除しました: {id}\n"));
+    }
+    out
+}
+
+/// `cancelled` / `キャンセルしました` を返す。
+#[must_use]
+pub fn render_cancelled(locale: Locale) -> String {
+    let mut out = String::from("cancelled\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str("キャンセルしました\n");
+    }
+    out
+}
+
+/// `initialized plaintext vault at {path}` / `平文 vault を {path} に初期化しました` を返す。
+#[must_use]
+pub fn render_initialized_vault(path: &Path, locale: Locale) -> String {
+    let path_str = path.display();
+    let mut out = format!("initialized plaintext vault at {path_str}\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!("平文 vault を {path_str} に初期化しました\n"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn id() -> RecordId {
+        RecordId::new(Uuid::now_v7()).unwrap()
+    }
+
+    #[test]
+    fn test_render_added_english_single_line() {
+        let rendered = render_added(&id(), Locale::English);
+        assert!(rendered.starts_with("added: "));
+        assert!(!rendered.contains("追加"));
+    }
+
+    #[test]
+    fn test_render_added_japanese_en_two_lines() {
+        let rendered = render_added(&id(), Locale::JapaneseEn);
+        assert!(rendered.contains("added: "));
+        assert!(rendered.contains("追加しました: "));
+    }
+
+    #[test]
+    fn test_render_cancelled_english() {
+        assert_eq!(render_cancelled(Locale::English), "cancelled\n");
+    }
+}

--- a/crates/shikomi-cli/src/presenter/warning.rs
+++ b/crates/shikomi-cli/src/presenter/warning.rs
@@ -1,0 +1,36 @@
+//! 警告メッセージ（stderr）。MSG-CLI-050。
+
+use super::Locale;
+
+/// `--value` 経由の secret 入力が shell 履歴に残る可能性を警告する。
+#[must_use]
+pub fn render_shell_history_warning(locale: Locale) -> String {
+    let mut out = String::from(
+        "warning: '--value' for a secret leaks into shell history; prefer '--stdin'\n",
+    );
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(
+            "警告: secret を --value で渡すと shell 履歴に残ります。--stdin を推奨します\n",
+        );
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_shell_history_warning_english_contains_stdin_hint() {
+        let rendered = render_shell_history_warning(Locale::English);
+        assert!(rendered.contains("--stdin"));
+        assert!(!rendered.contains("警告"));
+    }
+
+    #[test]
+    fn test_render_shell_history_warning_japanese_en_contains_both() {
+        let rendered = render_shell_history_warning(Locale::JapaneseEn);
+        assert!(rendered.contains("--stdin"));
+        assert!(rendered.contains("警告"));
+    }
+}

--- a/crates/shikomi-cli/src/usecase/add.rs
+++ b/crates/shikomi-cli/src/usecase/add.rs
@@ -1,0 +1,47 @@
+//! `add` UseCase — 新規レコードを追加する。vault 未作成なら平文 vault を初期化。
+
+use shikomi_core::{
+    ProtectionMode, Record, RecordId, RecordPayload, Vault, VaultHeader, VaultVersion,
+};
+use shikomi_infra::persistence::VaultRepository;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::error::CliError;
+use crate::input::AddInput;
+
+/// 新規レコードを vault に追加する。vault 未作成なら平文モードで自動作成。
+///
+/// `now` は呼び出し側（`run()`）で `OffsetDateTime::now_utc()` を評価して渡す
+/// （UseCase の純粋性維持のため）。
+///
+/// # Errors
+/// - 暗号化モード検出: `CliError::EncryptionUnsupported`
+/// - ドメイン整合性エラー（id 重複 / モード不一致等）: `CliError::Domain`
+/// - 永続化エラー: `CliError::Persistence`
+pub fn add_record(
+    repo: &dyn VaultRepository,
+    input: AddInput,
+    now: OffsetDateTime,
+) -> Result<RecordId, CliError> {
+    let mut vault = if repo.exists()? {
+        let loaded = repo.load()?;
+        if loaded.protection_mode() == ProtectionMode::Encrypted {
+            return Err(CliError::EncryptionUnsupported);
+        }
+        loaded
+    } else {
+        let header =
+            VaultHeader::new_plaintext(VaultVersion::CURRENT, now).map_err(CliError::Domain)?;
+        Vault::new(header)
+    };
+
+    let id = RecordId::new(Uuid::now_v7()).map_err(CliError::Domain)?;
+    let payload = RecordPayload::Plaintext(input.value);
+    let record = Record::new(id.clone(), input.kind, input.label, payload, now);
+
+    vault.add_record(record).map_err(CliError::Domain)?;
+    repo.save(&vault)?;
+
+    Ok(id)
+}

--- a/crates/shikomi-cli/src/usecase/edit.rs
+++ b/crates/shikomi-cli/src/usecase/edit.rs
@@ -1,0 +1,64 @@
+//! `edit` UseCase — 既存レコードの label / value を更新する。
+
+use std::path::Path;
+
+use shikomi_core::{DomainError, ProtectionMode, RecordId, RecordPayload, VaultConsistencyReason};
+use shikomi_infra::persistence::VaultRepository;
+use time::OffsetDateTime;
+
+use crate::error::CliError;
+use crate::input::EditInput;
+
+/// 既存レコードの `label` / `value` を更新する。少なくとも一方が `Some` である前提（`run` 側で検証）。
+///
+/// # Errors
+/// - vault 未作成: `CliError::VaultNotInitialized`
+/// - 暗号化モード検出: `CliError::EncryptionUnsupported`
+/// - 対象レコード不存在: `CliError::RecordNotFound`
+/// - ドメイン / 永続化エラー
+pub fn edit_record(
+    repo: &dyn VaultRepository,
+    input: EditInput,
+    now: OffsetDateTime,
+    vault_dir: &Path,
+) -> Result<RecordId, CliError> {
+    if !repo.exists()? {
+        return Err(CliError::VaultNotInitialized(vault_dir.to_path_buf()));
+    }
+    let mut vault = repo.load()?;
+    if vault.protection_mode() == ProtectionMode::Encrypted {
+        return Err(CliError::EncryptionUnsupported);
+    }
+
+    // 先に存在チェックして RecordNotFound を user error で返す（ドメイン側も同等検出するが、
+    // こちらで先に捕捉して CliError::RecordNotFound に写像する）。
+    if vault.find_record(&input.id).is_none() {
+        return Err(CliError::RecordNotFound(input.id));
+    }
+
+    let id_for_return = input.id.clone();
+    let EditInput { id, label, value } = input;
+    vault
+        .update_record(&id, |mut record| {
+            if let Some(new_label) = label {
+                record = record.with_updated_label(new_label, now)?;
+            }
+            if let Some(new_value) = value {
+                record = record.with_updated_payload(RecordPayload::Plaintext(new_value), now)?;
+            }
+            Ok(record)
+        })
+        .map_err(map_update_err)?;
+
+    repo.save(&vault)?;
+    Ok(id_for_return)
+}
+
+fn map_update_err(err: DomainError) -> CliError {
+    match err {
+        DomainError::VaultConsistencyError(VaultConsistencyReason::RecordNotFound(id)) => {
+            CliError::RecordNotFound(id)
+        }
+        other => CliError::Domain(other),
+    }
+}

--- a/crates/shikomi-cli/src/usecase/list.rs
+++ b/crates/shikomi-cli/src/usecase/list.rs
@@ -1,0 +1,36 @@
+//! `list` UseCase — vault 内の全レコードを `RecordView` 列として返す。
+
+use std::path::Path;
+
+use shikomi_core::ProtectionMode;
+use shikomi_infra::persistence::VaultRepository;
+
+use crate::error::CliError;
+use crate::view::RecordView;
+
+/// vault を読み取り、全レコードを `RecordView` に射影して返す。
+///
+/// `vault_dir` は `VaultNotInitialized` エラー文に埋め込む path（UseCase 純粋性維持のため
+/// 呼び出し側から注入、`&dyn VaultRepository` は path を公開しない設計）。
+///
+/// # Errors
+/// - vault 未作成: `CliError::VaultNotInitialized(vault_dir)`
+/// - 暗号化モード検出: `CliError::EncryptionUnsupported`
+/// - 永続化エラー: `CliError::Persistence`
+pub fn list_records(
+    repo: &dyn VaultRepository,
+    vault_dir: &Path,
+) -> Result<Vec<RecordView>, CliError> {
+    if !repo.exists()? {
+        return Err(CliError::VaultNotInitialized(vault_dir.to_path_buf()));
+    }
+    let vault = repo.load()?;
+    if vault.protection_mode() == ProtectionMode::Encrypted {
+        return Err(CliError::EncryptionUnsupported);
+    }
+    Ok(vault
+        .records()
+        .iter()
+        .map(RecordView::from_record)
+        .collect())
+}

--- a/crates/shikomi-cli/src/usecase/mod.rs
+++ b/crates/shikomi-cli/src/usecase/mod.rs
@@ -1,0 +1,13 @@
+//! UseCase 層。ドメイン操作の orchestration のみを担い、I/O・TTY・clap の知識を持たない。
+//!
+//! 各 UseCase は `&dyn VaultRepository` / 入力 DTO / `now: OffsetDateTime` を引数に取る
+//! pure に近い関数（実 Repository は I/O を持つが、UseCase 自身は副作用を持たない）。
+//! これにより UseCase 単位で固定時刻・モック Repository を使った結合テストが書ける。
+//!
+//! 設計根拠: docs/features/cli-vault-commands/basic-design/index.md
+//! §モジュール設計方針
+
+pub mod add;
+pub mod edit;
+pub mod list;
+pub mod remove;

--- a/crates/shikomi-cli/src/usecase/remove.rs
+++ b/crates/shikomi-cli/src/usecase/remove.rs
@@ -1,0 +1,45 @@
+//! `remove` UseCase — 確認済みレコードを削除する。
+
+use std::path::Path;
+
+use shikomi_core::{DomainError, ProtectionMode, RecordId, VaultConsistencyReason};
+use shikomi_infra::persistence::VaultRepository;
+
+use crate::error::CliError;
+use crate::input::ConfirmedRemoveInput;
+
+/// 事前確認経由の `ConfirmedRemoveInput` を受け取り、レコードを削除する。
+///
+/// `ConfirmedRemoveInput` は確認を経ない経路では構築できないため、UseCase 側での
+/// `debug_assert!` 等による再検証は不要（型で事前条件が強制される）。
+///
+/// # Errors
+/// - vault 未作成: `CliError::VaultNotInitialized`
+/// - 暗号化モード検出: `CliError::EncryptionUnsupported`
+/// - 対象レコード不存在: `CliError::RecordNotFound`
+/// - ドメイン / 永続化エラー
+pub fn remove_record(
+    repo: &dyn VaultRepository,
+    input: ConfirmedRemoveInput,
+    vault_dir: &Path,
+) -> Result<RecordId, CliError> {
+    if !repo.exists()? {
+        return Err(CliError::VaultNotInitialized(vault_dir.to_path_buf()));
+    }
+    let mut vault = repo.load()?;
+    if vault.protection_mode() == ProtectionMode::Encrypted {
+        return Err(CliError::EncryptionUnsupported);
+    }
+
+    let id = input.id().clone();
+    match vault.remove_record(&id) {
+        Ok(_) => {}
+        Err(DomainError::VaultConsistencyError(VaultConsistencyReason::RecordNotFound(bad_id))) => {
+            return Err(CliError::RecordNotFound(bad_id));
+        }
+        Err(other) => return Err(CliError::Domain(other)),
+    }
+
+    repo.save(&vault)?;
+    Ok(id)
+}

--- a/crates/shikomi-cli/src/view.rs
+++ b/crates/shikomi-cli/src/view.rs
@@ -1,0 +1,129 @@
+//! Presenter への出力 DTO。
+//!
+//! Record から射影する表示用ビュー。Secret kind は `ValueView::Masked` に変換し、
+//! Text kind は `shikomi_core::Record::text_preview` 経由で平文プレビュー文字列を取り出す。
+//! `shikomi-cli/src/` 内で secret 値を直接取り出す呼び出しを行わない契約を満たす
+//! ための委譲（CI grep 対象：シークレット経路監査）。
+//!
+//! 設計根拠: docs/features/cli-vault-commands/detailed-design/data-structures.md
+//! §`ValueView` の構築ルール、basic-design/security.md §シークレット経路監査
+
+use shikomi_core::{Record, RecordId, RecordKind, RecordLabel};
+
+/// `list` プレビューの最大文字数（char 単位）。
+pub const LIST_VALUE_PREVIEW_MAX: usize = 40;
+
+// -------------------------------------------------------------------
+// ValueView
+// -------------------------------------------------------------------
+
+/// レコード値の表示用ビュー。Secret は常にマスク、Text はプレビュー文字列を保持。
+#[derive(Debug, Clone)]
+pub enum ValueView {
+    /// Text レコードの平文プレビュー（先頭 `LIST_VALUE_PREVIEW_MAX` char）
+    Plain(String),
+    /// Secret レコード。マスク表示（`****`）に置き換えられる。
+    Masked,
+}
+
+// -------------------------------------------------------------------
+// RecordView
+// -------------------------------------------------------------------
+
+/// `list` 表示用の Record 射影。
+#[derive(Debug, Clone)]
+pub struct RecordView {
+    pub id: RecordId,
+    pub kind: RecordKind,
+    pub label: RecordLabel,
+    pub value: ValueView,
+}
+
+impl RecordView {
+    /// ドメイン Record から表示用ビューを構築する。
+    ///
+    /// - Secret kind → `ValueView::Masked`
+    /// - Text kind → `Record::text_preview(LIST_VALUE_PREVIEW_MAX)` を呼び、`Some(s)` なら `Plain(s)`、
+    ///   `None`（想定外、暗号化等）なら `Masked` フォールバック（防御的）
+    ///
+    /// 本メソッド内で secret 値を直接取り出す呼び出しを行わない（`shikomi_core::Record::text_preview`
+    /// に委譲し、露出経路を core 内部に封じる。
+    /// `docs/features/cli-vault-commands/basic-design/security.md §シークレット経路監査` 参照）。
+    #[must_use]
+    pub fn from_record(record: &Record) -> Self {
+        let value = match record.kind() {
+            RecordKind::Secret => ValueView::Masked,
+            RecordKind::Text => record
+                .text_preview(LIST_VALUE_PREVIEW_MAX)
+                .map_or(ValueView::Masked, ValueView::Plain),
+        };
+        Self {
+            id: record.id().clone(),
+            kind: record.kind(),
+            label: record.label().clone(),
+            value,
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// テスト
+// -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::{RecordLabel, RecordPayload, SecretString};
+    use time::OffsetDateTime;
+    use uuid::Uuid;
+
+    fn make_id() -> RecordId {
+        RecordId::new(Uuid::now_v7()).unwrap()
+    }
+
+    #[test]
+    fn test_record_view_from_record_secret_kind_yields_masked() {
+        let record = Record::new(
+            make_id(),
+            RecordKind::Secret,
+            RecordLabel::try_new("pw".to_owned()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string("super-secret".to_owned())),
+            OffsetDateTime::UNIX_EPOCH,
+        );
+        let view = RecordView::from_record(&record);
+        assert!(matches!(view.value, ValueView::Masked));
+    }
+
+    #[test]
+    fn test_record_view_from_record_text_kind_yields_plain() {
+        let record = Record::new(
+            make_id(),
+            RecordKind::Text,
+            RecordLabel::try_new("url".to_owned()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string("https://example.com".to_owned())),
+            OffsetDateTime::UNIX_EPOCH,
+        );
+        let view = RecordView::from_record(&record);
+        match view.value {
+            ValueView::Plain(s) => assert_eq!(s, "https://example.com"),
+            ValueView::Masked => panic!("expected Plain, got Masked"),
+        }
+    }
+
+    #[test]
+    fn test_record_view_from_record_text_long_value_truncates_to_40_chars() {
+        let long = "a".repeat(100);
+        let record = Record::new(
+            make_id(),
+            RecordKind::Text,
+            RecordLabel::try_new("l".to_owned()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string(long)),
+            OffsetDateTime::UNIX_EPOCH,
+        );
+        let view = RecordView::from_record(&record);
+        match view.value {
+            ValueView::Plain(s) => assert_eq!(s.chars().count(), LIST_VALUE_PREVIEW_MAX),
+            ValueView::Masked => panic!("expected Plain"),
+        }
+    }
+}

--- a/crates/shikomi-cli/tests/common/fixtures.rs
+++ b/crates/shikomi-cli/tests/common/fixtures.rs
@@ -1,0 +1,163 @@
+//! 暗号化 vault フィクスチャ生成ヘルパー。
+//!
+//! `shikomi-infra` は暗号化 vault の save() を `PersistenceError::UnsupportedYet`
+//! で拒否するため、テスト用の暗号化 `vault.db` は rusqlite を直接叩いて生成する。
+//! schema 定義は `shikomi-infra/src/persistence/sqlite/schema.rs` と同一構造を
+//! 使うが、定数は `pub(crate)` のため本 fixture 内で独立に保持する。
+//!
+//! 対応 Issue: #20
+//! 設計書: `docs/features/cli-vault-commands/test-design/integration.md §5`
+//!         `docs/features/cli-vault-commands/test-design/e2e.md §7 暗号化 vault（Fail Fast）`
+//!
+//! **契約**:
+//! - 本 helper が生成する `vault.db` は `load()` 時に `protection_mode = encrypted` を
+//!   検出して `PersistenceError::UnsupportedYet` を返す経路の検証専用
+//! - 暗号鍵・実データは含まない（ダミーバイト列で CHECK 制約のみ満たす）
+//! - git に commit されない（テスト実行時に毎回生成して破棄）
+
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use anyhow::Context;
+use rusqlite::{params, Connection};
+
+/// shikomi vault DB の `application_id`（`schema.rs` と同値）。
+const APPLICATION_ID: u32 = 0x73_68_6B_6D;
+
+/// `user_version`（Phase 1 では 1 固定）。
+const USER_VERSION: u32 = 1;
+
+/// KDF ソルトの要求長（CHECK 制約で 16 バイト固定）。
+const KDF_SALT_LEN: usize = 16;
+
+/// Wrapped VEK の最小長（CHECK 制約で >= 32 バイト）。
+const WRAPPED_VEK_MIN_LEN: usize = 32;
+
+/// 指定ディレクトリ `dir` の配下に、`protection_mode = encrypted` な
+/// 最小限の `vault.db` を生成する。
+///
+/// 生成後の `vault.db` は `SqliteVaultRepository::load()` から読み込まれ、
+/// `load_inner` の Step 12 で暗号化モード検出 → `PersistenceError::UnsupportedYet`
+/// を経由して `CliError::EncryptionUnsupported` に写像される。
+///
+/// # Errors
+/// SQLite 接続・DDL 実行・INSERT 失敗時にエラーを返す。
+pub fn create_encrypted_vault(dir: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dir).context("create vault dir")?;
+    let vault_db = dir.join("vault.db");
+    // 既存ファイルがあれば削除（再実行時の冪等性）
+    if vault_db.exists() {
+        std::fs::remove_file(&vault_db).context("remove stale vault.db")?;
+    }
+
+    // Unix 環境では infra 側が 0700/0600 を強制するため事前に合わせておく。
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+            .context("chmod 0700 dir")?;
+    }
+
+    let conn = Connection::open(&vault_db).context("open sqlite")?;
+
+    // PRAGMA: shikomi 識別子を設定
+    conn.pragma_update(None, "journal_mode", "DELETE")
+        .context("set journal_mode")?;
+    conn.pragma_update(None, "application_id", APPLICATION_ID)
+        .context("set application_id")?;
+    conn.pragma_update(None, "user_version", USER_VERSION)
+        .context("set user_version")?;
+
+    // Schema 作成（`schema.rs` CREATE_VAULT_HEADER / CREATE_RECORDS と同一構造）
+    conn.execute_batch(CREATE_VAULT_HEADER)
+        .context("create vault_header")?;
+    conn.execute_batch(CREATE_RECORDS)
+        .context("create records")?;
+
+    // 暗号化ヘッダ行を 1 件 INSERT（CHECK 制約を満たす最小値）
+    let kdf_salt = vec![0u8; KDF_SALT_LEN];
+    let wrapped_vek_by_pw = vec![0u8; WRAPPED_VEK_MIN_LEN];
+    let wrapped_vek_by_recovery = vec![0u8; WRAPPED_VEK_MIN_LEN];
+    conn.execute(
+        INSERT_ENCRYPTED_VAULT_HEADER,
+        params![
+            "encrypted",
+            USER_VERSION,
+            "1970-01-01T00:00:00Z",
+            kdf_salt,
+            wrapped_vek_by_pw,
+            wrapped_vek_by_recovery
+        ],
+    )
+    .context("insert encrypted vault_header row")?;
+
+    // 明示的に close してから chmod（Linux で busy file の permission 変更は可能だが確実に）
+    drop(conn);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&vault_db, std::fs::Permissions::from_mode(0o600))
+            .context("chmod 0600 vault.db")?;
+    }
+
+    Ok(())
+}
+
+// -------------------------------------------------------------------
+// Schema DDL（`shikomi-infra/src/persistence/sqlite/schema.rs` と同一構造）
+// -------------------------------------------------------------------
+
+const CREATE_VAULT_HEADER: &str = concat!(
+    "CREATE TABLE IF NOT EXISTS vault_header (",
+    "  id INTEGER PRIMARY KEY CHECK(id = 1),",
+    "  protection_mode TEXT NOT NULL CHECK(protection_mode IN ('plaintext', 'encrypted')),",
+    "  vault_version INTEGER NOT NULL CHECK(vault_version >= 1),",
+    "  created_at TEXT NOT NULL,",
+    "  kdf_salt BLOB,",
+    "  wrapped_vek_by_pw BLOB,",
+    "  wrapped_vek_by_recovery BLOB,",
+    "  CHECK(",
+    "    (protection_mode = 'plaintext'",
+    "      AND kdf_salt IS NULL",
+    "      AND wrapped_vek_by_pw IS NULL",
+    "      AND wrapped_vek_by_recovery IS NULL)",
+    "    OR",
+    "    (protection_mode = 'encrypted'",
+    "      AND kdf_salt IS NOT NULL AND length(kdf_salt) = 16",
+    "      AND wrapped_vek_by_pw IS NOT NULL AND length(wrapped_vek_by_pw) >= 32",
+    "      AND wrapped_vek_by_recovery IS NOT NULL AND length(wrapped_vek_by_recovery) >= 32)",
+    "  )",
+    ")",
+);
+
+const CREATE_RECORDS: &str = concat!(
+    "CREATE TABLE IF NOT EXISTS records (",
+    "  id TEXT PRIMARY KEY,",
+    "  kind TEXT NOT NULL CHECK(kind IN ('text', 'secret')),",
+    "  label TEXT NOT NULL CHECK(length(label) > 0),",
+    "  payload_variant TEXT NOT NULL CHECK(payload_variant IN ('plaintext', 'encrypted')),",
+    "  plaintext_value TEXT,",
+    "  nonce BLOB,",
+    "  ciphertext BLOB,",
+    "  aad BLOB,",
+    "  created_at TEXT NOT NULL,",
+    "  updated_at TEXT NOT NULL,",
+    "  CHECK(",
+    "    (payload_variant = 'plaintext'",
+    "      AND plaintext_value IS NOT NULL",
+    "      AND nonce IS NULL AND ciphertext IS NULL AND aad IS NULL)",
+    "    OR",
+    "    (payload_variant = 'encrypted'",
+    "      AND plaintext_value IS NULL",
+    "      AND nonce IS NOT NULL AND length(nonce) = 12",
+    "      AND ciphertext IS NOT NULL AND length(ciphertext) > 0",
+    "      AND aad IS NOT NULL AND length(aad) = 26)",
+    "  )",
+    ")",
+);
+
+const INSERT_ENCRYPTED_VAULT_HEADER: &str =
+    "INSERT INTO vault_header(id, protection_mode, vault_version, created_at, kdf_salt, \
+     wrapped_vek_by_pw, wrapped_vek_by_recovery) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6)";

--- a/crates/shikomi-cli/tests/common/mod.rs
+++ b/crates/shikomi-cli/tests/common/mod.rs
@@ -1,0 +1,92 @@
+//! 結合 / E2E テスト共通ヘルパー。
+//!
+//! - `fresh_repo`: tempfile ベースで `SqliteVaultRepository` を生成
+//! - `fixed_time`: 決定的テストのための固定時刻
+//! - `fixtures`: 暗号化 vault フィクスチャ生成（`fixtures::create_encrypted_vault`）
+//!
+//! テスト戦略ガイド準拠: 結合テストは実 SQLite + `tempfile` を使い、
+//! モック `VaultRepository` は使わない。
+//!
+//! トレーサビリティ:
+//! - 設計書 `docs/features/cli-vault-commands/test-design/integration.md §3`
+//! - 対応 Issue: #20
+
+#![allow(dead_code)] // 各 integration test file で部分的に使用されるため
+
+use std::path::Path;
+
+use shikomi_infra::persistence::SqliteVaultRepository;
+use tempfile::TempDir;
+use time::OffsetDateTime;
+
+pub mod fixtures;
+
+/// 一時ディレクトリ + `SqliteVaultRepository` のペアを返す。
+///
+/// 返却される `TempDir` が `Drop` されると一時ディレクトリが削除されるため、
+/// 呼び出し側がスコープ中保持すること。
+///
+/// **permission**: Unix 環境では `TempDir` のデフォルトは 0755 だが、infra 側の
+/// `PermissionGuard::verify_dir` は 0700 を要求する。そのため `chmod 0700` に
+/// 揃えて `load()` 経路を通す。
+pub fn fresh_repo() -> (TempDir, SqliteVaultRepository) {
+    let dir = TempDir::new().expect("failed to create tempdir");
+    tighten_perms_unix(dir.path());
+    let repo =
+        SqliteVaultRepository::from_directory(dir.path()).expect("failed to create repository");
+    (dir, repo)
+}
+
+/// `TempDir` 配下のパーミッションを Unix では `0700` に揃える（no-op on non-Unix）。
+#[cfg(unix)]
+pub fn tighten_perms_unix(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path).expect("metadata").permissions();
+    perms.set_mode(0o700);
+    std::fs::set_permissions(path, perms).expect("chmod 0700");
+}
+
+#[cfg(not(unix))]
+pub fn tighten_perms_unix(_path: &Path) {}
+
+/// 決定的テスト用の固定時刻（UNIX_EPOCH + 1 時間）。
+///
+/// `SystemTime::now()` に依存しない固定値で、テスト間の再現性を保つ。
+#[must_use]
+pub fn fixed_time() -> OffsetDateTime {
+    OffsetDateTime::UNIX_EPOCH + time::Duration::hours(1)
+}
+
+/// 任意オフセットの固定時刻を返す（`created_at < updated_at` の検証用）。
+#[must_use]
+pub fn fixed_time_at(hours: i64) -> OffsetDateTime {
+    OffsetDateTime::UNIX_EPOCH + time::Duration::hours(hours)
+}
+
+/// 指定ディレクトリで平文 vault を初期化し、1 件の Text レコードを追加する。
+///
+/// ラウンドトリップ検証の前提を整える共通セットアップ。追加したレコードの UUID 文字列を返す。
+pub fn init_vault_with_one_text_record(dir: &Path, label: &str, value: &str) -> String {
+    use shikomi_core::{
+        Record, RecordId, RecordKind, RecordLabel, RecordPayload, SecretString, Vault, VaultHeader,
+        VaultVersion,
+    };
+    use shikomi_infra::persistence::VaultRepository;
+    use uuid::Uuid;
+
+    let repo = SqliteVaultRepository::from_directory(dir).expect("from_directory");
+    let now = fixed_time();
+    let header = VaultHeader::new_plaintext(VaultVersion::CURRENT, now).unwrap();
+    let mut vault = Vault::new(header);
+    let id = RecordId::new(Uuid::now_v7()).unwrap();
+    let record = Record::new(
+        id.clone(),
+        RecordKind::Text,
+        RecordLabel::try_new(label.to_owned()).unwrap(),
+        RecordPayload::Plaintext(SecretString::from_string(value.to_owned())),
+        now,
+    );
+    vault.add_record(record).unwrap();
+    repo.save(&vault).unwrap();
+    id.to_string()
+}

--- a/crates/shikomi-cli/tests/e2e_add.rs
+++ b/crates/shikomi-cli/tests/e2e_add.rs
@@ -47,17 +47,17 @@ fn tc_e2e_010_add_text_roundtrips_through_list() {
         .expect("added line");
     let uuid = uuid_line.trim_start_matches("added: ").trim();
     // UUIDv7 全長 36
-    assert_eq!(uuid.chars().count(), 36, "uuid should be 36 chars, got {uuid}");
+    assert_eq!(
+        uuid.chars().count(),
+        36,
+        "uuid should be 36 chars, got {uuid}"
+    );
 
-    shikomi(dir.path())
-        .arg("list")
-        .assert()
-        .success()
-        .stdout(
-            predicate::str::contains(uuid)
-                .and(predicate::str::contains("L"))
-                .and(predicate::str::contains("V")),
-        );
+    shikomi(dir.path()).arg("list").assert().success().stdout(
+        predicate::str::contains(uuid)
+            .and(predicate::str::contains("L"))
+            .and(predicate::str::contains("V")),
+    );
 }
 
 // -------------------------------------------------------------------
@@ -74,17 +74,18 @@ fn tc_e2e_011_add_secret_stdin_never_echoes_secret_marker() {
         .success();
     let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
     let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
-    assert!(!stdout.contains("SECRET_TEST_VALUE"), "stdout leaked secret: {stdout}");
-    assert!(!stderr.contains("SECRET_TEST_VALUE"), "stderr leaked secret: {stderr}");
+    assert!(
+        !stdout.contains("SECRET_TEST_VALUE"),
+        "stdout leaked secret: {stdout}"
+    );
+    assert!(
+        !stderr.contains("SECRET_TEST_VALUE"),
+        "stderr leaked secret: {stderr}"
+    );
 
-    shikomi(dir.path())
-        .arg("list")
-        .assert()
-        .success()
-        .stdout(
-            predicate::str::contains("****")
-                .and(predicate::str::contains("SECRET_TEST_VALUE").not()),
-        );
+    shikomi(dir.path()).arg("list").assert().success().stdout(
+        predicate::str::contains("****").and(predicate::str::contains("SECRET_TEST_VALUE").not()),
+    );
 }
 
 // -------------------------------------------------------------------
@@ -106,7 +107,8 @@ fn tc_e2e_012_add_secret_value_warns_on_stderr_and_exits_zero() {
         "stderr should contain shell-history warning: {stderr}"
     );
     // warning 内に secret 値原文が出ないこと
-    assert!(!stderr.contains(" P ") && !stderr.ends_with("P\n") && !stderr.contains("value: P"),
+    assert!(
+        !stderr.contains(" P ") && !stderr.ends_with("P\n") && !stderr.contains("value: P"),
         "warning text unexpectedly contained secret value: {stderr}"
     );
 }

--- a/crates/shikomi-cli/tests/e2e_add.rs
+++ b/crates/shikomi-cli/tests/e2e_add.rs
@@ -1,0 +1,170 @@
+//! E2E テスト — `shikomi add`
+//!
+//! 対応 REQ: REQ-CLI-002, REQ-CLI-007, MSG-CLI-050, MSG-CLI-100, MSG-CLI-101
+//! 対応 Issue: #20
+//! 対応 TC: TC-E2E-010〜015
+//! 設計書: `docs/features/cli-vault-commands/test-design/e2e.md §4`
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use common::tighten_perms_unix;
+
+fn shikomi(dir: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("shikomi").expect("cargo_bin");
+    cmd.env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .arg("--vault-dir")
+        .arg(dir);
+    cmd
+}
+
+fn setup_vault_dir() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    dir
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-010: add --kind text → list でラウンドトリップ確認
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_010_add_text_roundtrips_through_list() {
+    let dir = setup_vault_dir();
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "text", "--label", "L", "--value", "V"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    assert!(stdout.contains("added: "));
+    let uuid_line = stdout
+        .lines()
+        .find(|l| l.starts_with("added: "))
+        .expect("added line");
+    let uuid = uuid_line.trim_start_matches("added: ").trim();
+    // UUIDv7 全長 36
+    assert_eq!(uuid.chars().count(), 36, "uuid should be 36 chars, got {uuid}");
+
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains(uuid)
+                .and(predicate::str::contains("L"))
+                .and(predicate::str::contains("V")),
+        );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-011: add --kind secret --stdin で secret を stdout / stderr に露出しない
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_011_add_secret_stdin_never_echoes_secret_marker() {
+    let dir = setup_vault_dir();
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "secret", "--label", "S", "--stdin"])
+        .write_stdin("SECRET_TEST_VALUE\n")
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(!stdout.contains("SECRET_TEST_VALUE"), "stdout leaked secret: {stdout}");
+    assert!(!stderr.contains("SECRET_TEST_VALUE"), "stderr leaked secret: {stderr}");
+
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("****")
+                .and(predicate::str::contains("SECRET_TEST_VALUE").not()),
+        );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-012: add --kind secret --value → 警告 + exit 0
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_012_add_secret_value_warns_on_stderr_and_exits_zero() {
+    let dir = setup_vault_dir();
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "secret", "--label", "S", "--value", "P"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(stdout.contains("added: "));
+    assert!(
+        stderr.to_lowercase().contains("warning") && stderr.to_lowercase().contains("shell"),
+        "stderr should contain shell-history warning: {stderr}"
+    );
+    // warning 内に secret 値原文が出ないこと
+    assert!(!stderr.contains(" P ") && !stderr.ends_with("P\n") && !stderr.contains("value: P"),
+        "warning text unexpectedly contained secret value: {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-013: add で --value と --stdin 併用は exit 1
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_013_add_rejects_value_and_stdin_together() {
+    let dir = setup_vault_dir();
+    let out = shikomi(dir.path())
+        .args([
+            "add", "--kind", "text", "--label", "L", "--value", "V", "--stdin",
+        ])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(stderr.contains("error:"));
+    assert!(
+        stderr.contains("--value") && stderr.contains("--stdin"),
+        "stderr should mention both flags: {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-014: add で --value / --stdin ともに未指定
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_014_add_without_value_or_stdin_fails_with_user_error() {
+    let dir = setup_vault_dir();
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "text", "--label", "L"])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(stderr.contains("error:"));
+    assert!(
+        stderr.contains("--value") || stderr.contains("--stdin") || stderr.contains("required"),
+        "stderr should mention missing value: {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-015: add — 不正ラベル（空文字）
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_015_add_empty_label_reports_invalid_label() {
+    let dir = setup_vault_dir();
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "text", "--label", "", "--value", "V"])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("invalid label") || stderr.contains("label"),
+        "stderr should mention invalid label: {stderr}"
+    );
+}

--- a/crates/shikomi-cli/tests/e2e_edit.rs
+++ b/crates/shikomi-cli/tests/e2e_edit.rs
@@ -153,3 +153,188 @@ fn tc_e2e_025_edit_kind_flag_is_unknown_argument() {
         "stderr should mention --kind rejection: {stderr}"
     );
 }
+
+// -------------------------------------------------------------------
+// REG-E2E-edit-secret-*: ペテルギウス指摘①（secret echo leak）回帰テスト
+//
+// 実装根拠: `lib.rs::run_edit`（commit 87e1b66）で既存 kind を事前 load し、
+// Secret なら `read_password` / Text なら `read_line` に切り替える設計。
+// assert_cmd からは TTY を提供できないため `is_stdin_tty() == false` 経路で
+// secret 値が stdout/stderr に漏れないこと + Fail Fast 経路を検証する。
+// -------------------------------------------------------------------
+
+/// stdin pipe された値を edit で新しい secret 値としてセットできることを、
+/// secret 値が stdout / stderr のどこにも現れないこと（REQ-CLI-007）と合わせて検証。
+#[test]
+fn reg_e2e_edit_secret_record_via_stdin_never_echoes_and_roundtrips_as_masked() {
+    // 前提: secret レコードを 1 件 add
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "secret", "--label", "S", "--stdin"])
+        .write_stdin("OLD_SECRET_TEST_VALUE\n")
+        .assert()
+        .success();
+    let uuid = String::from_utf8_lossy(&out.get_output().stdout)
+        .lines()
+        .find(|l| l.starts_with("added: "))
+        .unwrap()
+        .trim_start_matches("added: ")
+        .trim()
+        .to_owned();
+
+    // edit --stdin で新値を注入
+    let out = shikomi(dir.path())
+        .args(["edit", "--id", &uuid, "--stdin"])
+        .write_stdin("NEW_SECRET_TEST_VALUE\n")
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    // stdout/stderr に旧値も新値も一切出ない
+    assert!(!stdout.contains("OLD_SECRET_TEST_VALUE"));
+    assert!(!stdout.contains("NEW_SECRET_TEST_VALUE"));
+    assert!(!stderr.contains("OLD_SECRET_TEST_VALUE"));
+    assert!(!stderr.contains("NEW_SECRET_TEST_VALUE"));
+    assert!(stdout.contains("updated: "));
+
+    // ラウンドトリップ: list で Masked + 新旧どちらの secret 値も含まれない
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("****")
+                .and(predicate::str::contains("OLD_SECRET_TEST_VALUE").not())
+                .and(predicate::str::contains("NEW_SECRET_TEST_VALUE").not()),
+        );
+}
+
+/// 既存 kind が Secret のとき `--value` 直接指定すると shell 履歴警告が stderr に出る。
+/// 実装は `run_edit` で事前 load → `existing_kind == Secret && args.value.is_some()` で
+/// `render_shell_history_warning` を呼ぶ（ペテルギウス指摘③の YAGNI 解消で `locale`
+/// 引数が実際に使われる経路となる）。
+#[test]
+fn reg_e2e_edit_secret_record_with_value_flag_emits_shell_history_warning_on_stderr() {
+    // 前提: secret レコードを add（stdin 経由で初期値は漏洩させない）
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "secret", "--label", "S", "--stdin"])
+        .write_stdin("INIT_SECRET\n")
+        .assert()
+        .success();
+    let uuid = String::from_utf8_lossy(&out.get_output().stdout)
+        .lines()
+        .find(|l| l.starts_with("added: "))
+        .unwrap()
+        .trim_start_matches("added: ")
+        .trim()
+        .to_owned();
+
+    let out = shikomi(dir.path())
+        .args(["edit", "--id", &uuid, "--value", "P"])
+        .assert()
+        .success();
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.to_lowercase().contains("warning") && stderr.to_lowercase().contains("shell"),
+        "stderr should emit shell-history warning for secret+--value: {stderr}"
+    );
+}
+
+/// 既存 kind が Text のときは `--value` 指定でも shell 履歴警告は出さない。
+/// （shell 履歴リスクは secret のみに該当する設計）。
+#[test]
+fn reg_e2e_edit_text_record_with_value_flag_does_not_emit_shell_history_warning() {
+    let (dir, uuid) = setup_vault_with_record("L", "V");
+    let out = shikomi(dir.path())
+        .args(["edit", "--id", &uuid, "--value", "V2"])
+        .assert()
+        .success();
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        !stderr.to_lowercase().contains("shell"),
+        "Text kind edit must not emit shell-history warning: {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// REG-E2E-edit-failfast-*: ペテルギウス指摘②（Fail Fast 違反）の
+// 事前 load 経路における回帰テスト。
+//
+// `run_edit` は `--value` / `--stdin` 指定時のみ事前 load する。この経路での
+// VaultNotInitialized / EncryptionUnsupported / RecordNotFound が正しく
+// Fail Fast で exit するかを確認する（既存 TC-E2E-024/041/052 は `--label` のみ
+// の経路＝事前 load しない経路をカバー）。
+// -------------------------------------------------------------------
+
+/// `--value` 指定 + vault 未初期化 → 事前 load の exists() チェックで
+/// VaultNotInitialized → exit 1
+#[test]
+fn reg_e2e_edit_with_value_on_uninitialized_vault_exits_with_code_one() {
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    let out = shikomi(dir.path())
+        .args([
+            "edit",
+            "--id",
+            "018f0000-0000-7000-8000-000000000000",
+            "--value",
+            "X",
+        ])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("vault not initialized"),
+        "stderr should mention vault not initialized: {stderr}"
+    );
+}
+
+/// `--value` 指定 + 存在しない id（vault は初期化済み）→ 事前 load の
+/// find_record で RecordNotFound → exit 1
+#[test]
+fn reg_e2e_edit_with_value_on_missing_id_exits_with_code_one() {
+    let (dir, _uuid) = setup_vault_with_record("L", "V");
+    let out = shikomi(dir.path())
+        .args([
+            "edit",
+            "--id",
+            "018f0000-0000-7000-8000-000000000000",
+            "--value",
+            "X",
+        ])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("record not found"),
+        "stderr should contain 'record not found': {stderr}"
+    );
+}
+
+/// `--value` 指定 + 暗号化 vault → 事前 load の protection_mode で
+/// EncryptionUnsupported → exit 3（BUG-001 と同じ契約、別経路で再確認）
+#[test]
+fn reg_e2e_edit_with_value_on_encrypted_vault_exits_with_code_three() {
+    use common::fixtures;
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    fixtures::create_encrypted_vault(dir.path()).unwrap();
+    let out = shikomi(dir.path())
+        .args([
+            "edit",
+            "--id",
+            "018f0000-0000-7000-8000-000000000000",
+            "--value",
+            "X",
+        ])
+        .assert()
+        .code(3);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("encrypt"),
+        "stderr should mention encryption: {stderr}"
+    );
+}

--- a/crates/shikomi-cli/tests/e2e_edit.rs
+++ b/crates/shikomi-cli/tests/e2e_edit.rs
@@ -199,15 +199,11 @@ fn reg_e2e_edit_secret_record_via_stdin_never_echoes_and_roundtrips_as_masked() 
     assert!(stdout.contains("updated: "));
 
     // ラウンドトリップ: list で Masked + 新旧どちらの secret 値も含まれない
-    shikomi(dir.path())
-        .arg("list")
-        .assert()
-        .success()
-        .stdout(
-            predicate::str::contains("****")
-                .and(predicate::str::contains("OLD_SECRET_TEST_VALUE").not())
-                .and(predicate::str::contains("NEW_SECRET_TEST_VALUE").not()),
-        );
+    shikomi(dir.path()).arg("list").assert().success().stdout(
+        predicate::str::contains("****")
+            .and(predicate::str::contains("OLD_SECRET_TEST_VALUE").not())
+            .and(predicate::str::contains("NEW_SECRET_TEST_VALUE").not()),
+    );
 }
 
 /// 既存 kind が Secret のとき `--value` 直接指定すると shell 履歴警告が stderr に出る。

--- a/crates/shikomi-cli/tests/e2e_edit.rs
+++ b/crates/shikomi-cli/tests/e2e_edit.rs
@@ -1,0 +1,155 @@
+//! E2E テスト — `shikomi edit`
+//!
+//! 対応 REQ: REQ-CLI-003, MSG-CLI-100, MSG-CLI-102, MSG-CLI-106
+//! 対応 Issue: #20
+//! 対応 TC: TC-E2E-020〜025
+//! 設計書: `docs/features/cli-vault-commands/test-design/e2e.md §5`
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use common::tighten_perms_unix;
+
+fn shikomi(dir: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("shikomi").expect("cargo_bin");
+    cmd.env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .arg("--vault-dir")
+        .arg(dir);
+    cmd
+}
+
+fn setup_vault_with_record(label: &str, value: &str) -> (TempDir, String) {
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "text", "--label", label, "--value", value])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    let uuid = stdout
+        .lines()
+        .find(|l| l.starts_with("added: "))
+        .expect("added line")
+        .trim_start_matches("added: ")
+        .trim()
+        .to_owned();
+    (dir, uuid)
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-020: edit --label で label のみ更新、list で反映確認
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_020_edit_label_only_reflects_in_list() {
+    let (dir, uuid) = setup_vault_with_record("OLD", "V");
+    shikomi(dir.path())
+        .args(["edit", "--id", &uuid, "--label", "NEW_L"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("updated: ").and(predicate::str::contains(uuid.as_str())));
+
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("NEW_L"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-021: edit で --value と --stdin 併用は exit 1
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_021_edit_rejects_value_and_stdin_together() {
+    let (dir, uuid) = setup_vault_with_record("L", "V");
+    let out = shikomi(dir.path())
+        .args(["edit", "--id", &uuid, "--value", "X", "--stdin"])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(stderr.contains("--value") && stderr.contains("--stdin"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-022: edit フラグ全未指定 → 更新内容なしで exit 1
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_022_edit_without_any_update_field_fails() {
+    let (dir, uuid) = setup_vault_with_record("L", "V");
+    let out = shikomi(dir.path())
+        .args(["edit", "--id", &uuid])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("--label") || stderr.contains("required") || stderr.contains("at least"),
+        "stderr should mention at-least-one-required: {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-023: edit — 不正 UUID
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_023_edit_rejects_invalid_uuid() {
+    let (dir, _uuid) = setup_vault_with_record("L", "V");
+    let out = shikomi(dir.path())
+        .args(["edit", "--id", "not-a-uuid", "--label", "L"])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("invalid record id") || stderr.contains("invalid"),
+        "stderr should mention invalid id: {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-024: edit — 存在しない id
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_024_edit_on_missing_id_reports_record_not_found() {
+    let (dir, _uuid) = setup_vault_with_record("L", "V");
+    let out = shikomi(dir.path())
+        .args([
+            "edit",
+            "--id",
+            "018f0000-0000-7000-8000-000000000000",
+            "--label",
+            "L",
+        ])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("record not found"),
+        "stderr should contain 'record not found': {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-025: edit --kind は clap レベルで unknown argument
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_025_edit_kind_flag_is_unknown_argument() {
+    let (dir, uuid) = setup_vault_with_record("L", "V");
+    let out = shikomi(dir.path())
+        .args(["edit", "--id", &uuid, "--kind", "secret"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    // clap が unexpected argument / unknown flag / --kind を報告する
+    assert!(
+        stderr.contains("--kind") || stderr.contains("unexpected") || stderr.contains("unknown"),
+        "stderr should mention --kind rejection: {stderr}"
+    );
+}

--- a/crates/shikomi-cli/tests/e2e_encrypted.rs
+++ b/crates/shikomi-cli/tests/e2e_encrypted.rs
@@ -1,0 +1,118 @@
+//! E2E テスト — 暗号化 vault（Fail Fast）
+//!
+//! 対応 REQ: REQ-CLI-009, MSG-CLI-103
+//! 対応 Issue: #20
+//! 対応 TC: TC-E2E-040 / TC-E2E-041
+//! 設計書: `docs/features/cli-vault-commands/test-design/e2e.md §7`
+
+mod common;
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+use common::{fixtures, tighten_perms_unix};
+
+fn shikomi(dir: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("shikomi").expect("cargo_bin");
+    cmd.env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .arg("--vault-dir")
+        .arg(dir);
+    cmd
+}
+
+fn setup_encrypted_vault() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    fixtures::create_encrypted_vault(dir.path()).expect("create encrypted vault");
+    dir
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-040: 暗号化 vault に対する `list` → exit 3 + MSG-CLI-103
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_040_list_on_encrypted_vault_exits_with_code_three() {
+    let dir = setup_encrypted_vault();
+    let out = shikomi(dir.path()).arg("list").assert().code(3);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("encrypt") || stderr.contains("encryption"),
+        "stderr should mention encryption: {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-041: 暗号化 vault に対する add / edit / remove → exit 3
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_041_add_on_encrypted_vault_exits_with_code_three() {
+    let dir = setup_encrypted_vault();
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "text", "--label", "L", "--value", "V"])
+        .assert()
+        .code(3);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("encrypt") || stderr.contains("encryption"),
+        "stderr should mention encryption: {stderr}"
+    );
+}
+
+#[test]
+fn tc_e2e_041_edit_on_encrypted_vault_exits_with_code_three() {
+    let dir = setup_encrypted_vault();
+    let out = shikomi(dir.path())
+        .args([
+            "edit",
+            "--id",
+            "018f0000-0000-7000-8000-000000000000",
+            "--label",
+            "L",
+        ])
+        .assert()
+        .code(3);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("encrypt") || stderr.contains("encryption"),
+        "stderr should mention encryption: {stderr}"
+    );
+}
+
+#[test]
+fn tc_e2e_041_remove_on_encrypted_vault_exits_with_code_three() {
+    let dir = setup_encrypted_vault();
+    let out = shikomi(dir.path())
+        .args([
+            "remove",
+            "--id",
+            "018f0000-0000-7000-8000-000000000000",
+            "--yes",
+        ])
+        .assert()
+        .code(3);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("encrypt") || stderr.contains("encryption"),
+        "stderr should mention encryption: {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-040 補: vault 内容が触られていないこと（副作用ゼロ）
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_040b_encrypted_vault_db_is_unchanged_after_list_attempt() {
+    let dir = setup_encrypted_vault();
+    let vault_db = dir.path().join("vault.db");
+    let before = std::fs::read(&vault_db).unwrap();
+
+    // 結果の exit code はバグの有無で変わりうるが、vault 内容は変わらない契約。
+    let _ = shikomi(dir.path()).arg("list").output();
+
+    let after = std::fs::read(&vault_db).unwrap();
+    assert_eq!(before, after, "encrypted vault.db should not be modified");
+}

--- a/crates/shikomi-cli/tests/e2e_i18n.rs
+++ b/crates/shikomi-cli/tests/e2e_i18n.rs
@@ -1,0 +1,75 @@
+//! E2E テスト — i18n（英日 2 段 / `LANG=C` 英語のみ）
+//!
+//! 対応 REQ: REQ-CLI-008
+//! 対応 Issue: #20
+//! 対応 TC: TC-E2E-070 / TC-E2E-071
+//! 設計書: `docs/features/cli-vault-commands/test-design/e2e.md §10`
+
+mod common;
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+use common::tighten_perms_unix;
+
+fn empty_vault_dir() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    dir
+}
+
+fn shikomi_with_lang(dir: &std::path::Path, lang: &str) -> Command {
+    let mut cmd = Command::cargo_bin("shikomi").expect("cargo_bin");
+    cmd.env_remove("SHIKOMI_VAULT_DIR")
+        .env("LANG", lang)
+        .arg("--vault-dir")
+        .arg(dir);
+    cmd
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-070: LANG=ja_JP.UTF-8 → 英日 2 段
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_070_japanese_locale_produces_english_and_japanese_lines() {
+    let dir = empty_vault_dir();
+    // vault 未初期化 → エラーで両 locale の文言を誘発
+    let out = shikomi_with_lang(dir.path(), "ja_JP.UTF-8")
+        .arg("list")
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("vault not initialized"),
+        "missing english line: {stderr}"
+    );
+    assert!(
+        stderr.contains("vault が初期化されていません"),
+        "missing japanese line: {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-071: LANG=C → 英語のみ（日本語が一切出ない）
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_071_c_locale_produces_english_only() {
+    let dir = empty_vault_dir();
+    let out = shikomi_with_lang(dir.path(), "C").arg("list").assert().code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("vault not initialized"),
+        "missing english line: {stderr}"
+    );
+    assert!(
+        !stderr.contains("vault が"),
+        "unexpected japanese line: {stderr}"
+    );
+    // `LANG=C` 配下では日本語文字（ひらがな・カタカナ）を一切出さない
+    let has_hiragana = stderr
+        .chars()
+        .any(|c| ('\u{3040}'..='\u{309F}').contains(&c));
+    assert!(!has_hiragana, "stderr contains hiragana: {stderr}");
+}

--- a/crates/shikomi-cli/tests/e2e_i18n.rs
+++ b/crates/shikomi-cli/tests/e2e_i18n.rs
@@ -57,7 +57,10 @@ fn tc_e2e_070_japanese_locale_produces_english_and_japanese_lines() {
 #[test]
 fn tc_e2e_071_c_locale_produces_english_only() {
     let dir = empty_vault_dir();
-    let out = shikomi_with_lang(dir.path(), "C").arg("list").assert().code(1);
+    let out = shikomi_with_lang(dir.path(), "C")
+        .arg("list")
+        .assert()
+        .code(1);
     let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
     assert!(
         stderr.contains("vault not initialized"),

--- a/crates/shikomi-cli/tests/e2e_list.rs
+++ b/crates/shikomi-cli/tests/e2e_list.rs
@@ -71,19 +71,15 @@ fn tc_e2e_002_list_single_text_record_renders_value_with_header() {
         .assert()
         .success();
 
-    shikomi(dir.path())
-        .arg("list")
-        .assert()
-        .success()
-        .stdout(
-            predicate::str::contains("text")
-                .and(predicate::str::contains("L1"))
-                .and(predicate::str::contains("V1"))
-                .and(predicate::str::contains("ID"))
-                .and(predicate::str::contains("KIND"))
-                .and(predicate::str::contains("LABEL"))
-                .and(predicate::str::contains("VALUE")),
-        );
+    shikomi(dir.path()).arg("list").assert().success().stdout(
+        predicate::str::contains("text")
+            .and(predicate::str::contains("L1"))
+            .and(predicate::str::contains("V1"))
+            .and(predicate::str::contains("ID"))
+            .and(predicate::str::contains("KIND"))
+            .and(predicate::str::contains("LABEL"))
+            .and(predicate::str::contains("VALUE")),
+    );
 }
 
 // -------------------------------------------------------------------
@@ -96,7 +92,13 @@ fn tc_e2e_003_list_mixed_records_masks_secret_and_preserves_text() {
     // text: PUBLIC_VAL
     shikomi(dir.path())
         .args([
-            "add", "--kind", "text", "--label", "T1", "--value", "PUBLIC_VAL",
+            "add",
+            "--kind",
+            "text",
+            "--label",
+            "T1",
+            "--value",
+            "PUBLIC_VAL",
         ])
         .assert()
         .success();

--- a/crates/shikomi-cli/tests/e2e_list.rs
+++ b/crates/shikomi-cli/tests/e2e_list.rs
@@ -1,0 +1,133 @@
+//! E2E テスト — `shikomi list`
+//!
+//! 対応 REQ: REQ-CLI-001, REQ-CLI-007
+//! 対応 Issue: #20
+//! 対応 TC: TC-E2E-001 / TC-E2E-002 / TC-E2E-003
+//! 設計書: `docs/features/cli-vault-commands/test-design/e2e.md §3`
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use common::tighten_perms_unix;
+
+/// 共通: `shikomi` バイナリに `--vault-dir <dir>` を付けた Command を返す。
+/// env は明示的に除去して残留影響を避ける。
+fn shikomi(dir: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("shikomi").expect("cargo_bin");
+    cmd.env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .arg("--vault-dir")
+        .arg(dir);
+    cmd
+}
+
+fn setup_vault_dir() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    tighten_perms_unix(dir.path());
+    dir
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-001: list — 空 vault（vault 初期化後に 0 件）
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_001_list_empty_vault_prints_no_records_with_exit_zero() {
+    let dir = setup_vault_dir();
+    // add → remove で 0 件 vault を作る……の代わりに、`add` だけ実行して
+    // 直後に `remove --yes` は E2E_remove で扱うので、ここでは add で初期化だけして
+    // 1 件ある状態での空ケースは境界値 TC-E2E-002 の観点になってしまう。
+    // そのため、先に 1 件 add → id を取って remove で消してから list を呼ぶ。
+    let add_out = shikomi(dir.path())
+        .args(["add", "--kind", "text", "--label", "L", "--value", "V"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&add_out.get_output().stdout).to_string();
+    let uuid = extract_added_uuid(&stdout).expect("added uuid");
+    shikomi(dir.path())
+        .args(["remove", "--id", &uuid, "--yes"])
+        .assert()
+        .success();
+
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no records"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-002: list — 1 件（Text のみ）
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_002_list_single_text_record_renders_value_with_header() {
+    let dir = setup_vault_dir();
+    shikomi(dir.path())
+        .args(["add", "--kind", "text", "--label", "L1", "--value", "V1"])
+        .assert()
+        .success();
+
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("text")
+                .and(predicate::str::contains("L1"))
+                .and(predicate::str::contains("V1"))
+                .and(predicate::str::contains("ID"))
+                .and(predicate::str::contains("KIND"))
+                .and(predicate::str::contains("LABEL"))
+                .and(predicate::str::contains("VALUE")),
+        );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-003: list — Text + Secret 混在、Secret はマスク表示
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_003_list_mixed_records_masks_secret_and_preserves_text() {
+    let dir = setup_vault_dir();
+    // text: PUBLIC_VAL
+    shikomi(dir.path())
+        .args([
+            "add", "--kind", "text", "--label", "T1", "--value", "PUBLIC_VAL",
+        ])
+        .assert()
+        .success();
+    // secret: SECRET_TEST_VALUE via stdin
+    shikomi(dir.path())
+        .args(["add", "--kind", "secret", "--label", "S1", "--stdin"])
+        .write_stdin("SECRET_TEST_VALUE\n")
+        .assert()
+        .success();
+
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("PUBLIC_VAL")
+                .and(predicate::str::contains("****"))
+                .and(predicate::str::contains("SECRET_TEST_VALUE").not()),
+        )
+        .stderr(predicate::str::contains("SECRET_TEST_VALUE").not());
+}
+
+// -------------------------------------------------------------------
+// Helper: `added: <uuid>` から UUID を抽出
+// -------------------------------------------------------------------
+
+fn extract_added_uuid(stdout: &str) -> Option<String> {
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix("added: ") {
+            return Some(rest.trim().to_owned());
+        }
+    }
+    None
+}

--- a/crates/shikomi-cli/tests/e2e_personas.rs
+++ b/crates/shikomi-cli/tests/e2e_personas.rs
@@ -1,0 +1,223 @@
+//! E2E テスト — ペルソナシナリオ統合
+//!
+//! 対応 Issue: #20
+//! 対応 TC: TC-E2E-100 (SCN-A) / TC-E2E-101 (SCN-B) / TC-E2E-102 (SCN-C)
+//! 設計書: `docs/features/cli-vault-commands/test-design/e2e.md §11`
+//!         `docs/features/cli-vault-commands/requirements-analysis.md §ペルソナ`
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use common::tighten_perms_unix;
+
+fn shikomi(dir: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("shikomi").expect("cargo_bin");
+    cmd.env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .arg("--vault-dir")
+        .arg(dir);
+    cmd
+}
+
+fn extract_added_uuid(stdout: &str) -> String {
+    stdout
+        .lines()
+        .find(|l| l.starts_with("added: "))
+        .expect("added line")
+        .trim_start_matches("added: ")
+        .trim()
+        .to_owned()
+}
+
+fn fresh_dir() -> TempDir {
+    let d = TempDir::new().unwrap();
+    tighten_perms_unix(d.path());
+    d
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-100: SCN-A 山田美咲ライフサイクル統合
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_100_scn_a_fullstack_engineer_record_lifecycle() {
+    let dir = fresh_dir();
+
+    // (1) add text
+    let out1 = shikomi(dir.path())
+        .args([
+            "add", "--kind", "text", "--label", "SSH: prod", "--value", "ssh -J bastion prod",
+        ])
+        .assert()
+        .success();
+    let text_uuid = extract_added_uuid(&String::from_utf8_lossy(&out1.get_output().stdout));
+
+    // (2) add secret via stdin
+    let out2 = shikomi(dir.path())
+        .args(["add", "--kind", "secret", "--label", "AWS_KEY", "--stdin"])
+        .write_stdin("SECRET_TEST_VALUE\n")
+        .assert()
+        .success();
+    let secret_uuid = extract_added_uuid(&String::from_utf8_lossy(&out2.get_output().stdout));
+    assert!(!String::from_utf8_lossy(&out2.get_output().stdout).contains("SECRET_TEST_VALUE"));
+    assert!(!String::from_utf8_lossy(&out2.get_output().stderr).contains("SECRET_TEST_VALUE"));
+
+    // (3) list で 2 件確認、Secret マスク、SECRET_TEST_VALUE 不在
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains(&text_uuid)
+                .and(predicate::str::contains(&secret_uuid))
+                .and(predicate::str::contains("****"))
+                .and(predicate::str::contains("SECRET_TEST_VALUE").not()),
+        );
+
+    // (4) edit label 更新
+    shikomi(dir.path())
+        .args(["edit", "--id", &text_uuid, "--label", "SSH: prod-v2"])
+        .assert()
+        .success();
+
+    // (5) list で更新反映確認
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("SSH: prod-v2"));
+
+    // (6) remove secret_uuid
+    shikomi(dir.path())
+        .args(["remove", "--id", &secret_uuid, "--yes"])
+        .assert()
+        .success();
+
+    // (7) list で 1 件残存、SECRET_TEST_VALUE 不在
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains(&text_uuid)
+                .and(predicate::str::contains(&secret_uuid).not())
+                .and(predicate::str::contains("SECRET_TEST_VALUE").not()),
+        );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-101: SCN-B 田中俊介初心者保護（日本語併記 + 非 TTY 削除拒否）
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_101_scn_b_non_interactive_removal_is_refused_with_japanese_hint() {
+    let dir = fresh_dir();
+    // セットアップ: add 1 件
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "text", "--label", "TAN", "--value", "田中のメモ"])
+        .assert()
+        .success();
+    let uuid = extract_added_uuid(&String::from_utf8_lossy(&out.get_output().stdout));
+
+    // (1) 日本語併記 list 確認
+    let mut cmd = Command::cargo_bin("shikomi").unwrap();
+    cmd.env_remove("SHIKOMI_VAULT_DIR")
+        .env("LANG", "ja_JP.UTF-8")
+        .args(["--vault-dir", dir.path().to_str().unwrap(), "list"])
+        .assert()
+        .success();
+
+    // (2) 非 TTY + --yes 無しで remove → 拒否 + 日本語ヒント
+    let mut cmd = Command::cargo_bin("shikomi").unwrap();
+    let out = cmd
+        .env_remove("SHIKOMI_VAULT_DIR")
+        .env("LANG", "ja_JP.UTF-8")
+        .args([
+            "--vault-dir",
+            dir.path().to_str().unwrap(),
+            "remove",
+            "--id",
+            &uuid,
+        ])
+        .write_stdin("")
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(stderr.contains("--yes"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("再実行") || stderr.contains("確認"),
+        "stderr should contain Japanese hint: {stderr}"
+    );
+
+    // 続けて list で当該レコード残存確認
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(uuid.as_str()));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-102: SCN-C 自己記述性
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_102_scn_c_help_and_version_messages_are_well_formed() {
+    // (a) shikomi --help → 全サブコマンド一覧
+    let out = Command::cargo_bin("shikomi")
+        .unwrap()
+        .env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .arg("--help")
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    for sub in ["list", "add", "edit", "remove"] {
+        assert!(stdout.contains(sub), "--help missing subcommand '{sub}': {stdout}");
+    }
+
+    // (b) --version
+    let out = Command::cargo_bin("shikomi")
+        .unwrap()
+        .env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .arg("--version")
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    assert!(
+        stdout.contains(pkg_version),
+        "--version should match CARGO_PKG_VERSION={pkg_version}: {stdout}"
+    );
+
+    // (c) add --help → --kind / --label / --value / --stdin
+    let out = Command::cargo_bin("shikomi")
+        .unwrap()
+        .env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .args(["add", "--help"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    for flag in ["--kind", "--label", "--value", "--stdin"] {
+        assert!(stdout.contains(flag), "add --help missing flag '{flag}': {stdout}");
+    }
+
+    // (d) edit --help → --kind は含まない（Phase 1 スコープ外）
+    let out = Command::cargo_bin("shikomi")
+        .unwrap()
+        .env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .args(["edit", "--help"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    assert!(
+        !stdout.contains("--kind"),
+        "edit --help MUST NOT contain --kind (Phase 1 scope): {stdout}"
+    );
+}

--- a/crates/shikomi-cli/tests/e2e_personas.rs
+++ b/crates/shikomi-cli/tests/e2e_personas.rs
@@ -49,7 +49,13 @@ fn tc_e2e_100_scn_a_fullstack_engineer_record_lifecycle() {
     // (1) add text
     let out1 = shikomi(dir.path())
         .args([
-            "add", "--kind", "text", "--label", "SSH: prod", "--value", "ssh -J bastion prod",
+            "add",
+            "--kind",
+            "text",
+            "--label",
+            "SSH: prod",
+            "--value",
+            "ssh -J bastion prod",
         ])
         .assert()
         .success();
@@ -66,16 +72,12 @@ fn tc_e2e_100_scn_a_fullstack_engineer_record_lifecycle() {
     assert!(!String::from_utf8_lossy(&out2.get_output().stderr).contains("SECRET_TEST_VALUE"));
 
     // (3) list で 2 件確認、Secret マスク、SECRET_TEST_VALUE 不在
-    shikomi(dir.path())
-        .arg("list")
-        .assert()
-        .success()
-        .stdout(
-            predicate::str::contains(&text_uuid)
-                .and(predicate::str::contains(&secret_uuid))
-                .and(predicate::str::contains("****"))
-                .and(predicate::str::contains("SECRET_TEST_VALUE").not()),
-        );
+    shikomi(dir.path()).arg("list").assert().success().stdout(
+        predicate::str::contains(&text_uuid)
+            .and(predicate::str::contains(&secret_uuid))
+            .and(predicate::str::contains("****"))
+            .and(predicate::str::contains("SECRET_TEST_VALUE").not()),
+    );
 
     // (4) edit label 更新
     shikomi(dir.path())
@@ -97,15 +99,11 @@ fn tc_e2e_100_scn_a_fullstack_engineer_record_lifecycle() {
         .success();
 
     // (7) list で 1 件残存、SECRET_TEST_VALUE 不在
-    shikomi(dir.path())
-        .arg("list")
-        .assert()
-        .success()
-        .stdout(
-            predicate::str::contains(&text_uuid)
-                .and(predicate::str::contains(&secret_uuid).not())
-                .and(predicate::str::contains("SECRET_TEST_VALUE").not()),
-        );
+    shikomi(dir.path()).arg("list").assert().success().stdout(
+        predicate::str::contains(&text_uuid)
+            .and(predicate::str::contains(&secret_uuid).not())
+            .and(predicate::str::contains("SECRET_TEST_VALUE").not()),
+    );
 }
 
 // -------------------------------------------------------------------
@@ -117,7 +115,15 @@ fn tc_e2e_101_scn_b_non_interactive_removal_is_refused_with_japanese_hint() {
     let dir = fresh_dir();
     // セットアップ: add 1 件
     let out = shikomi(dir.path())
-        .args(["add", "--kind", "text", "--label", "TAN", "--value", "田中のメモ"])
+        .args([
+            "add",
+            "--kind",
+            "text",
+            "--label",
+            "TAN",
+            "--value",
+            "田中のメモ",
+        ])
         .assert()
         .success();
     let uuid = extract_added_uuid(&String::from_utf8_lossy(&out.get_output().stdout));
@@ -176,7 +182,10 @@ fn tc_e2e_102_scn_c_help_and_version_messages_are_well_formed() {
         .success();
     let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
     for sub in ["list", "add", "edit", "remove"] {
-        assert!(stdout.contains(sub), "--help missing subcommand '{sub}': {stdout}");
+        assert!(
+            stdout.contains(sub),
+            "--help missing subcommand '{sub}': {stdout}"
+        );
     }
 
     // (b) --version
@@ -204,7 +213,10 @@ fn tc_e2e_102_scn_c_help_and_version_messages_are_well_formed() {
         .success();
     let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
     for flag in ["--kind", "--label", "--value", "--stdin"] {
-        assert!(stdout.contains(flag), "add --help missing flag '{flag}': {stdout}");
+        assert!(
+            stdout.contains(flag),
+            "add --help missing flag '{flag}': {stdout}"
+        );
     }
 
     // (d) edit --help → --kind は含まない（Phase 1 スコープ外）

--- a/crates/shikomi-cli/tests/e2e_remove.rs
+++ b/crates/shikomi-cli/tests/e2e_remove.rs
@@ -1,0 +1,125 @@
+//! E2E テスト — `shikomi remove`
+//!
+//! 対応 REQ: REQ-CLI-004, REQ-CLI-011, MSG-CLI-105
+//! 対応 Issue: #20
+//! 対応 TC: TC-E2E-030〜033
+//! 設計書: `docs/features/cli-vault-commands/test-design/e2e.md §6`
+//!
+//! NOTE: TC-E2E-030（擬似 TTY 必要）は `expectrl`/`rexpect` 依存を避けるため
+//! `#[ignore]` でスキップする（設計書 §6 の注記通り）。TC-E2E-031（非 TTY + --yes 無し）
+//! を主検証とする。
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use common::tighten_perms_unix;
+
+fn shikomi(dir: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("shikomi").expect("cargo_bin");
+    cmd.env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .arg("--vault-dir")
+        .arg(dir);
+    cmd
+}
+
+fn setup_vault_with_record() -> (TempDir, String) {
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "text", "--label", "L", "--value", "V"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    let uuid = stdout
+        .lines()
+        .find(|l| l.starts_with("added: "))
+        .expect("added line")
+        .trim_start_matches("added: ")
+        .trim()
+        .to_owned();
+    (dir, uuid)
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-030: remove — 擬似 TTY での 'y' 確認（CI で動作しない可能性のため ignore）
+// -------------------------------------------------------------------
+
+#[test]
+#[ignore = "pseudo-tty (expectrl/rexpect) not used; main assertion is TC-E2E-031"]
+fn tc_e2e_030_remove_pseudo_tty_confirmation_y_deletes_record() {
+    // 擬似 TTY 実装は Phase 2 で検討。主受入基準は TC-E2E-031 で満たす。
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-031: remove — 非 TTY + --yes 無しで exit 1（主検証）
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_031_remove_non_tty_without_yes_refuses_and_exits_one() {
+    let (dir, uuid) = setup_vault_with_record();
+    let out = shikomi(dir.path())
+        .args(["remove", "--id", &uuid])
+        // .write_stdin("") でパイプ stdin を接続 → is_terminal() false
+        .write_stdin("")
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("--yes") || stderr.contains("non-interactive") || stderr.contains("refusing"),
+        "stderr should mention --yes requirement: {stderr}"
+    );
+
+    // レコードが残存している（ラウンドトリップ検証）
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(uuid.as_str()));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-032: remove --yes で確認なし削除 → list で不在
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_032_remove_with_yes_deletes_record_and_disappears_from_list() {
+    let (dir, uuid) = setup_vault_with_record();
+    shikomi(dir.path())
+        .args(["remove", "--id", &uuid, "--yes"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("removed: ").and(predicate::str::contains(uuid.as_str())));
+
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(uuid.as_str()).not());
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-033: remove --yes で存在しない id → exit 1 + record not found
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_033_remove_missing_id_with_yes_reports_record_not_found() {
+    let (dir, _uuid) = setup_vault_with_record();
+    let out = shikomi(dir.path())
+        .args([
+            "remove",
+            "--id",
+            "018f0000-0000-7000-8000-000000000000",
+            "--yes",
+        ])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("record not found"),
+        "stderr should contain 'record not found': {stderr}"
+    );
+}

--- a/crates/shikomi-cli/tests/e2e_remove.rs
+++ b/crates/shikomi-cli/tests/e2e_remove.rs
@@ -69,7 +69,9 @@ fn tc_e2e_031_remove_non_tty_without_yes_refuses_and_exits_one() {
         .code(1);
     let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
     assert!(
-        stderr.contains("--yes") || stderr.contains("non-interactive") || stderr.contains("refusing"),
+        stderr.contains("--yes")
+            || stderr.contains("non-interactive")
+            || stderr.contains("refusing"),
         "stderr should mention --yes requirement: {stderr}"
     );
 

--- a/crates/shikomi-cli/tests/e2e_uninitialized.rs
+++ b/crates/shikomi-cli/tests/e2e_uninitialized.rs
@@ -1,0 +1,105 @@
+//! E2E テスト — vault 未初期化
+//!
+//! 対応 REQ: REQ-CLI-010, MSG-CLI-104, MSG-CLI-005
+//! 対応 Issue: #20
+//! 対応 TC: TC-E2E-050〜052
+//! 設計書: `docs/features/cli-vault-commands/test-design/e2e.md §8`
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use common::tighten_perms_unix;
+
+fn shikomi(dir: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("shikomi").expect("cargo_bin");
+    cmd.env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .arg("--vault-dir")
+        .arg(dir);
+    cmd
+}
+
+fn empty_vault_dir() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    dir
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-050: vault 未初期化で list → exit 1
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_050_list_on_uninitialized_vault_exits_with_code_one() {
+    let dir = empty_vault_dir();
+    let out = shikomi(dir.path()).arg("list").assert().code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("vault not initialized") || stderr.contains("not initialized"),
+        "stderr should contain 'vault not initialized': {stderr}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-051: vault 未初期化で add → 自動初期化 + added: uuid
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_051_add_on_uninitialized_vault_auto_initializes() {
+    let dir = empty_vault_dir();
+    let out = shikomi(dir.path())
+        .args(["add", "--kind", "text", "--label", "L", "--value", "V"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    assert!(stdout.contains("initialized plaintext vault"), "stdout: {stdout}");
+    assert!(stdout.contains("added: "), "stdout: {stdout}");
+
+    shikomi(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("L").and(predicate::str::contains("V")),
+        );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-052: vault 未初期化で edit / remove → exit 1
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_052_edit_on_uninitialized_vault_exits_with_code_one() {
+    let dir = empty_vault_dir();
+    let out = shikomi(dir.path())
+        .args([
+            "edit",
+            "--id",
+            "018f0000-0000-7000-8000-000000000000",
+            "--label",
+            "L",
+        ])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(stderr.contains("not initialized"), "stderr: {stderr}");
+}
+
+#[test]
+fn tc_e2e_052_remove_on_uninitialized_vault_exits_with_code_one() {
+    let dir = empty_vault_dir();
+    let out = shikomi(dir.path())
+        .args([
+            "remove",
+            "--id",
+            "018f0000-0000-7000-8000-000000000000",
+            "--yes",
+        ])
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(stderr.contains("not initialized"), "stderr: {stderr}");
+}

--- a/crates/shikomi-cli/tests/e2e_uninitialized.rs
+++ b/crates/shikomi-cli/tests/e2e_uninitialized.rs
@@ -55,16 +55,17 @@ fn tc_e2e_051_add_on_uninitialized_vault_auto_initializes() {
         .assert()
         .success();
     let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
-    assert!(stdout.contains("initialized plaintext vault"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("initialized plaintext vault"),
+        "stdout: {stdout}"
+    );
     assert!(stdout.contains("added: "), "stdout: {stdout}");
 
     shikomi(dir.path())
         .arg("list")
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("L").and(predicate::str::contains("V")),
-        );
+        .stdout(predicate::str::contains("L").and(predicate::str::contains("V")));
 }
 
 // -------------------------------------------------------------------

--- a/crates/shikomi-cli/tests/e2e_vault_path.rs
+++ b/crates/shikomi-cli/tests/e2e_vault_path.rs
@@ -1,0 +1,122 @@
+//! E2E テスト — vault パス優先順位
+//!
+//! 対応 REQ: REQ-CLI-005
+//! 対応 Issue: #20
+//! 対応 TC: TC-E2E-060 / 061 / 062
+//! 設計書: `docs/features/cli-vault-commands/test-design/e2e.md §9`
+//!
+//! env を操作するため `#[serial]` でプロセス内の並列衝突を避ける。
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serial_test::serial;
+use tempfile::TempDir;
+
+use common::tighten_perms_unix;
+
+fn fresh_dir() -> TempDir {
+    let d = TempDir::new().unwrap();
+    tighten_perms_unix(d.path());
+    d
+}
+
+fn add_one(dir: &std::path::Path, label: &str, value: &str) -> String {
+    let mut cmd = Command::cargo_bin("shikomi").unwrap();
+    let out = cmd
+        .env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .args([
+            "--vault-dir",
+            dir.to_str().unwrap(),
+            "add",
+            "--kind",
+            "text",
+            "--label",
+            label,
+            "--value",
+            value,
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    stdout
+        .lines()
+        .find(|l| l.starts_with("added: "))
+        .unwrap()
+        .trim_start_matches("added: ")
+        .trim()
+        .to_owned()
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-060: --vault-dir は env var より優先
+// -------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn tc_e2e_060_flag_overrides_env_var() {
+    let dir_a = fresh_dir();
+    let dir_b = fresh_dir();
+    let _id_a = add_one(dir_a.path(), "A_LABEL", "A_VAL");
+    // B を空のままに
+
+    let mut cmd = Command::cargo_bin("shikomi").unwrap();
+    cmd.env("SHIKOMI_VAULT_DIR", dir_b.path())
+        .env_remove("LANG")
+        .args(["--vault-dir", dir_a.path().to_str().unwrap(), "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("A_LABEL"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-061: env var は OS デフォルトより優先
+// -------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn tc_e2e_061_env_var_is_consumed_when_flag_absent() {
+    let dir_a = fresh_dir();
+    let _id = add_one(dir_a.path(), "E_LABEL", "E_VAL");
+
+    let mut cmd = Command::cargo_bin("shikomi").unwrap();
+    cmd.env("SHIKOMI_VAULT_DIR", dir_a.path())
+        .env_remove("LANG")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("E_LABEL"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-062: フラグも env もない → OS デフォルト解決に失敗しないこと
+// -------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn tc_e2e_062_os_default_resolution_does_not_crash() {
+    // HOME を tempdir に向け、XDG_DATA_HOME も設定して OS デフォルトを安定化。
+    let home = fresh_dir();
+    let xdg_data_home = home.path().join("share");
+    std::fs::create_dir_all(&xdg_data_home).unwrap();
+
+    let mut cmd = Command::cargo_bin("shikomi").unwrap();
+    // `--vault-dir` も env もなし → `dirs::data_dir()` 経由で OS デフォルトを解決
+    let assert = cmd
+        .env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .env("HOME", home.path())
+        .env("XDG_DATA_HOME", &xdg_data_home)
+        .arg("list")
+        .assert();
+
+    // 期待: exit 1（vault 未初期化）または exit 0（空 vault）
+    let code = assert.get_output().status.code();
+    // 2 (SystemError) / 3 (EncryptionUnsupported) になるとパス解決失敗の兆候
+    assert!(
+        matches!(code, Some(0) | Some(1)),
+        "OS default resolution should succeed; got exit code {code:?}"
+    );
+}

--- a/crates/shikomi-cli/tests/it_usecase_add.rs
+++ b/crates/shikomi-cli/tests/it_usecase_add.rs
@@ -1,0 +1,112 @@
+//! 結合テスト — `usecase::add::add_record`
+//!
+//! 対応 REQ: REQ-CLI-002, REQ-CLI-007, REQ-CLI-009
+//! 対応 Issue: #20
+//! 対応 TC: TC-IT-010 / TC-IT-011 / TC-IT-012 / TC-IT-013
+//! 設計書: `docs/features/cli-vault-commands/test-design/integration.md §4.2`
+
+mod common;
+
+use shikomi_cli::error::CliError;
+use shikomi_cli::input::AddInput;
+use shikomi_cli::usecase::{add::add_record, list::list_records};
+use shikomi_cli::view::ValueView;
+use shikomi_core::{RecordKind, RecordLabel, SecretString};
+
+use common::{fixed_time, fixtures, fresh_repo};
+
+// -------------------------------------------------------------------
+// TC-IT-010: add_record — vault 未作成 + Text 入力 → 自動初期化 + Round trip
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_010_add_record_text_auto_initializes_vault_and_roundtrips() {
+    let (dir, repo) = fresh_repo();
+    let now = fixed_time();
+
+    let input = AddInput {
+        kind: RecordKind::Text,
+        label: RecordLabel::try_new("L".to_owned()).unwrap(),
+        value: SecretString::from_string("V".to_owned()),
+    };
+    let id = add_record(&repo, input, now).expect("add_record");
+
+    // ラウンドトリップ: list_records で 1 件、Plain("V")
+    let views = list_records(&repo, dir.path()).expect("list_records");
+    assert_eq!(views.len(), 1);
+    assert_eq!(&views[0].id, &id);
+    match &views[0].value {
+        ValueView::Plain(s) => assert_eq!(s, "V"),
+        ValueView::Masked => panic!("expected Plain for Text kind"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-IT-011: add_record — Secret → 保存成功 + list で Masked + Debug に secret 不在
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_011_add_record_secret_persists_as_masked_view_without_leaking_value() {
+    let (dir, repo) = fresh_repo();
+    let now = fixed_time();
+
+    let input = AddInput {
+        kind: RecordKind::Secret,
+        label: RecordLabel::try_new("S".to_owned()).unwrap(),
+        value: SecretString::from_string("SECRET_TEST_VALUE".to_owned()),
+    };
+    let id = add_record(&repo, input, now).expect("add_record secret");
+
+    let views = list_records(&repo, dir.path()).expect("list_records");
+    assert_eq!(views.len(), 1);
+    assert_eq!(&views[0].id, &id);
+    assert!(
+        matches!(views[0].value, ValueView::Masked),
+        "Secret kind must become Masked view"
+    );
+
+    // Debug 表現に secret 値が含まれない
+    let dbg = format!("{views:?}");
+    assert!(
+        !dbg.contains("SECRET_TEST_VALUE"),
+        "Debug output must not leak secret: {dbg}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-012: add_record — 暗号化 vault で EncryptionUnsupported
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_012_add_record_on_encrypted_vault_returns_encryption_unsupported() {
+    let (dir, repo) = fresh_repo();
+    fixtures::create_encrypted_vault(dir.path()).expect("create encrypted vault");
+
+    let input = AddInput {
+        kind: RecordKind::Text,
+        label: RecordLabel::try_new("L".to_owned()).unwrap(),
+        value: SecretString::from_string("V".to_owned()),
+    };
+    let err = add_record(&repo, input, fixed_time()).expect_err("expected error");
+    assert!(
+        matches!(err, CliError::EncryptionUnsupported),
+        "expected EncryptionUnsupported, got {err:?}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-013: add_record — 不正ラベル（空文字）は RecordLabel::try_new の段階で拒否
+// （AddInput の構築時点で domain 検証されるため、本結合テストでは
+//   "try_new が DomainError を返す" ことを確認）
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_013_invalid_empty_label_is_rejected_at_record_label_try_new() {
+    let result = RecordLabel::try_new(String::new());
+    assert!(
+        result.is_err(),
+        "empty label should be rejected at try_new stage"
+    );
+    // run() では CliError::InvalidLabel(domain) でユーザー向けに整形される。
+    // その検証は E2E テスト (TC-E2E-015) で実施する。
+}

--- a/crates/shikomi-cli/tests/it_usecase_cross.rs
+++ b/crates/shikomi-cli/tests/it_usecase_cross.rs
@@ -9,7 +9,9 @@ mod common;
 
 use shikomi_cli::error::CliError;
 use shikomi_cli::input::{AddInput, ConfirmedRemoveInput, EditInput};
-use shikomi_cli::usecase::{add::add_record, edit::edit_record, list::list_records, remove::remove_record};
+use shikomi_cli::usecase::{
+    add::add_record, edit::edit_record, list::list_records, remove::remove_record,
+};
 use shikomi_core::{RecordId, RecordKind, RecordLabel, SecretString};
 use uuid::Uuid;
 

--- a/crates/shikomi-cli/tests/it_usecase_cross.rs
+++ b/crates/shikomi-cli/tests/it_usecase_cross.rs
@@ -1,0 +1,123 @@
+//! 結合テスト — UseCase 横断パラメタライズ
+//!
+//! 対応 REQ: REQ-CLI-009, REQ-CLI-010
+//! 対応 Issue: #20
+//! 対応 TC: TC-IT-040 / TC-IT-050
+//! 設計書: `docs/features/cli-vault-commands/test-design/integration.md §4.5`
+
+mod common;
+
+use shikomi_cli::error::CliError;
+use shikomi_cli::input::{AddInput, ConfirmedRemoveInput, EditInput};
+use shikomi_cli::usecase::{add::add_record, edit::edit_record, list::list_records, remove::remove_record};
+use shikomi_core::{RecordId, RecordKind, RecordLabel, SecretString};
+use uuid::Uuid;
+
+use common::{fixed_time, fixtures, fresh_repo};
+
+/// 暗号化 vault の内容（`vault.db` の SHA-256 ではなくサイズ + mtime）を採取する
+/// シンプルな不変性観測ヘルパー。副作用ゼロの UseCase 呼び出し前後で値が一致する
+/// ことを確認する目的。
+fn snapshot(path: &std::path::Path) -> (u64, Vec<u8>) {
+    let meta = std::fs::metadata(path).expect("metadata");
+    let size = meta.len();
+    let bytes = std::fs::read(path).expect("read vault.db");
+    (size, bytes)
+}
+
+// -------------------------------------------------------------------
+// TC-IT-040: 暗号化 vault に対して 4 UseCase 全てが EncryptionUnsupported
+// + vault 内容が変化しないこと（契約: 副作用ゼロ）
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_040_all_usecases_on_encrypted_vault_return_encryption_unsupported_without_side_effects() {
+    let (dir, repo) = fresh_repo();
+    fixtures::create_encrypted_vault(dir.path()).unwrap();
+    let vault_db = dir.path().join("vault.db");
+    let before = snapshot(&vault_db);
+
+    // list
+    let err = list_records(&repo, dir.path()).expect_err("list should err");
+    assert!(matches!(err, CliError::EncryptionUnsupported));
+
+    // add
+    let err = add_record(
+        &repo,
+        AddInput {
+            kind: RecordKind::Text,
+            label: RecordLabel::try_new("L".to_owned()).unwrap(),
+            value: SecretString::from_string("V".to_owned()),
+        },
+        fixed_time(),
+    )
+    .expect_err("add should err");
+    assert!(matches!(err, CliError::EncryptionUnsupported));
+
+    // edit
+    let err = edit_record(
+        &repo,
+        EditInput {
+            id: RecordId::new(Uuid::now_v7()).unwrap(),
+            label: Some(RecordLabel::try_new("L".to_owned()).unwrap()),
+            value: None,
+        },
+        fixed_time(),
+        dir.path(),
+    )
+    .expect_err("edit should err");
+    assert!(matches!(err, CliError::EncryptionUnsupported));
+
+    // remove
+    let err = remove_record(
+        &repo,
+        ConfirmedRemoveInput::new(RecordId::new(Uuid::now_v7()).unwrap()),
+        dir.path(),
+    )
+    .expect_err("remove should err");
+    assert!(matches!(err, CliError::EncryptionUnsupported));
+
+    let after = snapshot(&vault_db);
+    assert_eq!(
+        before.0, after.0,
+        "vault.db size changed under Encrypted Fail Fast path"
+    );
+    assert_eq!(
+        before.1, after.1,
+        "vault.db bytes changed under Encrypted Fail Fast path"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-050: vault 未初期化で list / edit / remove 全て VaultNotInitialized
+// （add は自動初期化のため対象外）
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_050_list_edit_remove_on_uninitialized_vault_all_return_vault_not_initialized() {
+    let (dir, repo) = fresh_repo();
+
+    let err = list_records(&repo, dir.path()).expect_err("list");
+    assert!(matches!(err, CliError::VaultNotInitialized(_)));
+
+    let err = edit_record(
+        &repo,
+        EditInput {
+            id: RecordId::new(Uuid::now_v7()).unwrap(),
+            label: Some(RecordLabel::try_new("L".to_owned()).unwrap()),
+            value: None,
+        },
+        fixed_time(),
+        dir.path(),
+    )
+    .expect_err("edit");
+    assert!(matches!(err, CliError::VaultNotInitialized(_)));
+
+    let err = remove_record(
+        &repo,
+        ConfirmedRemoveInput::new(RecordId::new(Uuid::now_v7()).unwrap()),
+        dir.path(),
+    )
+    .expect_err("remove");
+    assert!(matches!(err, CliError::VaultNotInitialized(_)));
+}

--- a/crates/shikomi-cli/tests/it_usecase_edit.rs
+++ b/crates/shikomi-cli/tests/it_usecase_edit.rs
@@ -144,8 +144,7 @@ fn tc_it_023_edit_record_on_encrypted_vault_returns_encryption_unsupported() {
         label: Some(RecordLabel::try_new("L".to_owned()).unwrap()),
         value: None,
     };
-    let err =
-        edit_record(&repo, input, fixed_time(), dir.path()).expect_err("expected error");
+    let err = edit_record(&repo, input, fixed_time(), dir.path()).expect_err("expected error");
     assert!(
         matches!(err, CliError::EncryptionUnsupported),
         "expected EncryptionUnsupported, got {err:?}"
@@ -164,8 +163,7 @@ fn tc_it_050a_edit_record_on_uninitialized_vault_returns_vault_not_initialized()
         label: Some(RecordLabel::try_new("L".to_owned()).unwrap()),
         value: None,
     };
-    let err =
-        edit_record(&repo, input, fixed_time(), dir.path()).expect_err("expected error");
+    let err = edit_record(&repo, input, fixed_time(), dir.path()).expect_err("expected error");
     assert!(
         matches!(err, CliError::VaultNotInitialized(_)),
         "expected VaultNotInitialized, got {err:?}"

--- a/crates/shikomi-cli/tests/it_usecase_edit.rs
+++ b/crates/shikomi-cli/tests/it_usecase_edit.rs
@@ -1,0 +1,173 @@
+//! 結合テスト — `usecase::edit::edit_record`
+//!
+//! 対応 REQ: REQ-CLI-003, REQ-CLI-009
+//! 対応 Issue: #20
+//! 対応 TC: TC-IT-020 / TC-IT-021 / TC-IT-022 / TC-IT-023
+//! 設計書: `docs/features/cli-vault-commands/test-design/integration.md §4.3`
+//!
+//! NOTE: TC-IT-024（label/value 共に None で UsageError）は `edit_record` の事前条件
+//! 検証ではなく `lib.rs::run_edit` 側の責務のため、本結合テストでは対応しない
+//! （設計書 §4.3 注記参照）。
+
+mod common;
+
+use shikomi_cli::error::CliError;
+use shikomi_cli::input::{AddInput, EditInput};
+use shikomi_cli::usecase::{add::add_record, edit::edit_record, list::list_records};
+use shikomi_cli::view::ValueView;
+use shikomi_core::{RecordId, RecordKind, RecordLabel, SecretString};
+use uuid::Uuid;
+
+use common::{fixed_time, fixtures, fresh_repo};
+
+// -------------------------------------------------------------------
+// TC-IT-020: edit_record — label のみ更新 → value 不変
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_020_edit_record_updates_only_label_when_value_is_none() {
+    let (dir, repo) = fresh_repo();
+    let now = fixed_time();
+
+    // 前提: 1 件存在
+    let id = add_record(
+        &repo,
+        AddInput {
+            kind: RecordKind::Text,
+            label: RecordLabel::try_new("OLD".to_owned()).unwrap(),
+            value: SecretString::from_string("ORIG_VALUE".to_owned()),
+        },
+        now,
+    )
+    .unwrap();
+
+    let edit_now = now + time::Duration::seconds(1);
+    let input = EditInput {
+        id: id.clone(),
+        label: Some(RecordLabel::try_new("NEW".to_owned()).unwrap()),
+        value: None,
+    };
+    let returned_id = edit_record(&repo, input, edit_now, dir.path()).expect("edit_record");
+    assert_eq!(returned_id, id);
+
+    // ラウンドトリップ: label が NEW に更新、value は ORIG_VALUE
+    let views = list_records(&repo, dir.path()).unwrap();
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].label.as_str(), "NEW");
+    match &views[0].value {
+        ValueView::Plain(s) => assert_eq!(s, "ORIG_VALUE"),
+        ValueView::Masked => panic!("Text kind should yield Plain"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-IT-021: edit_record — label と value 両方更新
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_021_edit_record_updates_both_fields_when_both_are_some() {
+    let (dir, repo) = fresh_repo();
+    let now = fixed_time();
+
+    let id = add_record(
+        &repo,
+        AddInput {
+            kind: RecordKind::Text,
+            label: RecordLabel::try_new("OLD".to_owned()).unwrap(),
+            value: SecretString::from_string("OLD_VAL".to_owned()),
+        },
+        now,
+    )
+    .unwrap();
+
+    let edit_now = now + time::Duration::seconds(1);
+    let input = EditInput {
+        id: id.clone(),
+        label: Some(RecordLabel::try_new("NEW".to_owned()).unwrap()),
+        value: Some(SecretString::from_string("NEW_VAL".to_owned())),
+    };
+    edit_record(&repo, input, edit_now, dir.path()).expect("edit_record");
+
+    let views = list_records(&repo, dir.path()).unwrap();
+    assert_eq!(views[0].label.as_str(), "NEW");
+    match &views[0].value {
+        ValueView::Plain(s) => assert_eq!(s, "NEW_VAL"),
+        ValueView::Masked => panic!("Text kind should yield Plain"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-IT-022: edit_record — 存在しない id で RecordNotFound
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_022_edit_record_with_nonexistent_id_returns_record_not_found() {
+    let (dir, repo) = fresh_repo();
+    let now = fixed_time();
+
+    // 1 件を追加しておく（vault 初期化のため）
+    add_record(
+        &repo,
+        AddInput {
+            kind: RecordKind::Text,
+            label: RecordLabel::try_new("L".to_owned()).unwrap(),
+            value: SecretString::from_string("V".to_owned()),
+        },
+        now,
+    )
+    .unwrap();
+
+    let missing_id = RecordId::new(Uuid::now_v7()).unwrap();
+    let input = EditInput {
+        id: missing_id.clone(),
+        label: Some(RecordLabel::try_new("X".to_owned()).unwrap()),
+        value: None,
+    };
+    let err = edit_record(&repo, input, now, dir.path()).expect_err("expected error");
+    match err {
+        CliError::RecordNotFound(id) => assert_eq!(id, missing_id),
+        other => panic!("expected RecordNotFound, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-IT-023: edit_record — 暗号化 vault で EncryptionUnsupported
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_023_edit_record_on_encrypted_vault_returns_encryption_unsupported() {
+    let (dir, repo) = fresh_repo();
+    fixtures::create_encrypted_vault(dir.path()).unwrap();
+
+    let input = EditInput {
+        id: RecordId::new(Uuid::now_v7()).unwrap(),
+        label: Some(RecordLabel::try_new("L".to_owned()).unwrap()),
+        value: None,
+    };
+    let err =
+        edit_record(&repo, input, fixed_time(), dir.path()).expect_err("expected error");
+    assert!(
+        matches!(err, CliError::EncryptionUnsupported),
+        "expected EncryptionUnsupported, got {err:?}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-050 (edit 部分): vault 未初期化で VaultNotInitialized
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_050a_edit_record_on_uninitialized_vault_returns_vault_not_initialized() {
+    let (dir, repo) = fresh_repo();
+    let input = EditInput {
+        id: RecordId::new(Uuid::now_v7()).unwrap(),
+        label: Some(RecordLabel::try_new("L".to_owned()).unwrap()),
+        value: None,
+    };
+    let err =
+        edit_record(&repo, input, fixed_time(), dir.path()).expect_err("expected error");
+    assert!(
+        matches!(err, CliError::VaultNotInitialized(_)),
+        "expected VaultNotInitialized, got {err:?}"
+    );
+}

--- a/crates/shikomi-cli/tests/it_usecase_list.rs
+++ b/crates/shikomi-cli/tests/it_usecase_list.rs
@@ -1,0 +1,143 @@
+//! 結合テスト — `usecase::list::list_records`
+//!
+//! 対応 REQ: REQ-CLI-001, REQ-CLI-007, REQ-CLI-010
+//! 対応 Issue: #20
+//! 対応 TC: TC-IT-001 / TC-IT-002 / TC-IT-003
+//! 設計書: `docs/features/cli-vault-commands/test-design/integration.md §4.1`
+
+mod common;
+
+use shikomi_cli::error::CliError;
+use shikomi_cli::usecase::list::list_records;
+use shikomi_cli::view::ValueView;
+use shikomi_core::{
+    Record, RecordId, RecordKind, RecordLabel, RecordPayload, SecretString, Vault, VaultHeader,
+    VaultVersion,
+};
+use shikomi_infra::persistence::VaultRepository;
+use uuid::Uuid;
+
+use common::{fixed_time, fresh_repo};
+
+// -------------------------------------------------------------------
+// TC-IT-001: list_records — 空 vault（records 0 件）は Ok(Vec::new())
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_001_list_records_empty_vault_returns_empty_vec() {
+    let (dir, repo) = fresh_repo();
+    // 空 vault を初期化（record 0 件）
+    let header = VaultHeader::new_plaintext(VaultVersion::CURRENT, fixed_time()).unwrap();
+    let vault = Vault::new(header);
+    repo.save(&vault).expect("save empty vault");
+
+    let result = list_records(&repo, dir.path()).expect("list_records");
+    assert!(
+        result.is_empty(),
+        "empty vault should yield empty Vec, got {result:?}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-002: list_records — 3 件 mixed (Text x 2, Secret x 1)
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_002_list_records_mixed_kinds_returns_three_views_with_correct_masking() {
+    let (dir, repo) = fresh_repo();
+    let now = fixed_time();
+    let header = VaultHeader::new_plaintext(VaultVersion::CURRENT, now).unwrap();
+    let mut vault = Vault::new(header);
+
+    // Text x 2
+    for (label, value) in [("url-1", "https://example.com/a"), ("url-2", "https://example.com/b")] {
+        let record = Record::new(
+            RecordId::new(Uuid::now_v7()).unwrap(),
+            RecordKind::Text,
+            RecordLabel::try_new(label.to_owned()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string(value.to_owned())),
+            now,
+        );
+        vault.add_record(record).unwrap();
+    }
+    // Secret x 1
+    let record = Record::new(
+        RecordId::new(Uuid::now_v7()).unwrap(),
+        RecordKind::Secret,
+        RecordLabel::try_new("pw".to_owned()).unwrap(),
+        RecordPayload::Plaintext(SecretString::from_string(
+            "SECRET_TEST_VALUE".to_owned(),
+        )),
+        now,
+    );
+    vault.add_record(record).unwrap();
+    repo.save(&vault).expect("save");
+
+    let views = list_records(&repo, dir.path()).expect("list_records");
+    assert_eq!(views.len(), 3, "expected 3 views, got {}", views.len());
+
+    // Secret は 1 件、Text は 2 件、Secret は Masked のみ
+    let secret_views: Vec<_> = views
+        .iter()
+        .filter(|v| matches!(v.kind, RecordKind::Secret))
+        .collect();
+    assert_eq!(secret_views.len(), 1);
+    assert!(matches!(secret_views[0].value, ValueView::Masked));
+
+    let text_views: Vec<_> = views
+        .iter()
+        .filter(|v| matches!(v.kind, RecordKind::Text))
+        .collect();
+    assert_eq!(text_views.len(), 2);
+    for v in text_views {
+        assert!(
+            matches!(v.value, ValueView::Plain(_)),
+            "Text kind should yield Plain"
+        );
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-IT-003: list_records — exists()=false（vault.db 不在）で VaultNotInitialized
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_003_list_records_vault_db_missing_returns_vault_not_initialized() {
+    let (dir, repo) = fresh_repo();
+    // save() を呼ばない → vault.db は存在しない
+    let err = list_records(&repo, dir.path()).expect_err("expected error");
+    assert!(
+        matches!(err, CliError::VaultNotInitialized(_)),
+        "expected VaultNotInitialized, got {err:?}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-002 補: list_records の返却値に secret 原文が含まれないこと
+// (secret マスキングの横串検証、REQ-CLI-007)
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_002b_list_records_debug_representation_excludes_secret_value() {
+    let (dir, repo) = fresh_repo();
+    let now = fixed_time();
+    let header = VaultHeader::new_plaintext(VaultVersion::CURRENT, now).unwrap();
+    let mut vault = Vault::new(header);
+    vault
+        .add_record(Record::new(
+            RecordId::new(Uuid::now_v7()).unwrap(),
+            RecordKind::Secret,
+            RecordLabel::try_new("pw".to_owned()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string("SECRET_TEST_VALUE".to_owned())),
+            now,
+        ))
+        .unwrap();
+    repo.save(&vault).unwrap();
+
+    let views = list_records(&repo, dir.path()).unwrap();
+    let dbg = format!("{views:?}");
+    assert!(
+        !dbg.contains("SECRET_TEST_VALUE"),
+        "RecordView Debug must not leak secret: {dbg}"
+    );
+}

--- a/crates/shikomi-cli/tests/it_usecase_list.rs
+++ b/crates/shikomi-cli/tests/it_usecase_list.rs
@@ -50,7 +50,10 @@ fn tc_it_002_list_records_mixed_kinds_returns_three_views_with_correct_masking()
     let mut vault = Vault::new(header);
 
     // Text x 2
-    for (label, value) in [("url-1", "https://example.com/a"), ("url-2", "https://example.com/b")] {
+    for (label, value) in [
+        ("url-1", "https://example.com/a"),
+        ("url-2", "https://example.com/b"),
+    ] {
         let record = Record::new(
             RecordId::new(Uuid::now_v7()).unwrap(),
             RecordKind::Text,
@@ -65,9 +68,7 @@ fn tc_it_002_list_records_mixed_kinds_returns_three_views_with_correct_masking()
         RecordId::new(Uuid::now_v7()).unwrap(),
         RecordKind::Secret,
         RecordLabel::try_new("pw".to_owned()).unwrap(),
-        RecordPayload::Plaintext(SecretString::from_string(
-            "SECRET_TEST_VALUE".to_owned(),
-        )),
+        RecordPayload::Plaintext(SecretString::from_string("SECRET_TEST_VALUE".to_owned())),
         now,
     );
     vault.add_record(record).unwrap();

--- a/crates/shikomi-cli/tests/it_usecase_remove.rs
+++ b/crates/shikomi-cli/tests/it_usecase_remove.rs
@@ -1,0 +1,109 @@
+//! 結合テスト — `usecase::remove::remove_record`
+//!
+//! 対応 REQ: REQ-CLI-004, REQ-CLI-009, REQ-CLI-010
+//! 対応 Issue: #20
+//! 対応 TC: TC-IT-030 / TC-IT-031 / TC-IT-033
+//! 設計書: `docs/features/cli-vault-commands/test-design/integration.md §4.4`
+//!
+//! NOTE: TC-IT-032（`bool` フィールド撤廃の型契約）は `unit.md` §TC-UT-110 の
+//! doc-test 相当で検証。本結合テストでは対応しない（設計書 §4.4 注記）。
+
+mod common;
+
+use shikomi_cli::error::CliError;
+use shikomi_cli::input::{AddInput, ConfirmedRemoveInput};
+use shikomi_cli::usecase::{add::add_record, list::list_records, remove::remove_record};
+use shikomi_core::{RecordId, RecordKind, RecordLabel, SecretString};
+use uuid::Uuid;
+
+use common::{fixed_time, fixtures, fresh_repo};
+
+// -------------------------------------------------------------------
+// TC-IT-030: remove_record — 既存 id を削除するとレコードが消える
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_030_remove_record_removes_existing_record_and_roundtrips_empty() {
+    let (dir, repo) = fresh_repo();
+    let now = fixed_time();
+
+    let id = add_record(
+        &repo,
+        AddInput {
+            kind: RecordKind::Text,
+            label: RecordLabel::try_new("L".to_owned()).unwrap(),
+            value: SecretString::from_string("V".to_owned()),
+        },
+        now,
+    )
+    .unwrap();
+
+    let input = ConfirmedRemoveInput::new(id.clone());
+    let returned_id = remove_record(&repo, input, dir.path()).expect("remove_record");
+    assert_eq!(returned_id, id);
+
+    let views = list_records(&repo, dir.path()).unwrap();
+    assert!(views.is_empty(), "vault should be empty after remove");
+}
+
+// -------------------------------------------------------------------
+// TC-IT-031: remove_record — 存在しない id で RecordNotFound
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_031_remove_record_with_nonexistent_id_returns_record_not_found() {
+    let (dir, repo) = fresh_repo();
+    let now = fixed_time();
+
+    // vault 初期化のため 1 件追加
+    add_record(
+        &repo,
+        AddInput {
+            kind: RecordKind::Text,
+            label: RecordLabel::try_new("L".to_owned()).unwrap(),
+            value: SecretString::from_string("V".to_owned()),
+        },
+        now,
+    )
+    .unwrap();
+
+    let missing = RecordId::new(Uuid::now_v7()).unwrap();
+    let input = ConfirmedRemoveInput::new(missing.clone());
+    let err = remove_record(&repo, input, dir.path()).expect_err("expected error");
+    match err {
+        CliError::RecordNotFound(id) => assert_eq!(id, missing),
+        other => panic!("expected RecordNotFound, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-IT-033: remove_record — 暗号化 vault で EncryptionUnsupported
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_033_remove_record_on_encrypted_vault_returns_encryption_unsupported() {
+    let (dir, repo) = fresh_repo();
+    fixtures::create_encrypted_vault(dir.path()).unwrap();
+
+    let input = ConfirmedRemoveInput::new(RecordId::new(Uuid::now_v7()).unwrap());
+    let err = remove_record(&repo, input, dir.path()).expect_err("expected error");
+    assert!(
+        matches!(err, CliError::EncryptionUnsupported),
+        "expected EncryptionUnsupported, got {err:?}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-050 (remove 部分): vault 未初期化で VaultNotInitialized
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_050b_remove_record_on_uninitialized_vault_returns_vault_not_initialized() {
+    let (dir, repo) = fresh_repo();
+    let input = ConfirmedRemoveInput::new(RecordId::new(Uuid::now_v7()).unwrap());
+    let err = remove_record(&repo, input, dir.path()).expect_err("expected error");
+    assert!(
+        matches!(err, CliError::VaultNotInitialized(_)),
+        "expected VaultNotInitialized, got {err:?}"
+    );
+}

--- a/crates/shikomi-core/src/vault/record/aggregate.rs
+++ b/crates/shikomi-core/src/vault/record/aggregate.rs
@@ -174,4 +174,25 @@ impl Record {
         self.updated_at = ts;
         Ok(self)
     }
+
+    /// Text レコードの平文プレビュー（先頭 `max_chars` char）を返す。
+    ///
+    /// - `RecordKind::Text` かつ `RecordPayload::Plaintext(SecretString)` のとき `Some(先頭 N char)`
+    /// - それ以外（`Secret` kind / `Encrypted` variant）は `None`
+    ///
+    /// `SecretString::expose_secret()` は本関数内で完結する（`shikomi-cli` から呼ばせないための
+    /// 集約側 read-only アクセサ。`docs/features/cli-vault-commands/basic-design/security.md
+    /// §expose_secret 経路監査` 参照）。grapheme 境界は考慮せず char 単位で切る（CLI プレビュー用途）。
+    ///
+    /// 境界: `max_chars == 0` は `Some("".to_owned())` を返す。`max_chars` が文字列長を超える
+    /// 場合は全文を返す。
+    #[must_use]
+    pub fn text_preview(&self, max_chars: usize) -> Option<String> {
+        match (self.kind, &self.payload) {
+            (RecordKind::Text, RecordPayload::Plaintext(secret)) => {
+                Some(secret.expose_secret().chars().take(max_chars).collect())
+            }
+            _ => None,
+        }
+    }
 }

--- a/crates/shikomi-core/src/vault/record/tests.rs
+++ b/crates/shikomi-core/src/vault/record/tests.rs
@@ -245,3 +245,82 @@ fn test_record_rehydrate_truncates_subsecond_to_microseconds() {
         "切り捨て後も updated_at >= created_at を保持すべき"
     );
 }
+
+// --- text_preview の挙動検証（cli-vault-commands feature 用アクセサ） ---
+
+#[test]
+fn test_text_preview_text_kind_returns_prefix() {
+    let record = Record::new(
+        make_id(),
+        RecordKind::Text,
+        RecordLabel::try_new("l".to_string()).unwrap(),
+        RecordPayload::Plaintext(SecretString::from_string("hello world".to_string())),
+        OffsetDateTime::UNIX_EPOCH,
+    );
+    assert_eq!(record.text_preview(5), Some("hello".to_string()));
+}
+
+#[test]
+fn test_text_preview_max_chars_zero_returns_empty_string() {
+    let record = Record::new(
+        make_id(),
+        RecordKind::Text,
+        RecordLabel::try_new("l".to_string()).unwrap(),
+        RecordPayload::Plaintext(SecretString::from_string("value".to_string())),
+        OffsetDateTime::UNIX_EPOCH,
+    );
+    assert_eq!(record.text_preview(0), Some(String::new()));
+}
+
+#[test]
+fn test_text_preview_max_chars_exceeds_length_returns_whole_string() {
+    let record = Record::new(
+        make_id(),
+        RecordKind::Text,
+        RecordLabel::try_new("l".to_string()).unwrap(),
+        RecordPayload::Plaintext(SecretString::from_string("abc".to_string())),
+        OffsetDateTime::UNIX_EPOCH,
+    );
+    assert_eq!(record.text_preview(100), Some("abc".to_string()));
+}
+
+#[test]
+fn test_text_preview_multibyte_char_unit_truncation() {
+    // 先頭 3 char を取る。grapheme ではなく char 単位なので "あいう" が返る。
+    let record = Record::new(
+        make_id(),
+        RecordKind::Text,
+        RecordLabel::try_new("l".to_string()).unwrap(),
+        RecordPayload::Plaintext(SecretString::from_string("あいうえお".to_string())),
+        OffsetDateTime::UNIX_EPOCH,
+    );
+    assert_eq!(record.text_preview(3), Some("あいう".to_string()));
+}
+
+#[test]
+fn test_text_preview_secret_kind_returns_none() {
+    let record = Record::new(
+        make_id(),
+        RecordKind::Secret,
+        RecordLabel::try_new("l".to_string()).unwrap(),
+        RecordPayload::Plaintext(SecretString::from_string("super-secret".to_string())),
+        OffsetDateTime::UNIX_EPOCH,
+    );
+    assert_eq!(record.text_preview(10), None);
+}
+
+#[test]
+fn test_text_preview_encrypted_variant_returns_none() {
+    let nonce = NonceBytes::try_new(&[0u8; 12]).unwrap();
+    let ciphertext = CipherText::try_new(vec![0u8; 32].into_boxed_slice()).unwrap();
+    let aad = make_aad();
+    let enc = RecordPayloadEncrypted::new(nonce, ciphertext, aad).unwrap();
+    let record = Record::new(
+        make_id(),
+        RecordKind::Text,
+        RecordLabel::try_new("l".to_string()).unwrap(),
+        RecordPayload::Encrypted(enc),
+        OffsetDateTime::UNIX_EPOCH,
+    );
+    assert_eq!(record.text_preview(10), None);
+}

--- a/crates/shikomi-infra/src/persistence/paths.rs
+++ b/crates/shikomi-infra/src/persistence/paths.rs
@@ -7,6 +7,31 @@ use std::path::{Component, Path, PathBuf};
 use super::error::{PersistenceError, VaultDirReason};
 
 // -------------------------------------------------------------------
+// vault dir 解決ヘルパ（crate 内部のみ）
+// -------------------------------------------------------------------
+
+/// `SHIKOMI_VAULT_DIR` 環境変数 → OS データディレクトリ直下の `shikomi/` の順で
+/// vault ディレクトリパスを解決する。
+///
+/// `SqliteVaultRepository::new()` の後方互換ラッパ用。新規の CLI / GUI コードは
+/// 本関数ではなく `SqliteVaultRepository::from_directory(&Path)` を直接使うこと
+/// （env 解決の真実源は clap attribute 側に寄せる、
+/// `docs/features/cli-vault-commands/detailed-design/infra-changes.md §変更 2`）。
+///
+/// # Errors
+/// `dirs::data_dir()` が `None` かつ `SHIKOMI_VAULT_DIR` 未設定の場合
+/// `PersistenceError::CannotResolveVaultDir` を返す。
+pub(crate) fn resolve_os_default_or_env() -> Result<PathBuf, PersistenceError> {
+    if let Ok(val) = std::env::var(ENV_VAR_VAULT_DIR) {
+        Ok(PathBuf::from(val))
+    } else {
+        dirs::data_dir()
+            .ok_or(PersistenceError::CannotResolveVaultDir)
+            .map(|base| base.join(APP_SUBDIR_NAME))
+    }
+}
+
+// -------------------------------------------------------------------
 // 定数
 // -------------------------------------------------------------------
 

--- a/crates/shikomi-infra/src/persistence/repository.rs
+++ b/crates/shikomi-infra/src/persistence/repository.rs
@@ -1,6 +1,6 @@
 //! `SqliteVaultRepository` — `VaultRepository` の SQLite 実装。
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::time::Instant;
 
 use rusqlite::{Connection, OpenFlags};
@@ -33,14 +33,22 @@ impl SqliteVaultRepository {
     /// - vault ディレクトリの解決失敗: `PersistenceError::CannotResolveVaultDir`
     /// - ディレクトリ検証失敗: `PersistenceError::InvalidVaultDir`
     pub fn new() -> Result<Self, PersistenceError> {
-        let dir = if let Ok(val) = std::env::var(paths::ENV_VAR_VAULT_DIR) {
-            PathBuf::from(val)
-        } else {
-            dirs::data_dir()
-                .ok_or(PersistenceError::CannotResolveVaultDir)?
-                .join(paths::APP_SUBDIR_NAME)
-        };
-        let paths = VaultPaths::new(dir)?;
+        let dir = paths::resolve_os_default_or_env()?;
+        Self::from_directory(&dir)
+    }
+
+    /// 明示的な vault ディレクトリ path を受け取って `SqliteVaultRepository` を構築する。
+    ///
+    /// 呼び出し側（CLI / GUI）で `--vault-dir` フラグ等を thread-safe に渡すためのエントリポイント。
+    /// `std::env` を一切参照しない。
+    ///
+    /// # Errors
+    ///
+    /// - ディレクトリ検証失敗（絶対パス / path traversal / symlink / 保護領域 / 非ディレクトリ等）:
+    ///   `PersistenceError::InvalidVaultDir`
+    /// - `fs::canonicalize` 失敗: `PersistenceError::InvalidVaultDir { reason: Canonicalize }`
+    pub fn from_directory(path: &Path) -> Result<Self, PersistenceError> {
+        let paths = VaultPaths::new(path.to_path_buf())?;
         Ok(Self { paths })
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -60,6 +60,12 @@ skip = [
     # getrandom 0.2.x は uuid 1.x の依存。0.4.x は wit-bindgen 経由の新規依存。
     # Issue #7/#10 で導入。バージョン更新時に再評価すること。
     { name = "getrandom", version = "0.2" },
+    # rustix / linux-raw-sys は `fs4` 0.9（shikomi-infra）が旧系（rustix 0.38 / linux-raw-sys 0.4）、
+    # `tempfile` 3.x / `clap` 4.x などの新しい依存が新系（rustix 1.x / linux-raw-sys 0.12）を
+    # 引くため共存する。Issue #20（cli-vault-commands 実装）で顕在化。
+    # `fs4` が rustix 1.x に追従次第、両エントリとも削除して重複解消する。
+    { name = "rustix", version = "0.38" },
+    { name = "linux-raw-sys", version = "0.4" },
 ]
 skip-tree = []
 

--- a/docs/architecture/tech-stack.md
+++ b/docs/architecture/tech-stack.md
@@ -305,3 +305,19 @@ flowchart LR
 - `std::time::SystemTime`（タイムゾーン非対応）
 - `anyhow` / `eyre`（動的エラー型、呼び出し側がエラー種別で分岐できない）
 - `async_trait` / `tokio` 等の非同期ランタイム（`shikomi-core` は同期のみ、async は境界層で委譲）
+
+### 4.6 `shikomi-cli` 層で追加する crate（feature `cli-vault-commands` で導入）
+
+Phase 1 CLI（`list` / `add` / `edit` / `remove`）の実装に伴い `[workspace.dependencies]` へ以下を追加する。`shikomi-core` とは独立した上位層の依存であり、ドメイン層へは波及させない。
+
+| 用途 | 採用 crate | バージョン方針 | 根拠 |
+|-----|---------|-------------|------|
+| CLI パーサ | `clap`（feature `derive` / `env` / `wrap_help`） | major ピン（v4） | §2.1 CLI パーサ行の既定採用。`env` feature で `SHIKOMI_VAULT_DIR` の吸収を clap に一任し、アプリ層で `std::env::var` を重ねて呼ばない（真実源の二重化防止） |
+| アプリ層エラー包み | `anyhow` | major ピン（v1） | `shikomi-core` ドメインエラーは `thiserror` で厳密な型表現を維持しつつ、CLI / 将来のアプリ層で扱う上位の総合エラーは `anyhow` でラップする。`shikomi-core` では採用禁止（§4.5）、CLI 層限定 |
+| TTY 判定 | `is-terminal`（feature なし、v0.4 系） | minor ピン | stdin/stdout の TTY 判定に使用。MSRV 1.80 では `std::io::IsTerminal` が利用可能だが、テスト差し替え容易性のため crate 経由を採用 |
+| 非エコー stdin 入力 | `rpassword` | major ピン（v7） | secret 値入力時の非エコー読取。Unix `termios` / Windows `SetConsoleMode` を薄くラップする業界標準 |
+| tracing init | `tracing-subscriber`（feature `fmt` / `env-filter`） | minor ピン | CLI 起動時に `tracing` subscriber を初期化するため（ログ出力の標準化、RUST_LOG 連携）。`shikomi-core` / `shikomi-infra` 側は `tracing` マクロのみ使用し subscriber 選定は bin 側に任せる |
+| E2E プロセス起動 | `assert_cmd`（dev-dep） | major ピン（v2） | `crates/shikomi-cli/tests/e2e_*.rs` でサブプロセス起動 + stdout / stderr / exit code 検証 |
+| `assert_cmd` 補助 | `predicates`（dev-dep） | major ピン（v3） | `assert_cmd` の assertion 記述で併用する業界標準 |
+
+**CI との連携**: 本 feature の契約（`SecretString::expose_secret()` を `shikomi-cli/src/` 内で呼ばない / panic hook で `tracing::*` を呼ばず payload を参照しない）は `scripts/ci/audit-secret-paths.sh` で静的検証する（`TC-CI-012〜015`）。audit ワークフロー（`.github/workflows/audit.yml`）に組込み済み。

--- a/scripts/ci/audit-secret-paths.sh
+++ b/scripts/ci/audit-secret-paths.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# CI audit script — cli-vault-commands feature の secret 経路契約を静的に検証する。
+#
+# 対応 TC:
+# - TC-CI-013: `crates/shikomi-cli/src/` 配下で `expose_secret` 呼び出しが 0 件
+# - TC-CI-014: panic hook 内で `tracing::*` マクロを呼ばない
+# - TC-CI-015: panic hook 内で `info.payload()` / `info.message()` 等を参照しない
+#
+# 設計根拠: docs/features/cli-vault-commands/test-design/ci.md §1.1
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+fail() {
+    echo "::error::$1"
+    exit 1
+}
+
+# --- TC-CI-013 ------------------------------------------------------
+echo "[TC-CI-013] expose_secret 呼び出しが shikomi-cli/src/ に 0 件であることを確認"
+if matches="$(grep -rn 'expose_secret' crates/shikomi-cli/src/)"; then
+    echo "$matches"
+    fail "TC-CI-013 FAIL: crates/shikomi-cli/src/ 配下に expose_secret 呼び出しが存在します"
+fi
+echo "[TC-CI-013] PASS"
+
+# --- TC-CI-014 / TC-CI-015 -----------------------------------------
+# panic hook ブロック（std::panic::set_hook から fn panic_hook 本体まで）を抽出し、
+# tracing::* マクロ呼び出し / PanicHookInfo payload 参照が存在しないことを確認する。
+echo "[TC-CI-014/015] panic hook 内で tracing 呼び出し / payload 参照を禁止する契約を検証"
+
+# lib.rs / main.rs 限定で fn panic_hook(...) の本体を抽出（awk で `fn panic_hook` 開始 〜 末尾閉じ括弧）。
+panic_hook_body="$(awk '/fn panic_hook\(/,/^}$/' \
+    crates/shikomi-cli/src/lib.rs \
+    crates/shikomi-cli/src/main.rs 2>/dev/null || true)"
+
+if [[ -n "$panic_hook_body" ]]; then
+    if echo "$panic_hook_body" | grep -qE 'tracing::'; then
+        echo "$panic_hook_body"
+        fail "TC-CI-014 FAIL: panic hook 内で tracing マクロが呼ばれています"
+    fi
+    if echo "$panic_hook_body" | grep -qE '\.payload\(\)|info\.payload|PanicHookInfo::payload|info\.message|info\.location'; then
+        echo "$panic_hook_body"
+        fail "TC-CI-015 FAIL: panic hook 内で PanicHookInfo::payload/message/location を参照しています"
+    fi
+fi
+echo "[TC-CI-014/015] PASS"
+
+# --- TC-CI-012（補強）----------------------------------------------
+# 具体型 `SqliteVaultRepository` の参照が usecase/presenter/error/view/input/io に漏れていないか
+echo "[TC-CI-012] SqliteVaultRepository 具体型参照の漏洩監査"
+leak_dirs=(
+    "crates/shikomi-cli/src/usecase/"
+    "crates/shikomi-cli/src/presenter/"
+    "crates/shikomi-cli/src/io/"
+)
+leak_files=(
+    "crates/shikomi-cli/src/error.rs"
+    "crates/shikomi-cli/src/view.rs"
+    "crates/shikomi-cli/src/input.rs"
+    "crates/shikomi-cli/src/cli.rs"
+)
+for target in "${leak_dirs[@]}" "${leak_files[@]}"; do
+    if [[ -e "$target" ]] && grep -rn 'SqliteVaultRepository' "$target" > /dev/null; then
+        grep -rn 'SqliteVaultRepository' "$target"
+        fail "TC-CI-012 FAIL: $target に SqliteVaultRepository 参照が漏れています（lib.rs の run() 周辺に限定する契約）"
+    fi
+done
+echo "[TC-CI-012] PASS"
+
+echo "ALL secret-path audits PASS"


### PR DESCRIPTION
## Summary

- `shikomi-cli` crate に `[lib] + [[bin]]` 2 ターゲット構成で `run()` コンポジションルートと 4 サブコマンド（`list` / `add` / `edit` / `remove`）を実装
- `shikomi-core::Record::text_preview(&self, max_chars)` を追加（expose_secret を core 内に封じる）
- `shikomi-infra::SqliteVaultRepository::from_directory(&Path)` を追加（`--vault-dir` を thread-safe に受け取る経路）
- `scripts/ci/audit-secret-paths.sh` を追加し、TC-CI-012/013/014/015（secret 経路監査 / panic hook 契約）を静的検証する CI ステップを `audit` ワークフローに組み込み
- 設計書 `docs/features/cli-vault-commands/` 16 受入基準 × REQ-CLI-001〜012 の契約を満たすように実装

Closes #20

## 受入基準の実装根拠

| 受入基準 | 実装箇所 |
|---------|---------|
| 1 | `presenter::list::render_list` / `view::RecordView::from_record`（空 / 1 件 / 複数件 / Secret マスク） |
| 2 | `usecase::add::add_record` + `usecase::list::list_records` |
| 3 | `io::terminal::read_password`（非エコー入力）+ `ValueView::Masked` |
| 4 | `presenter::warning::render_shell_history_warning`（MSG-CLI-050） |
| 5 | `cli::EditArgs` + `lib.rs::run_edit`（`--value`/`--stdin` 併用 Fail Fast、`--kind` フィールド非定義） |
| 6 | `lib.rs::run_remove`（TTY プロンプト / `CliError::NonInteractiveRemove`） |
| 7 | `RemoveArgs.yes` による確認スキップ |
| 8 | `usecase::*` が `protection_mode() == Encrypted` を全経路でチェック、`ExitCode::EncryptionUnsupported = 3` |
| 9 | `usecase::add` は vault 未作成時に `VaultHeader::new_plaintext` で自動作成、他は `VaultNotInitialized` |
| 10 | `CliArgs.vault_dir` の `#[arg(env = SHIKOMI_VAULT_DIR)]` + `io::paths::resolve_os_default_vault_dir` |
| 11 | `presenter::error::render_error` + `presenter::Locale::detect_from_lang_env_value` |
| 12/13 | `cargo fmt --check --all` / `cargo clippy --workspace` / `cargo test --workspace` ローカル全 pass |
| 14 | `docs/architecture/context/process-model.md` §4.1.1 Phase 区分は既登録（設計 PR 由来） |
| 15 | `crates/shikomi-cli/src/{lib,main}.rs` + `usecase/` / `presenter/` / `io/` の 3 層構造 |
| 16 | `scripts/ci/audit-secret-paths.sh`（TC-CI-012/013/014/015、audit workflow 組込み済み） |

## ローカル検証結果

- `cargo fmt --check --all`: exit 0
- `cargo clippy --workspace --all-targets`: exit 0（pedantic warning のみ、workspace lint 設定通り）
- `cargo test --workspace`: **全 203 テスト PASS**（shikomi-core / shikomi-infra / shikomi-cli の UT + 既存 IT）
- `bash scripts/ci/audit-secret-paths.sh`: TC-CI-012/013/014/015 全 PASS

## Contract 検証

| 契約 | 状態 |
|------|------|
| `grep -rn expose_secret crates/shikomi-cli/src/` が 0 件 | ✅ |
| panic hook が `tracing::*` を呼ばない | ✅ |
| panic hook が `info.payload()` / `message()` / `location()` を参照しない | ✅ |
| `list` ID カラムが UUIDv7 全長 36 文字（トランケートなし） | ✅ |
| `ConfirmedRemoveInput` が `confirmed: bool` フィールドを持たない（型で確認経路を強制） | ✅ |

## テスト担当（涅マユリ）への申し送り事項

ユニットテストは各ソース `#[cfg(test)] mod tests` に配置済み（43 tests 追加）。結合 / E2E テスト（`tests/` 配下の `it_usecase_*.rs` / `e2e_*.rs`）は**未着手**——`test-design/` で定義された TC-IT-001〜050 / TC-E2E-001〜102 をテスト担当側で追加してほしい。暗号化 vault フィクスチャ（`test-design/unit.md §10.3`）の test helper を shikomi-infra 側に用意する作業も同じフェーズで想定。

## Test plan

- [ ] CI: branch-policy / lint / test-infra / unit-core / pr-title-check / audit が全てグリーンになることを確認
- [ ] テスト担当（涅マユリ）が E2E / 結合テストを追加する
- [ ] テスト完了後、外部レビュー（まこちゃん）承認 → `develop` マージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)