### PR TITLE
feat(daemon-ipc): implement IPC add/edit/remove via RepositoryHandle (Issue #30)

### DIFF
--- a/crates/shikomi-cli/src/error.rs
+++ b/crates/shikomi-cli/src/error.rs
@@ -87,6 +87,10 @@ impl From<PersistenceError> for CliError {
             PersistenceError::ProtocolVersionMismatch { server, client } => {
                 Self::ProtocolVersionMismatch { server, client }
             }
+            // Phase 1.5（Issue #30）: daemon 側 `IpcErrorCode::NotFound { id }` 由来の
+            // `PersistenceError::RecordNotFound(id)` は CLI 既存の同名バリアントへ写像し、
+            // SQLite 経路と同じ presenter 経路（MSG-CLI-103）に着地させる（DRY、UX 同一）。
+            PersistenceError::RecordNotFound(id) => Self::RecordNotFound(id),
             other => Self::Persistence(other),
         }
     }
@@ -200,6 +204,30 @@ mod tests {
         let pe = PersistenceError::UnsupportedYet {
             feature: "some other future feature",
             tracking_issue: None,
+        };
+        let cli_err: CliError = pe.into();
+        assert!(matches!(cli_err, CliError::Persistence(_)));
+        assert_eq!(ExitCode::from(&cli_err), ExitCode::SystemError);
+    }
+
+    /// Phase 1.5（Issue #30）: `PersistenceError::RecordNotFound(id)` は
+    /// CLI 既存 `RecordNotFound(id)` に直結（SQLite 経路と同 UX）。
+    #[test]
+    fn test_from_persistence_record_not_found_maps_to_record_not_found() {
+        let id =
+            RecordId::new(uuid::Uuid::now_v7()).expect("uuid v7 must satisfy RecordId invariant");
+        let pe = PersistenceError::RecordNotFound(id);
+        let cli_err: CliError = pe.into();
+        assert!(matches!(cli_err, CliError::RecordNotFound(_)));
+        assert_eq!(ExitCode::from(&cli_err), ExitCode::UserError);
+    }
+
+    /// Phase 1.5: `PersistenceError::Internal { reason }` は `Persistence` に
+    /// 寄せ、終了コードは `SystemError`（exit 2）。reason 文字列は固定文言のみ。
+    #[test]
+    fn test_from_persistence_internal_maps_to_persistence_system_error() {
+        let pe = PersistenceError::Internal {
+            reason: "persistence error".into(),
         };
         let cli_err: CliError = pe.into();
         assert!(matches!(cli_err, CliError::Persistence(_)));

--- a/crates/shikomi-cli/src/io/ipc_vault_repository.rs
+++ b/crates/shikomi-cli/src/io/ipc_vault_repository.rs
@@ -1,28 +1,46 @@
-//! `IpcVaultRepository` — daemon 経由で `--ipc list` を実装する細い IPC クライアント。
+//! `IpcVaultRepository` — daemon 経由の vault 操作を提供する narrow IPC クライアント。
 //!
-//! ## スコープ（縮減）
+//! ## スコープ（案 D 採用）
 //!
-//! 当初は `VaultRepository` trait を full impl して `--ipc add/edit/remove` も透過化する
-//! 案 C（投影 Vault）を採用していたが、レビューで以下の致命的問題が判明したため
-//! **`--ipc list` 専用に縮減**する（外部レビュー指摘に対応）:
+//! `VaultRepository` trait は **実装しない**。代わりに `list_summaries` /
+//! `add_record` / `edit_record` / `remove_record` の 4 専用メソッドを公開し、
+//! `crate::lib::run` が `enum RepositoryHandle { Sqlite, Ipc }` の `match` で
+//! 経路ディスパッチする（Composition over Inheritance）。
 //!
-//! - `load()` が daemon 由来 summary を `RecordPayload::Plaintext(SecretString::from_string(""))`
-//!   で偽装してドメイン集約に乗せる必要があった（嘘の値の注入）
-//! - `save()` が CLI 側生成 `RecordId` をそのまま提示する一方、daemon が独自 ID を再生成して
-//!   保存するため**ユーザに表示される ID が daemon vault に存在しない**（嘘の ID 出荷）
-//! - `exists()` が常に `Ok(true)` を返し trait 契約への嘘
+//! 当初の trait full impl 案 C は以下の致命的問題を抱えていたため棄却済み（PR #29
+//! レビュー、Phase 1.5 で構造的撤去）:
 //!
-//! 本 PR では `VaultRepository` trait 実装を**完全に削除**し、`list` のみを支える narrow
-//! API（`list_summaries() -> Vec<RecordSummary>`）に絞った。`add/edit/remove` の IPC 透過化は
-//! 案 B（trait 分割）への移行 PR で正式実装する。
+//! - `load()` が daemon 由来 summary を `RecordPayload::Plaintext("")` で偽装する
+//!   必要があり、ドメイン集約に「嘘の値」を注入していた
+//! - `save()` が CLI 側生成 `RecordId` を提示する一方、daemon が独自 ID を再生成して
+//!   保存するため、ユーザに表示される ID が daemon vault に存在しない（嘘 ID 出荷）
+//! - `exists()` が常に `Ok(true)` を返し trait 契約に対して嘘
 //!
-//! 設計根拠: docs/features/daemon-ipc/detailed-design/ipc-vault-repository.md §縮減後 API
+//! 案 D ではこれらを **型レベルで封じ込める**:
+//!
+//! - `IpcVaultRepository` は `VaultRepository` を実装しないので `Box<dyn VaultRepository>`
+//!   に注入できない（CI grep `TC-CI-030` + `compile_fail` doctest `TC-UT-119` で二重防衛）
+//! - `add_record` 戻り値の `RecordId` は daemon 側 `IpcResponse::Added { id }` を**そのまま**
+//!   返す（CLI 側で `Uuid::*` を呼ばない、CI grep `TC-CI-029` 監査）
+//!
+//! 設計根拠: docs/features/daemon-ipc/detailed-design/ipc-vault-repository.md
+//! §案 D（VaultRepository trait 非実装 + RepositoryHandle enum）
+//!
+//! ```compile_fail
+//! // TC-UT-119: `IpcVaultRepository` が `VaultRepository` trait を**実装しない**ことの
+//! // 構造契約。本 doctest が `compile_fail` で成立する = 嘘 ID / 嘘 Plaintext を生む案 C
+//! // が再発していない、を保証する（CI 監査 `TC-CI-030` の二重防衛）。
+//! fn assert_not_vault_repository<T: shikomi_infra::persistence::VaultRepository>() {}
+//! assert_not_vault_repository::<shikomi_cli::io::ipc_vault_repository::IpcVaultRepository>();
+//! ```
 
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use shikomi_core::ipc::{IpcErrorCode, IpcRequest, IpcResponse, RecordSummary};
+use shikomi_core::ipc::{IpcRequest, IpcResponse, RecordSummary, SerializableSecretBytes};
+use shikomi_core::{RecordId, RecordKind, RecordLabel, SecretString};
 use shikomi_infra::persistence::PersistenceError;
+use time::OffsetDateTime;
 use tokio::runtime::Runtime;
 
 use super::ipc_client::IpcClient;
@@ -96,10 +114,82 @@ impl IpcVaultRepository {
     pub fn list_summaries(&self) -> Result<Vec<RecordSummary>, PersistenceError> {
         match self.round_trip(&IpcRequest::ListRecords)? {
             IpcResponse::Records(s) => Ok(s),
-            IpcResponse::Error(code) => Err(map_ipc_error_code(&code)),
-            other => Err(PersistenceError::IpcDecode {
-                reason: format!("unexpected response variant: {}", other.variant_name()),
-            }),
+            IpcResponse::Error(code) => Err(PersistenceError::from(code)),
+            _ => Err(unexpected_response("ListRecords")),
+        }
+    }
+
+    /// daemon に新規レコード追加を依頼する（`--ipc add` の主経路）。
+    ///
+    /// id は **daemon 側で生成**され `IpcResponse::Added { id }` でそのまま返る
+    /// （CLI 側で `Uuid::*` を呼ばない契約、CI grep `TC-CI-029`）。
+    /// `value: SecretString` は `SerializableSecretBytes::from_secret_string` で
+    /// IPC 送信用ラッパに包む（平文取り出し経路は core 内に閉じる、CI grep
+    /// `TC-CI-016` の遵守）。
+    ///
+    /// # Errors
+    /// IPC 失敗 / daemon 側 vault エラーは `PersistenceError` に写像。
+    pub fn add_record(
+        &self,
+        kind: RecordKind,
+        label: RecordLabel,
+        value: SecretString,
+        now: OffsetDateTime,
+    ) -> Result<RecordId, PersistenceError> {
+        let request = IpcRequest::AddRecord {
+            kind,
+            label,
+            value: SerializableSecretBytes::from_secret_string(value),
+            now,
+        };
+        match self.round_trip(&request)? {
+            IpcResponse::Added { id } => Ok(id),
+            IpcResponse::Error(code) => Err(PersistenceError::from(code)),
+            _ => Err(unexpected_response("AddRecord")),
+        }
+    }
+
+    /// daemon にレコード編集を依頼する（`--ipc edit` の主経路）。
+    ///
+    /// `label` と `value` は両方 `Option`、片方のみ更新も両方更新も可能
+    /// （両方 `None` は CLI 側 `usecase::edit` で事前に拒否済み）。
+    ///
+    /// # Errors
+    /// id 非存在 / IPC 失敗 / daemon 側 vault エラーは `PersistenceError` に写像。
+    pub fn edit_record(
+        &self,
+        id: RecordId,
+        label: Option<RecordLabel>,
+        value: Option<SecretString>,
+        now: OffsetDateTime,
+    ) -> Result<RecordId, PersistenceError> {
+        let request = IpcRequest::EditRecord {
+            id,
+            label,
+            value: value.map(SerializableSecretBytes::from_secret_string),
+            now,
+        };
+        match self.round_trip(&request)? {
+            IpcResponse::Edited { id } => Ok(id),
+            IpcResponse::Error(code) => Err(PersistenceError::from(code)),
+            _ => Err(unexpected_response("EditRecord")),
+        }
+    }
+
+    /// daemon にレコード削除を依頼する（`--ipc remove` の主経路）。
+    ///
+    /// 存在確認・label プレビュー取得は `list_summaries` 経由で別途行う設計
+    /// （`docs/features/daemon-ipc/basic-design/flows.md §shikomi --ipc remove`）。
+    /// 本メソッドは確定済みの id を `RemoveRecord` として送出するのみ。
+    ///
+    /// # Errors
+    /// id 非存在 / IPC 失敗 / daemon 側 vault エラーは `PersistenceError` に写像。
+    pub fn remove_record(&self, id: RecordId) -> Result<RecordId, PersistenceError> {
+        let request = IpcRequest::RemoveRecord { id };
+        match self.round_trip(&request)? {
+            IpcResponse::Removed { id } => Ok(id),
+            IpcResponse::Error(code) => Err(PersistenceError::from(code)),
+            _ => Err(unexpected_response("RemoveRecord")),
         }
     }
 
@@ -133,35 +223,23 @@ fn unix_default_socket_path() -> Result<PathBuf, PersistenceError> {
 }
 
 // -------------------------------------------------------------------
-// 補助関数
+// 不正応答時の固定文言ヘルパ
 // -------------------------------------------------------------------
 
-fn map_ipc_error_code(code: &IpcErrorCode) -> PersistenceError {
-    match code {
-        IpcErrorCode::EncryptionUnsupported => PersistenceError::UnsupportedYet {
-            feature: "encrypted vault persistence",
-            tracking_issue: None,
-        },
-        IpcErrorCode::NotFound { .. } => PersistenceError::IpcDecode {
-            reason: "record not found".to_owned(),
-        },
-        IpcErrorCode::InvalidLabel { .. } => PersistenceError::IpcDecode {
-            reason: "invalid label".to_owned(),
-        },
-        IpcErrorCode::Persistence { .. } => PersistenceError::IpcIo {
-            reason: "persistence error".to_owned(),
-        },
-        IpcErrorCode::Domain { .. } => PersistenceError::IpcIo {
-            reason: "domain error".to_owned(),
-        },
-        IpcErrorCode::Internal { .. } => PersistenceError::IpcIo {
-            reason: "internal error".to_owned(),
-        },
-        // `#[non_exhaustive]` 属性により future variant が追加される可能性に備える。
-        // 本 wildcard は **cross-crate `non_exhaustive` の必須回避**であり、観測可能な reason
-        // 文言を返すためコード追跡を阻害しない。
-        _ => PersistenceError::IpcIo {
-            reason: "unknown error code".to_owned(),
+/// daemon から想定外の `IpcResponse` variant を受信したときの固定文言エラー。
+///
+/// 動的なフォーマット（variant 名の埋め込み等）を**意図的に避ける**。daemon 側の
+/// プロトコル違反は CLI から見れば「IPC 応答が壊れている」ことだけが意味を持つ。
+fn unexpected_response(request_kind: &'static str) -> PersistenceError {
+    PersistenceError::IpcDecode {
+        reason: match request_kind {
+            "ListRecords" => "unexpected response for ListRecords".to_owned(),
+            "AddRecord" => "unexpected response for AddRecord".to_owned(),
+            "EditRecord" => "unexpected response for EditRecord".to_owned(),
+            "RemoveRecord" => "unexpected response for RemoveRecord".to_owned(),
+            // `request_kind` は本ファイル内の static 文字列のみで呼ばれる契約。
+            // 万一新規呼出側がここに到達しても固定文言を返す（fail safe）。
+            _ => "unexpected ipc response".to_owned(),
         },
     }
 }

--- a/crates/shikomi-cli/src/lib.rs
+++ b/crates/shikomi-cli/src/lib.rs
@@ -333,10 +333,10 @@ fn run_edit(
 
     let needs_value_input = args.value.is_some() || args.stdin;
 
-    // 既存 kind を「Sqlite 経路かつ value 入力時」のみ取得（非エコー判定 + shell 履歴警告に使う）。
-    // IPC 経路では事前 load を避け（daemon round-trip のコストとレース）、kind は Text 既定で
-    // resolve（既存 kind と異なっても daemon 側 `update_record` が無修正で許容、
-    // composition-root.md §run_edit の DRY 方針）。
+    // 既存 kind は **Sqlite 経路かつ value 入力時のみ** load 経由で取得する。
+    // IPC 経路では事前 load を行わず `existing_kind = None` のままにする
+    // （daemon round-trip のコストとレース回避）。後段で fail-secure に Secret
+    // 扱いへ寄せる（composition-root.md §run_edit IPC 経路の方針 B）。
     let existing_kind = match handle {
         RepositoryHandle::Sqlite(repo) if needs_value_input => {
             let vault_dir = repo.paths().dir().to_path_buf();
@@ -357,8 +357,21 @@ fn run_edit(
         _ => None,
     };
 
+    // value 入力 kind の決定:
+    // - 既存 kind が判明（Sqlite + load 成功）→ それを使う
+    // - IPC 経路で既存 kind 不明 → **fail-secure で `Secret` 強制**。TTY からの value
+    //   入力は `read_password`（非エコー）経路を通る。既存が Text であっても画面
+    //   エコーが出ないだけで機能上は等価、Secret であれば想定通りの保護が成立する
+    //   （`composition-root.md §run_edit IPC 経路の方針 B`）。
+    // - Sqlite で needs_value_input == false → 入力しないので `Text` dummy で十分
+    //   （`resolve_secret_value` は `--value` 経路で kind を参照しない）。
+    let kind_for_input = match (existing_kind, handle) {
+        (Some(k), _) => k,
+        (None, RepositoryHandle::Ipc(_)) => RecordKind::Secret,
+        (None, RepositoryHandle::Sqlite(_)) => RecordKind::Text,
+    };
+
     let value = if needs_value_input {
-        let kind_for_input = existing_kind.unwrap_or(RecordKind::Text);
         Some(resolve_secret_value(
             args.value.as_deref(),
             args.stdin,
@@ -368,8 +381,11 @@ fn run_edit(
         None
     };
 
-    // shell 履歴警告: 既存 kind が Secret で `--value` 直接指定（= shell 履歴残留リスク）なら警告
-    if matches!(existing_kind, Some(RecordKind::Secret)) && args.value.is_some() {
+    // shell 履歴警告: 入力 kind が Secret として扱われる経路で `--value` 直接指定
+    // （= shell 履歴残留リスク）なら警告。IPC 経路の fail-secure（kind 不明 →
+    // Secret 想定）でも同様に警告を出すことで、Sqlite 経路と挙動を揃える（DRY、
+    // セキュリティ機能を経路依存にしない）。
+    if matches!(kind_for_input, RecordKind::Secret) && args.value.is_some() {
         let warning = presenter::warning::render_shell_history_warning(locale);
         eprint_stderr(&warning);
     }

--- a/crates/shikomi-cli/src/lib.rs
+++ b/crates/shikomi-cli/src/lib.rs
@@ -27,7 +27,7 @@ pub use error::{CliError, ExitCode};
 use std::io::Write;
 use std::sync::OnceLock;
 
-use shikomi_infra::persistence::SqliteVaultRepository;
+use shikomi_infra::persistence::{SqliteVaultRepository, VaultRepository};
 use time::OffsetDateTime;
 
 use cli::{AddArgs, CliArgs, EditArgs, RemoveArgs, Subcommand};
@@ -35,7 +35,6 @@ use input::{AddInput, ConfirmedRemoveInput, EditInput};
 use io::ipc_vault_repository::IpcVaultRepository;
 use presenter::Locale;
 use shikomi_core::{RecordId, RecordKind, RecordLabel, SecretString};
-use shikomi_infra::persistence::VaultRepository;
 
 // -------------------------------------------------------------------
 // グローバル Locale キャッシュ（panic hook から参照される）
@@ -86,6 +85,37 @@ fn panic_hook(_info: &std::panic::PanicInfo<'_>) {
 }
 
 // -------------------------------------------------------------------
+// RepositoryHandle — Sqlite / IPC の Composition over Inheritance
+// -------------------------------------------------------------------
+
+/// vault 操作経路を保持する non-public 値型（Issue #30、案 D）。
+///
+/// `IpcVaultRepository` は `VaultRepository` trait を**実装しない**ため
+/// `Box<dyn VaultRepository>` で抽象化できない。代わりに enum dispatch で経路を
+/// 表現し、各 `run_*` 関数の冒頭で `match` を取って 2 アームに分岐する。
+///
+/// `#[non_exhaustive]` を**付けない**: CLI 内部限定で、新バリアント追加時に
+/// `match` 網羅性検査が変更箇所を漏れなく列挙してくれる方が安全。
+///
+/// 設計根拠:
+/// - docs/features/cli-vault-commands/detailed-design/composition-root.md
+///   §`RepositoryHandle` enum
+/// - docs/features/daemon-ipc/detailed-design/ipc-vault-repository.md
+///   §案 D（VaultRepository trait 非実装 + RepositoryHandle enum）
+//
+// バリアント間サイズ差（Sqlite ~96 B / Ipc ~304 B、`tokio::runtime::Runtime` 込み）は
+// 本 enum を `run()` 寿命中に **唯一 1 個** しか作らない契約のため、heap 1 個分の節約に
+// 価値がない。`Box<IpcVaultRepository>` で alloc を増やすより、stack 配置を維持する方が
+// 設計意図（composition-root.md §`Box` 不要、stack 配置）に沿う。
+#[allow(clippy::large_enum_variant)]
+enum RepositoryHandle {
+    /// 既定の SQLite 直接アクセス経路。
+    Sqlite(SqliteVaultRepository),
+    /// `--ipc` opt-in の daemon 経由経路。
+    Ipc(IpcVaultRepository),
+}
+
+// -------------------------------------------------------------------
 // run() — コンポジションルート
 // -------------------------------------------------------------------
 
@@ -96,7 +126,7 @@ fn panic_hook(_info: &std::panic::PanicInfo<'_>) {
 /// 2. Locale 決定 + `LOCALE_CACHE` 格納
 /// 3. clap パース（失敗時は clap エラー扱い）
 /// 4. `tracing_subscriber` 初期化
-/// 5. Repository 構築（`--vault-dir` > env (clap attribute) > OS デフォルト）
+/// 5. `RepositoryHandle` 構築（`args.ipc` で `Sqlite` / `Ipc` を分岐）
 /// 6. サブコマンド分岐 → `run_*` 関数 → `Result<(), CliError>`
 /// 7. `Err` は `render_error` で stderr 出力 + `ExitCode::from(&err)` 写像
 #[must_use]
@@ -116,74 +146,50 @@ pub fn run() -> ExitCode {
 
     let quiet = args.quiet;
 
-    if args.ipc {
-        // `--ipc` は現状 `list` のみ対応（Phase 2 移行 PR で add/edit/remove の透過化を完成）。
-        // ここで早期 reject することで、IpcVaultRepository が `VaultRepository` trait を
-        // 偽実装する必要がなくなる（旧実装の「嘘の Plaintext(empty) 注入」「嘘 ID 出荷」「常に true な exists()」
-        // を構造的に消滅させる）。
-        if !matches!(args.subcommand, Subcommand::List) {
-            return emit_error_and_exit(
-                &CliError::UsageError(
-                    "--ipc currently supports only the `list` subcommand; \
-                     for add/edit/remove, omit --ipc to use direct vault file access"
-                        .to_owned(),
-                ),
-                locale,
-            );
-        }
-        if !quiet {
-            eprintln!("warning: --ipc is an opt-in preview; only `list` is currently supported");
-        }
-        run_list_via_ipc(locale, quiet)
-    } else {
-        run_with_sqlite_repo(&args, locale, quiet)
-    }
-}
-
-fn run_with_sqlite_repo(args: &CliArgs, locale: Locale, quiet: bool) -> ExitCode {
-    let repo = match build_repo(args.vault_dir.as_deref()) {
-        Ok(r) => r,
+    let handle = match build_handle(&args, locale, quiet) {
+        Ok(h) => h,
         Err(err) => return emit_error_and_exit(&err, locale),
     };
-    let vault_dir = repo.paths().dir().to_path_buf();
+
     let result = match &args.subcommand {
-        Subcommand::List => run_list(&repo, &vault_dir, locale, quiet),
-        Subcommand::Add(a) => run_add(&repo, a, &vault_dir, locale, quiet),
-        Subcommand::Edit(a) => run_edit(&repo, a, &vault_dir, locale, quiet),
-        Subcommand::Remove(a) => run_remove(&repo, a, &vault_dir, locale, quiet),
+        Subcommand::List => run_list(&handle, locale, quiet),
+        Subcommand::Add(a) => run_add(&handle, a, locale, quiet),
+        Subcommand::Edit(a) => run_edit(&handle, a, locale, quiet),
+        Subcommand::Remove(a) => run_remove(&handle, a, locale, quiet),
     };
+
     match result {
         Ok(()) => ExitCode::Success,
         Err(err) => emit_error_and_exit(&err, locale),
     }
 }
 
-/// `--ipc list` 専用エントリ。`IpcVaultRepository::list_summaries` で `RecordSummary` 列を
-/// 取得し、`Vault` 集約を経由せずに直接 `RecordView` に射影する。
-fn run_list_via_ipc(locale: Locale, quiet: bool) -> ExitCode {
-    let socket_path = match IpcVaultRepository::default_socket_path() {
-        Ok(p) => p,
-        Err(err) => return emit_error_and_exit(&CliError::from(err), locale),
-    };
-    let client = match IpcVaultRepository::connect(&socket_path) {
-        Ok(c) => c,
-        Err(err) => return emit_error_and_exit(&CliError::from(err), locale),
-    };
-    let summaries = match client.list_summaries() {
-        Ok(s) => s,
-        Err(err) => return emit_error_and_exit(&CliError::from(err), locale),
-    };
-    let views = usecase::list::summaries_to_views(&summaries);
-    if !quiet {
-        let rendered = presenter::list::render_list(&views, locale);
-        print_stdout(&rendered);
-    }
-    ExitCode::Success
-}
+// -------------------------------------------------------------------
+// 補助関数 — Repository 構築 / clap / tracing / 出力
+// -------------------------------------------------------------------
 
-// -------------------------------------------------------------------
-// 補助関数
-// -------------------------------------------------------------------
+/// `args.ipc` フラグから `RepositoryHandle` を構築する。
+///
+/// IPC 経路では `MSG-CLI-051`（opt-in 警告）を `quiet` 抑止下を除き先に出力した上で、
+/// daemon に接続してハンドシェイクまで完了させる。
+fn build_handle(args: &CliArgs, locale: Locale, quiet: bool) -> Result<RepositoryHandle, CliError> {
+    if args.ipc {
+        if !quiet {
+            let notice = presenter::warning::render_ipc_opt_in_notice(locale);
+            eprint_stderr(&notice);
+        }
+        let socket_path = IpcVaultRepository::default_socket_path()?;
+        let ipc = IpcVaultRepository::connect(&socket_path)?;
+        Ok(RepositoryHandle::Ipc(ipc))
+    } else {
+        let path = match args.vault_dir.as_deref() {
+            Some(p) => p.to_path_buf(),
+            None => io::paths::resolve_os_default_vault_dir()?,
+        };
+        let repo = SqliteVaultRepository::from_directory(&path)?;
+        Ok(RepositoryHandle::Sqlite(repo))
+    }
+}
 
 /// clap エラーを CLI 終了コード方針に合わせて整形する。
 ///
@@ -223,16 +229,6 @@ fn init_tracing(verbose: bool) {
         .try_init();
 }
 
-/// `--vault-dir` フラグ（clap attribute で env `SHIKOMI_VAULT_DIR` も吸収済み）があれば
-/// その path で、なければ OS デフォルトで Repository を構築する。
-fn build_repo(vault_dir: Option<&std::path::Path>) -> Result<SqliteVaultRepository, CliError> {
-    let path = match vault_dir {
-        Some(p) => p.to_path_buf(),
-        None => io::paths::resolve_os_default_vault_dir()?,
-    };
-    SqliteVaultRepository::from_directory(&path).map_err(CliError::from)
-}
-
 fn emit_error_and_exit(err: &CliError, locale: Locale) -> ExitCode {
     let rendered = presenter::error::render_error(err, locale);
     let mut stderr = std::io::stderr().lock();
@@ -241,16 +237,21 @@ fn emit_error_and_exit(err: &CliError, locale: Locale) -> ExitCode {
 }
 
 // -------------------------------------------------------------------
-// サブコマンドごとの dispatcher
+// サブコマンド dispatcher（各関数は `&RepositoryHandle` を受領し
+// 内部で `match handle` の 2 アーム分岐）
 // -------------------------------------------------------------------
 
-fn run_list(
-    repo: &dyn VaultRepository,
-    vault_dir: &std::path::Path,
-    locale: Locale,
-    quiet: bool,
-) -> Result<(), CliError> {
-    let views = usecase::list::list_records(repo, vault_dir)?;
+fn run_list(handle: &RepositoryHandle, locale: Locale, quiet: bool) -> Result<(), CliError> {
+    let views = match handle {
+        RepositoryHandle::Sqlite(repo) => {
+            let vault_dir = repo.paths().dir().to_path_buf();
+            usecase::list::list_records(repo, &vault_dir)?
+        }
+        RepositoryHandle::Ipc(ipc) => {
+            let summaries = ipc.list_summaries()?;
+            usecase::list::summaries_to_views(&summaries)
+        }
+    };
     if !quiet {
         let rendered = presenter::list::render_list(&views, locale);
         print_stdout(&rendered);
@@ -259,9 +260,8 @@ fn run_list(
 }
 
 fn run_add(
-    repo: &dyn VaultRepository,
+    handle: &RepositoryHandle,
     args: &AddArgs,
-    vault_dir: &std::path::Path,
     locale: Locale,
     quiet: bool,
 ) -> Result<(), CliError> {
@@ -282,16 +282,29 @@ fn run_add(
         value,
     };
 
-    let initially_existed = repo.exists().map_err(CliError::from)?;
-
     let now = OffsetDateTime::now_utc();
-    let id = usecase::add::add_record(repo, input, now)?;
+
+    let id = match handle {
+        RepositoryHandle::Sqlite(repo) => {
+            let vault_dir = repo.paths().dir().to_path_buf();
+            // 初期化メッセージ判定は Sqlite 経路でのみ意味を持つ（IPC 経路では daemon が
+            // vault の存在を保証する前提、composition-root.md §run_add ステップ 6）。
+            let initially_existed = repo.exists().map_err(CliError::from)?;
+            let id = usecase::add::add_record(repo, input, now)?;
+            if !quiet && !initially_existed {
+                let init_msg = presenter::success::render_initialized_vault(&vault_dir, locale);
+                print_stdout(&init_msg);
+            }
+            id
+        }
+        RepositoryHandle::Ipc(ipc) => {
+            // id は **daemon 側で生成**され `IpcResponse::Added { id }` でそのまま返る。
+            // CLI 側で `Uuid::*` を呼ばない契約（CI grep TC-CI-029）。
+            ipc.add_record(input.kind, input.label, input.value, now)?
+        }
+    };
 
     if !quiet {
-        if !initially_existed {
-            let init_msg = presenter::success::render_initialized_vault(vault_dir, locale);
-            print_stdout(&init_msg);
-        }
         let added = presenter::success::render_added(&id, locale);
         print_stdout(&added);
     }
@@ -299,9 +312,8 @@ fn run_add(
 }
 
 fn run_edit(
-    repo: &dyn VaultRepository,
+    handle: &RepositoryHandle,
     args: &EditArgs,
-    vault_dir: &std::path::Path,
     locale: Locale,
     quiet: bool,
 ) -> Result<(), CliError> {
@@ -319,33 +331,33 @@ fn run_edit(
         None => None,
     };
 
-    // 既存 kind を事前 load で取得（value 入力時の非エコー判定 + shell 履歴警告に使う）。
-    // 設計書 composition-root.md §run_edit L59-62: 「値取得は run_add と同様（kind に応じて
-    // `read_password` / `read_line`）」「警告判定は load 後の既存 kind と照合するかは実装時判断」
-    // ここでは load 2 回を許容して既存 kind を参照する（run_remove と同方針、ペテルギウス指摘
-    // ①への対応）。load 失敗は Fail Fast（`?` でユーザに伝搬）。
     let needs_value_input = args.value.is_some() || args.stdin;
-    let existing_kind = if needs_value_input {
-        if !repo.exists()? {
-            return Err(CliError::VaultNotInitialized(vault_dir.to_path_buf()));
+
+    // 既存 kind を「Sqlite 経路かつ value 入力時」のみ取得（非エコー判定 + shell 履歴警告に使う）。
+    // IPC 経路では事前 load を避け（daemon round-trip のコストとレース）、kind は Text 既定で
+    // resolve（既存 kind と異なっても daemon 側 `update_record` が無修正で許容、
+    // composition-root.md §run_edit の DRY 方針）。
+    let existing_kind = match handle {
+        RepositoryHandle::Sqlite(repo) if needs_value_input => {
+            let vault_dir = repo.paths().dir().to_path_buf();
+            if !repo.exists()? {
+                return Err(CliError::VaultNotInitialized(vault_dir));
+            }
+            let vault = repo.load()?;
+            if vault.protection_mode() == shikomi_core::ProtectionMode::Encrypted {
+                return Err(CliError::EncryptionUnsupported);
+            }
+            Some(
+                vault
+                    .find_record(&id)
+                    .map(shikomi_core::Record::kind)
+                    .ok_or_else(|| CliError::RecordNotFound(id.clone()))?,
+            )
         }
-        let vault = repo.load()?;
-        if vault.protection_mode() == shikomi_core::ProtectionMode::Encrypted {
-            return Err(CliError::EncryptionUnsupported);
-        }
-        Some(
-            vault
-                .find_record(&id)
-                .map(shikomi_core::Record::kind)
-                .ok_or_else(|| CliError::RecordNotFound(id.clone()))?,
-        )
-    } else {
-        None
+        _ => None,
     };
 
     let value = if needs_value_input {
-        // 既存が Secret ならエコーしない、Text なら通常 readline。
-        // `--value` と `--stdin` の相互排他は resolve_secret_value 側で検出。
         let kind_for_input = existing_kind.unwrap_or(RecordKind::Text);
         Some(resolve_secret_value(
             args.value.as_deref(),
@@ -369,40 +381,38 @@ fn run_edit(
     };
 
     let now = OffsetDateTime::now_utc();
-    let id = usecase::edit::edit_record(repo, input, now, vault_dir)?;
+
+    let new_id = match handle {
+        RepositoryHandle::Sqlite(repo) => {
+            let vault_dir = repo.paths().dir().to_path_buf();
+            usecase::edit::edit_record(repo, input, now, &vault_dir)?
+        }
+        RepositoryHandle::Ipc(ipc) => ipc.edit_record(input.id, input.label, input.value, now)?,
+    };
 
     if !quiet {
-        let rendered = presenter::success::render_updated(&id, locale);
+        let rendered = presenter::success::render_updated(&new_id, locale);
         print_stdout(&rendered);
     }
     Ok(())
 }
 
 fn run_remove(
-    repo: &dyn VaultRepository,
+    handle: &RepositoryHandle,
     args: &RemoveArgs,
-    vault_dir: &std::path::Path,
     locale: Locale,
     quiet: bool,
 ) -> Result<(), CliError> {
     let id = RecordId::try_from_str(&args.id).map_err(CliError::InvalidId)?;
 
+    // 確認プロンプト前段で **`--yes` の有無に関わらず** label を取得して id 存在確認を
+    // 行う（composition-root.md §確認プロンプトの label 表示と id 存在確認）。
+    // 非存在時は `RemoveRecord` リクエストを発行する前に Fail Fast で early return。
+    let label = lookup_label_for_remove(handle, &id)?;
+
     let confirmed = if args.yes {
         true
     } else if io::terminal::is_stdin_tty() {
-        // プロンプト表示用の label を取得するために load して find_record。
-        // load 失敗は Fail Fast で return（`.ok()` で握り潰さない — ペテルギウス指摘②）。
-        // これによりユーザは「load に失敗したのに y を押してしまう」欺き構造を踏まない。
-        if !repo.exists()? {
-            return Err(CliError::VaultNotInitialized(vault_dir.to_path_buf()));
-        }
-        let vault = repo.load()?;
-        if vault.protection_mode() == shikomi_core::ProtectionMode::Encrypted {
-            return Err(CliError::EncryptionUnsupported);
-        }
-        let label = vault
-            .find_record(&id)
-            .map(|r| r.label().as_str().to_owned());
         let prompt = presenter::prompt::render_remove_prompt(&id, label.as_deref(), locale);
         match io::terminal::read_line(&prompt) {
             Ok(line) => matches!(line.trim(), "y" | "Y"),
@@ -427,12 +437,58 @@ fn run_remove(
     }
 
     let input = ConfirmedRemoveInput::new(id);
-    let id = usecase::remove::remove_record(repo, input, vault_dir)?;
+    let removed_id = match handle {
+        RepositoryHandle::Sqlite(repo) => {
+            let vault_dir = repo.paths().dir().to_path_buf();
+            usecase::remove::remove_record(repo, input, &vault_dir)?
+        }
+        RepositoryHandle::Ipc(ipc) => ipc.remove_record(input.id().clone())?,
+    };
 
     if !quiet {
-        print_stdout(&presenter::success::render_removed(&id, locale));
+        print_stdout(&presenter::success::render_removed(&removed_id, locale));
     }
     Ok(())
+}
+
+/// `run_remove` の確認プロンプト用 label 取得 + id 存在確認。
+///
+/// - `Sqlite` 経路: `repo.load()` → `find_record(&id)` → `label`
+/// - `Ipc` 経路: `ipc.list_summaries()` → `iter().find(|s| s.id == id)` → `s.label`
+///
+/// 両経路ともに **id 非存在は `CliError::RecordNotFound(id)` で early return**。
+/// これにより `--yes` / 非 `--yes` で Fail Fast 経路が完全一致する
+/// （composition-root.md §確認プロンプトの label 表示と id 存在確認）。
+fn lookup_label_for_remove(
+    handle: &RepositoryHandle,
+    id: &RecordId,
+) -> Result<Option<String>, CliError> {
+    match handle {
+        RepositoryHandle::Sqlite(repo) => {
+            let vault_dir = repo.paths().dir().to_path_buf();
+            if !repo.exists()? {
+                return Err(CliError::VaultNotInitialized(vault_dir));
+            }
+            let vault = repo.load()?;
+            if vault.protection_mode() == shikomi_core::ProtectionMode::Encrypted {
+                return Err(CliError::EncryptionUnsupported);
+            }
+            let label = vault
+                .find_record(id)
+                .map(|r| r.label().as_str().to_owned())
+                .ok_or_else(|| CliError::RecordNotFound(id.clone()))?;
+            Ok(Some(label))
+        }
+        RepositoryHandle::Ipc(ipc) => {
+            let summaries = ipc.list_summaries()?;
+            let label = summaries
+                .iter()
+                .find(|s| &s.id == id)
+                .map(|s| s.label.as_str().to_owned())
+                .ok_or_else(|| CliError::RecordNotFound(id.clone()))?;
+            Ok(Some(label))
+        }
+    }
 }
 
 // -------------------------------------------------------------------

--- a/crates/shikomi-cli/src/presenter/warning.rs
+++ b/crates/shikomi-cli/src/presenter/warning.rs
@@ -1,8 +1,8 @@
-//! 警告メッセージ（stderr）。MSG-CLI-050。
+//! 警告メッセージ（stderr）。MSG-CLI-050 / MSG-CLI-051。
 
 use super::Locale;
 
-/// `--value` 経由の secret 入力が shell 履歴に残る可能性を警告する。
+/// `--value` 経由の secret 入力が shell 履歴に残る可能性を警告する（MSG-CLI-050）。
 #[must_use]
 pub fn render_shell_history_warning(locale: Locale) -> String {
     let mut out = String::from(
@@ -11,6 +11,26 @@ pub fn render_shell_history_warning(locale: Locale) -> String {
     if matches!(locale, Locale::JapaneseEn) {
         out.push_str(
             "警告: secret を --value で渡すと shell 履歴に残ります。--stdin を推奨します\n",
+        );
+    }
+    out
+}
+
+/// `--ipc` opt-in 起動時に MSG-CLI-051 を返す。
+///
+/// `--ipc` は preview 機能で、Phase 1.5 で list/add/edit/remove の 4 操作を支える。
+/// 現段階では既定の SQLite 直接アクセス経路と挙動が異なる可能性があるため、
+/// `--quiet` 指定時を除き必ず stderr に注意を出す。
+///
+/// 設計根拠: docs/features/cli-vault-commands/basic-design/error.md §MSG-CLI-051
+#[must_use]
+pub fn render_ipc_opt_in_notice(locale: Locale) -> String {
+    let mut out = String::from(
+        "warning: --ipc is an opt-in preview routing all vault operations through shikomi-daemon\n",
+    );
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(
+            "警告: --ipc はプレビュー機能で、全ての vault 操作を shikomi-daemon 経由で行います\n",
         );
     }
     out
@@ -31,6 +51,22 @@ mod tests {
     fn test_render_shell_history_warning_japanese_en_contains_both() {
         let rendered = render_shell_history_warning(Locale::JapaneseEn);
         assert!(rendered.contains("--stdin"));
+        assert!(rendered.contains("警告"));
+    }
+
+    #[test]
+    fn test_render_ipc_opt_in_notice_english_only_does_not_contain_japanese() {
+        let rendered = render_ipc_opt_in_notice(Locale::English);
+        assert!(rendered.contains("--ipc"));
+        assert!(rendered.contains("preview"));
+        assert!(!rendered.contains("警告"));
+    }
+
+    #[test]
+    fn test_render_ipc_opt_in_notice_japanese_en_contains_both() {
+        let rendered = render_ipc_opt_in_notice(Locale::JapaneseEn);
+        assert!(rendered.contains("--ipc"));
+        assert!(rendered.contains("preview"));
         assert!(rendered.contains("警告"));
     }
 }

--- a/crates/shikomi-cli/src/presenter/warning.rs
+++ b/crates/shikomi-cli/src/presenter/warning.rs
@@ -19,18 +19,20 @@ pub fn render_shell_history_warning(locale: Locale) -> String {
 /// `--ipc` opt-in 起動時に MSG-CLI-051 を返す。
 ///
 /// `--ipc` は preview 機能で、Phase 1.5 で list/add/edit/remove の 4 操作を支える。
-/// 現段階では既定の SQLite 直接アクセス経路と挙動が異なる可能性があるため、
-/// `--quiet` 指定時を除き必ず stderr に注意を出す。
+/// 文面は **「daemon 経由経路（preview）であること」+「既定経路は引き続き
+/// SQLite 直結であること」** を必ず併記する（ユーザに「`--ipc` を外せば安定
+/// 経路に戻れる」逃げ道を提示する UX 規約）。`--quiet` 指定時を除き必ず stderr
+/// に出す。
 ///
-/// 設計根拠: docs/features/cli-vault-commands/basic-design/error.md §MSG-CLI-051
+/// 設計根拠: docs/features/daemon-ipc/requirements.md §MSG-CLI-051
 #[must_use]
 pub fn render_ipc_opt_in_notice(locale: Locale) -> String {
     let mut out = String::from(
-        "warning: --ipc is an opt-in preview routing all vault operations through shikomi-daemon\n",
+        "warning: --ipc routes operations through shikomi-daemon (preview); default path remains direct SQLite\n",
     );
     if matches!(locale, Locale::JapaneseEn) {
         out.push_str(
-            "警告: --ipc はプレビュー機能で、全ての vault 操作を shikomi-daemon 経由で行います\n",
+            "警告: --ipc は shikomi-daemon 経由経路（プレビュー）。既定経路は引き続き SQLite 直結です\n",
         );
     }
     out
@@ -55,18 +57,29 @@ mod tests {
     }
 
     #[test]
-    fn test_render_ipc_opt_in_notice_english_only_does_not_contain_japanese() {
+    fn test_render_ipc_opt_in_notice_english_matches_spec_wording() {
+        // 設計書 docs/features/daemon-ipc/requirements.md §MSG-CLI-051 と
+        // 完全一致する英文行を保持する契約。
         let rendered = render_ipc_opt_in_notice(Locale::English);
-        assert!(rendered.contains("--ipc"));
-        assert!(rendered.contains("preview"));
+        assert!(rendered.contains(
+            "warning: --ipc routes operations through shikomi-daemon (preview); default path remains direct SQLite"
+        ));
+        // 「逃げ道（default path remains direct SQLite）」の文言が落ちていない
+        // ことの個別保証——preview 警告の核 UX 規約
+        assert!(rendered.contains("default path remains direct SQLite"));
+        // 英ロケールでは日本語行を出さない
         assert!(!rendered.contains("警告"));
     }
 
     #[test]
-    fn test_render_ipc_opt_in_notice_japanese_en_contains_both() {
+    fn test_render_ipc_opt_in_notice_japanese_en_contains_both_spec_wordings() {
         let rendered = render_ipc_opt_in_notice(Locale::JapaneseEn);
-        assert!(rendered.contains("--ipc"));
-        assert!(rendered.contains("preview"));
-        assert!(rendered.contains("警告"));
+        // 英文行（先頭に出る）
+        assert!(rendered.contains("default path remains direct SQLite"));
+        // 日本語行（既定経路の逃げ道明示）
+        assert!(rendered.contains(
+            "警告: --ipc は shikomi-daemon 経由経路（プレビュー）。既定経路は引き続き SQLite 直結です"
+        ));
+        assert!(rendered.contains("既定経路は引き続き SQLite 直結"));
     }
 }

--- a/crates/shikomi-cli/tests/it_ipc_vault_repository_phase15.rs
+++ b/crates/shikomi-cli/tests/it_ipc_vault_repository_phase15.rs
@@ -1,0 +1,427 @@
+//! `IpcVaultRepository` 専用メソッド round-trip IT (Phase 1.5)
+//! — test-design/integration.md §5.4 TC-IT-080〜089
+//!
+//! 案 D の核：`IpcVaultRepository::add_record / edit_record / remove_record` の
+//! 専用メソッドが `tokio::net::UnixListener` 上のスタブサーバと**ハンドシェイク
+//! 込み**で round-trip し、daemon 応答を期待値に写像することを検証する。
+//!
+//! `IpcVaultRepository::connect` 内部で `current_thread` runtime を構築するため、
+//! テスト本体はスタブサーバを**独立スレッドの `multi_thread` runtime**で動かす
+//! （`current_thread` を本体側でブロッキング保持しても干渉しない）。
+//!
+//! 対応 Issue: #30 / PR #32
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures_util::{SinkExt, StreamExt};
+use shikomi_cli::io::ipc_vault_repository::IpcVaultRepository;
+use shikomi_core::ipc::{
+    IpcErrorCode, IpcProtocolVersion, IpcRequest, IpcResponse, MAX_FRAME_LENGTH,
+};
+use shikomi_core::{RecordId, RecordKind, RecordLabel, SecretString};
+use shikomi_infra::persistence::PersistenceError;
+use tempfile::TempDir;
+use time::OffsetDateTime;
+use tokio::net::{UnixListener, UnixStream};
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use uuid::Uuid;
+
+const SECRET_MARKER: &str = "SECRET_TEST_VALUE";
+
+fn codec() -> LengthDelimitedCodec {
+    LengthDelimitedCodec::builder()
+        .max_frame_length(MAX_FRAME_LENGTH)
+        .little_endian()
+        .length_field_length(4)
+        .new_codec()
+}
+
+fn fresh_socket_dir() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("chmod 0700");
+    dir
+}
+
+fn fixed_time() -> OffsetDateTime {
+    OffsetDateTime::from_unix_timestamp(1_700_000_000).expect("fixed time")
+}
+
+/// 受信した `IpcRequest` を記録するシェア。
+type Recorder = Arc<Mutex<Vec<IpcRequest>>>;
+
+/// ハンドシェイク後 1 回 `IpcRequest` を受信し、固定 `response` を返してから close するスタブを起動。
+///
+/// 戻り値の `Recorder` で受信内容を観測する。スタブ自身は別スレッドの `multi_thread`
+/// runtime で走るため、テスト本体側 `IpcVaultRepository::connect` の `current_thread`
+/// runtime と干渉しない。
+fn spawn_one_shot_stub(sock_path: PathBuf, response: IpcResponse) -> Recorder {
+    let recorder: Recorder = Arc::new(Mutex::new(Vec::new()));
+    let recorder_for_thread = Arc::clone(&recorder);
+    thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("server runtime");
+        rt.block_on(async move {
+            let listener = UnixListener::bind(&sock_path).expect("bind");
+            if let Ok((stream, _)) = listener.accept().await {
+                let mut framed: Framed<UnixStream, LengthDelimitedCodec> =
+                    Framed::new(stream, codec());
+                // 1. ハンドシェイク受信 → 成功応答
+                if let Some(Ok(_)) = framed.next().await {
+                    let ok = IpcResponse::Handshake {
+                        server_version: IpcProtocolVersion::V1,
+                    };
+                    let b = rmp_serde::to_vec(&ok).expect("encode handshake");
+                    let _ = framed.send(Bytes::from(b)).await;
+                }
+                // 2. 主リクエスト受信 → 記録 → 固定応答
+                if let Some(Ok(bytes)) = framed.next().await {
+                    if let Ok(req) = rmp_serde::from_slice::<IpcRequest>(&bytes) {
+                        if let Ok(mut rec) = recorder_for_thread.lock() {
+                            rec.push(req);
+                        }
+                    }
+                    let b = rmp_serde::to_vec(&response).expect("encode response");
+                    let _ = framed.send(Bytes::from(b)).await;
+                }
+                // 接続を維持（client が drop されるまで）
+                let _ = framed.next().await;
+            }
+        });
+    });
+    // bind が完了する猶予
+    thread::sleep(Duration::from_millis(50));
+    recorder
+}
+
+fn fixed_record_id() -> RecordId {
+    RecordId::new(Uuid::now_v7()).expect("v7")
+}
+
+fn build_label(s: &str) -> RecordLabel {
+    RecordLabel::try_new(s.to_owned()).expect("valid label")
+}
+
+// -------------------------------------------------------------------
+// TC-IT-080 / 081 / 082: add_record の正常 + Persistence + Domain
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_080_add_record_success_returns_daemon_id_and_emits_add_request() {
+    let dir = fresh_socket_dir();
+    let sock = dir.path().join("stub.sock");
+    let daemon_id = fixed_record_id();
+    let recorder = spawn_one_shot_stub(
+        sock.clone(),
+        IpcResponse::Added {
+            id: daemon_id.clone(),
+        },
+    );
+
+    let repo = IpcVaultRepository::connect(&sock).expect("connect");
+    let label = build_label("tc-it-080");
+    let value = SecretString::from_string("v-it-080".to_owned());
+    let returned = repo
+        .add_record(RecordKind::Text, label, value, fixed_time())
+        .expect("add_record ok");
+
+    // 戻り値はスタブ送信 id と bit 同一（**id は daemon 集約**、CLI 側で生成しない）
+    assert_eq!(returned, daemon_id);
+
+    // 受信 IpcRequest 検証
+    let received = recorder.lock().unwrap().clone();
+    assert_eq!(
+        received.len(),
+        1,
+        "expected exactly 1 request, got {received:?}"
+    );
+    match &received[0] {
+        IpcRequest::AddRecord {
+            kind,
+            label: lbl,
+            value: _v,
+            now,
+        } => {
+            assert_eq!(*kind, RecordKind::Text);
+            // RecordLabel は PartialEq を実装しないため Debug 文字列で比較
+            assert!(format!("{lbl:?}").contains("tc-it-080"));
+            assert_eq!(*now, fixed_time());
+            // SerializableSecretBytes の Debug は [REDACTED] 固定であるべき
+            let dbg = format!("{:?}", received[0]);
+            assert!(!dbg.contains("v-it-080"), "value leaked in debug: {dbg}");
+        }
+        other => panic!("expected AddRecord, got {other:?}"),
+    }
+}
+
+#[test]
+fn tc_it_081_add_record_persistence_error_maps_to_internal() {
+    let dir = fresh_socket_dir();
+    let sock = dir.path().join("stub.sock");
+    let _recorder = spawn_one_shot_stub(
+        sock.clone(),
+        IpcResponse::Error(IpcErrorCode::Persistence {
+            reason: "persistence error".to_owned(),
+        }),
+    );
+
+    let repo = IpcVaultRepository::connect(&sock).expect("connect");
+    let result = repo.add_record(
+        RecordKind::Text,
+        build_label("tc-it-081"),
+        SecretString::from_string("v".to_owned()),
+        fixed_time(),
+    );
+    match result {
+        Err(PersistenceError::Internal { reason }) => {
+            assert_eq!(reason, "persistence error");
+            assert!(!reason.contains(SECRET_MARKER));
+            assert!(!reason.contains('/'));
+        }
+        other => panic!("expected Internal error, got {other:?}"),
+    }
+}
+
+#[test]
+fn tc_it_082_add_record_domain_error_maps_to_internal() {
+    let dir = fresh_socket_dir();
+    let sock = dir.path().join("stub.sock");
+    let _recorder = spawn_one_shot_stub(
+        sock.clone(),
+        IpcResponse::Error(IpcErrorCode::Domain {
+            reason: "duplicate record id".to_owned(),
+        }),
+    );
+
+    let repo = IpcVaultRepository::connect(&sock).expect("connect");
+    let result = repo.add_record(
+        RecordKind::Text,
+        build_label("tc-it-082"),
+        SecretString::from_string("v".to_owned()),
+        fixed_time(),
+    );
+    match result {
+        Err(PersistenceError::Internal { reason }) => {
+            assert_eq!(reason, "duplicate record id");
+        }
+        other => panic!("expected Internal error, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-IT-083 / 084 / 085: edit_record の label-only / value-only / NotFound
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_083_edit_record_label_only_succeeds() {
+    let dir = fresh_socket_dir();
+    let sock = dir.path().join("stub.sock");
+    let daemon_id = fixed_record_id();
+    let recorder = spawn_one_shot_stub(
+        sock.clone(),
+        IpcResponse::Edited {
+            id: daemon_id.clone(),
+        },
+    );
+
+    let repo = IpcVaultRepository::connect(&sock).expect("connect");
+    let returned = repo
+        .edit_record(
+            daemon_id.clone(),
+            Some(build_label("new")),
+            None,
+            fixed_time(),
+        )
+        .expect("edit ok");
+    assert_eq!(returned, daemon_id);
+
+    let received = recorder.lock().unwrap().clone();
+    match &received[0] {
+        IpcRequest::EditRecord {
+            id, label, value, ..
+        } => {
+            assert_eq!(id, &daemon_id);
+            assert!(label.is_some(), "label should be Some for label-only edit");
+            assert!(value.is_none(), "value should be None for label-only edit");
+        }
+        other => panic!("expected EditRecord, got {other:?}"),
+    }
+}
+
+#[test]
+fn tc_it_084_edit_record_value_only_succeeds_and_value_redacted() {
+    let dir = fresh_socket_dir();
+    let sock = dir.path().join("stub.sock");
+    let daemon_id = fixed_record_id();
+    let recorder = spawn_one_shot_stub(
+        sock.clone(),
+        IpcResponse::Edited {
+            id: daemon_id.clone(),
+        },
+    );
+
+    let repo = IpcVaultRepository::connect(&sock).expect("connect");
+    let returned = repo
+        .edit_record(
+            daemon_id.clone(),
+            None,
+            Some(SecretString::from_string("new-value-it-084".to_owned())),
+            fixed_time(),
+        )
+        .expect("edit ok");
+    assert_eq!(returned, daemon_id);
+
+    let received = recorder.lock().unwrap().clone();
+    match &received[0] {
+        IpcRequest::EditRecord {
+            label,
+            value: Some(_v),
+            ..
+        } => {
+            assert!(label.is_none());
+            // Debug 出力に value 平文が漏れない
+            let dbg = format!("{:?}", received[0]);
+            assert!(
+                !dbg.contains("new-value-it-084"),
+                "edit value leaked in debug: {dbg}"
+            );
+        }
+        other => panic!("expected EditRecord with value Some, got {other:?}"),
+    }
+}
+
+#[test]
+fn tc_it_085_edit_record_not_found_maps_to_record_not_found() {
+    let dir = fresh_socket_dir();
+    let sock = dir.path().join("stub.sock");
+    let daemon_id = fixed_record_id();
+    let _recorder = spawn_one_shot_stub(
+        sock.clone(),
+        IpcResponse::Error(IpcErrorCode::NotFound {
+            id: daemon_id.clone(),
+        }),
+    );
+
+    let repo = IpcVaultRepository::connect(&sock).expect("connect");
+    let result = repo.edit_record(
+        daemon_id.clone(),
+        Some(build_label("x")),
+        None,
+        fixed_time(),
+    );
+    match result {
+        Err(PersistenceError::RecordNotFound(id)) => {
+            assert_eq!(id, daemon_id);
+        }
+        other => panic!("expected RecordNotFound, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-IT-086 / 087 / 088: remove_record の正常 + NotFound + Persistence
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_it_086_remove_record_success() {
+    let dir = fresh_socket_dir();
+    let sock = dir.path().join("stub.sock");
+    let daemon_id = fixed_record_id();
+    let recorder = spawn_one_shot_stub(
+        sock.clone(),
+        IpcResponse::Removed {
+            id: daemon_id.clone(),
+        },
+    );
+
+    let repo = IpcVaultRepository::connect(&sock).expect("connect");
+    let returned = repo.remove_record(daemon_id.clone()).expect("remove ok");
+    assert_eq!(returned, daemon_id);
+
+    let received = recorder.lock().unwrap().clone();
+    match &received[0] {
+        IpcRequest::RemoveRecord { id } => assert_eq!(id, &daemon_id),
+        other => panic!("expected RemoveRecord, got {other:?}"),
+    }
+}
+
+#[test]
+fn tc_it_087_remove_record_not_found_maps_to_record_not_found() {
+    let dir = fresh_socket_dir();
+    let sock = dir.path().join("stub.sock");
+    let daemon_id = fixed_record_id();
+    let _recorder = spawn_one_shot_stub(
+        sock.clone(),
+        IpcResponse::Error(IpcErrorCode::NotFound {
+            id: daemon_id.clone(),
+        }),
+    );
+
+    let repo = IpcVaultRepository::connect(&sock).expect("connect");
+    let result = repo.remove_record(daemon_id.clone());
+    match result {
+        Err(PersistenceError::RecordNotFound(id)) => assert_eq!(id, daemon_id),
+        other => panic!("expected RecordNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn tc_it_088_remove_record_persistence_error_maps_to_internal() {
+    let dir = fresh_socket_dir();
+    let sock = dir.path().join("stub.sock");
+    let daemon_id = fixed_record_id();
+    let _recorder = spawn_one_shot_stub(
+        sock.clone(),
+        IpcResponse::Error(IpcErrorCode::Persistence {
+            reason: "persistence error".to_owned(),
+        }),
+    );
+
+    let repo = IpcVaultRepository::connect(&sock).expect("connect");
+    let result = repo.remove_record(daemon_id);
+    match result {
+        Err(PersistenceError::Internal { reason }) => {
+            assert_eq!(reason, "persistence error");
+        }
+        other => panic!("expected Internal, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-IT-089 横串: 全テスト共通 — secret マーカー不在を再確認
+// -------------------------------------------------------------------
+#[test]
+fn tc_it_089_secret_marker_never_appears_in_request_debug() {
+    let dir = fresh_socket_dir();
+    let sock = dir.path().join("stub.sock");
+    let daemon_id = fixed_record_id();
+    let recorder = spawn_one_shot_stub(
+        sock.clone(),
+        IpcResponse::Added {
+            id: daemon_id.clone(),
+        },
+    );
+
+    let repo = IpcVaultRepository::connect(&sock).expect("connect");
+    let _ = repo.add_record(
+        RecordKind::Secret,
+        build_label("tc-it-089"),
+        SecretString::from_string(SECRET_MARKER.to_owned()),
+        fixed_time(),
+    );
+    let received = recorder.lock().unwrap().clone();
+    let dbg = format!("{received:?}");
+    assert!(
+        !dbg.contains(SECRET_MARKER),
+        "SECRET_MARKER leaked in IpcRequest Debug: {dbg}"
+    );
+}

--- a/crates/shikomi-core/src/ipc/secret_bytes.rs
+++ b/crates/shikomi-core/src/ipc/secret_bytes.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::secret::SecretBytes;
+use crate::secret::{clone_secret_string_bytes, SecretBytes, SecretString};
 
 // -------------------------------------------------------------------
 // SerializableSecretBytes
@@ -43,6 +43,20 @@ impl SerializableSecretBytes {
     #[must_use]
     pub fn into_inner(self) -> SecretBytes {
         self.0
+    }
+
+    /// `SecretString` を消費して IPC 送信用 `SerializableSecretBytes` に変換する。
+    ///
+    /// CLI 側 `IpcVaultRepository::add_record` / `edit_record` から呼ばれ、
+    /// 平文取り出し経路を core 内（本ファイル）に閉じる
+    /// （CI grep TC-CI-015 / TC-CI-016 の監査範囲外を維持）。
+    ///
+    /// 設計根拠: docs/features/daemon-ipc/detailed-design/ipc-vault-repository.md
+    /// §`add_record` / §`edit_record`
+    #[must_use]
+    pub fn from_secret_string(secret: SecretString) -> Self {
+        let bytes = clone_secret_string_bytes(&secret);
+        Self(SecretBytes::from_vec(bytes))
     }
 }
 
@@ -140,5 +154,31 @@ mod tests {
         let s = SerializableSecretBytes(SecretBytes::from_vec(vec![5, 6, 7]));
         let inner = s.into_inner();
         assert_eq!(inner.as_serialize_slice().len(), 3);
+    }
+
+    #[test]
+    fn test_from_secret_string_preserves_byte_length_and_redacts_debug() {
+        let secret = SecretString::from_string("hunter2".to_string());
+        let wrapped = SerializableSecretBytes::from_secret_string(secret);
+        assert_eq!(wrapped.inner().as_serialize_slice().len(), "hunter2".len());
+
+        let debug_output = format!("{wrapped:?}");
+        assert!(debug_output.contains("[REDACTED]"));
+        assert!(!debug_output.contains("hunter2"));
+    }
+
+    #[test]
+    fn test_from_secret_string_round_trips_via_serialize_slice() {
+        // `SecretString` → `SerializableSecretBytes` → 内部スライスのラウンドトリップで
+        // バイト列が等価であることを、長さと先頭/末尾のバイトで間接検証する
+        // （本ファイルは CI grep `TC-CI-015` の監査範囲下のため、テストでも平文取出
+        //  API を呼ばない方針）。
+        let phrase = "こんにちは🌸";
+        let original = SecretString::from_string(phrase.to_string());
+        let wrapped = SerializableSecretBytes::from_secret_string(original);
+        let inner_slice = wrapped.inner().as_serialize_slice();
+        assert_eq!(inner_slice.len(), phrase.len());
+        assert_eq!(inner_slice.first(), phrase.as_bytes().first());
+        assert_eq!(inner_slice.last(), phrase.as_bytes().last());
     }
 }

--- a/crates/shikomi-daemon/tests/e2e_daemon_phase15.rs
+++ b/crates/shikomi-daemon/tests/e2e_daemon_phase15.rs
@@ -1,0 +1,470 @@
+//! daemon E2E (Phase 1.5) — test-design/e2e.md
+//! TC-E2E-011 / 012 / 013 / 014 / 015 / 016（Issue #30 で初活性化）
+//!
+//! Phase 1.5（Issue #30）の核：PR #29 の runtime reject 経路を撤去し、`--ipc add` /
+//! `--ipc edit` / `--ipc remove` が実 daemon 経由で透過動作する。本ファイルは
+//! 「ユーザーが完全ブラックボックスで観測する振る舞い」を `std::process::Command`
+//! 経由で検証する。
+//!
+//! - DB 直接確認 / 内部状態参照 / テスト用裏口は禁止（テスト戦略ガイド準拠）
+//! - 状態確認は `shikomi --ipc list` のラウンドトリップで実施
+//! - secret マーカー `SECRET_TEST_VALUE` の不在は全 stdout/stderr で横串アサート
+//!
+//! 対応 Issue: #30 / PR #32
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+const SECRET_MARKER: &str = "SECRET_TEST_VALUE";
+
+// -------------------------------------------------------------------
+// 共通ヘルパ（e2e_daemon.rs と同型、内部限定で複製、cross-test 共有を避ける）
+// -------------------------------------------------------------------
+
+fn seed_empty_vault(vault_dir: &Path) {
+    use shikomi_core::{Vault, VaultHeader, VaultVersion};
+    use shikomi_infra::persistence::{SqliteVaultRepository, VaultRepository};
+    use time::OffsetDateTime;
+    let header = VaultHeader::new_plaintext(
+        VaultVersion::CURRENT,
+        OffsetDateTime::UNIX_EPOCH + time::Duration::hours(1),
+    )
+    .expect("header");
+    let vault = Vault::new(header);
+    let repo = SqliteVaultRepository::from_directory(vault_dir).expect("repo");
+    repo.save(&vault).expect("seed empty vault");
+}
+
+fn tight_tempdir() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("chmod 0700");
+    dir
+}
+
+struct DaemonGuard {
+    child: Option<Child>,
+    stderr_log: Arc<Mutex<String>>,
+}
+
+impl DaemonGuard {
+    fn spawn(xdg_runtime_dir: &Path, vault_dir: &Path) -> Self {
+        let bin = env!("CARGO_BIN_EXE_shikomi-daemon");
+        let mut child = Command::new(bin)
+            .env("XDG_RUNTIME_DIR", xdg_runtime_dir)
+            .env("SHIKOMI_VAULT_DIR", vault_dir)
+            .env("SHIKOMI_DAEMON_LOG", "info")
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn daemon");
+
+        let stderr = child.stderr.take().expect("stderr piped");
+        let stderr_log: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+        let stderr_log_for_thread = Arc::clone(&stderr_log);
+        thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().map_while(Result::ok) {
+                if let Ok(mut log) = stderr_log_for_thread.lock() {
+                    log.push_str(&line);
+                    log.push('\n');
+                }
+            }
+        });
+
+        let sock_path: PathBuf = xdg_runtime_dir.join("shikomi").join("daemon.sock");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut listening_seen = false;
+        while Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(50));
+            if sock_path.exists() {
+                if let Ok(log) = stderr_log.lock() {
+                    if log.contains("listening on") {
+                        listening_seen = true;
+                        break;
+                    }
+                }
+            }
+        }
+        assert!(
+            sock_path.exists() && listening_seen,
+            "daemon failed to listen within 5s. stderr:\n{}",
+            stderr_log.lock().map(|s| s.clone()).unwrap_or_default()
+        );
+        Self {
+            child: Some(child),
+            stderr_log,
+        }
+    }
+
+    fn stderr(&self) -> String {
+        self.stderr_log
+            .lock()
+            .map(|s| s.clone())
+            .unwrap_or_default()
+    }
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// `shikomi <args>` を実行し `(stdout, stderr, exit_code)` を返す。
+fn run_shikomi(xdg: &Path, vault_dir: &Path, args: &[&str]) -> (String, String, Option<i32>) {
+    let bin = assert_cmd::cargo::cargo_bin("shikomi");
+    let output = Command::new(bin)
+        .env("XDG_RUNTIME_DIR", xdg)
+        .env("SHIKOMI_VAULT_DIR", vault_dir)
+        .args(args)
+        .output()
+        .expect("spawn shikomi cli");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+/// `added: <uuid>` / `updated: <uuid>` / `removed: <uuid>` から uuid 文字列を抽出。
+fn extract_uuid_after(prefix: &str, stdout: &str) -> String {
+    for line in stdout.lines() {
+        if let Some(rest) = line.trim().strip_prefix(prefix) {
+            let uuid = rest.trim();
+            // 36 文字 UUID v7 形式の最低限チェック（hyphen 4 + hex 32）
+            assert_eq!(uuid.len(), 36, "expected 36-char uuid, got {uuid:?}");
+            return uuid.to_owned();
+        }
+    }
+    panic!("prefix {prefix:?} not found in stdout:\n{stdout}");
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-016: PR #29 runtime reject 撤去回帰検証（Phase 1.5-α / REQ-DAEMON-027）
+// -------------------------------------------------------------------
+//
+// PR #29 段階で `--ipc add` は `--ipc currently supports only the list subcommand`
+// の reject エラーで exit 1 になっていた。Phase 1.5 でその経路を撤去し、daemon
+// 経由で AddRecord が透過するようにした。本 TC はその撤去契約が**実機で観測可能**
+// であることを検証する。CI grep TC-CI-028 と二重防衛。
+#[test]
+fn tc_e2e_016_pr29_runtime_reject_removed_for_ipc_add() {
+    let xdg = tight_tempdir();
+    let vault_dir = tight_tempdir();
+    seed_empty_vault(vault_dir.path());
+    let guard = DaemonGuard::spawn(xdg.path(), vault_dir.path());
+
+    let (stdout, stderr, code) = run_shikomi(
+        xdg.path(),
+        vault_dir.path(),
+        &[
+            "--ipc",
+            "add",
+            "--kind",
+            "text",
+            "--label",
+            "phase15-regression",
+            "--value",
+            "regression-value",
+        ],
+    );
+
+    assert_eq!(
+        code,
+        Some(0),
+        "exit code should be 0 (reject removed). stdout={stdout} stderr={stderr} daemon_stderr={}",
+        guard.stderr()
+    );
+    assert!(
+        stdout.contains("added: "),
+        "stdout should contain 'added: <id>': {stdout}"
+    );
+    // 旧 reject メッセージの不在
+    assert!(
+        !stderr.contains("currently supports only"),
+        "stderr should NOT contain old PR#29 reject message: {stderr}"
+    );
+    assert!(!stdout.contains(SECRET_MARKER));
+    assert!(!stderr.contains(SECRET_MARKER));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-011: --ipc add (text) → --ipc list で反映確認
+// -------------------------------------------------------------------
+#[test]
+fn tc_e2e_011_ipc_add_text_then_list_shows_record() {
+    let xdg = tight_tempdir();
+    let vault_dir = tight_tempdir();
+    seed_empty_vault(vault_dir.path());
+    let _guard = DaemonGuard::spawn(xdg.path(), vault_dir.path());
+
+    let (add_stdout, add_stderr, add_code) = run_shikomi(
+        xdg.path(),
+        vault_dir.path(),
+        &[
+            "--ipc",
+            "add",
+            "--kind",
+            "text",
+            "--label",
+            "tc011-label",
+            "--value",
+            "tc011-value",
+        ],
+    );
+    assert_eq!(
+        add_code,
+        Some(0),
+        "add should succeed: stdout={add_stdout} stderr={add_stderr}"
+    );
+    let new_id = extract_uuid_after("added: ", &add_stdout);
+
+    // 反映確認：--ipc list で新 id が出る（ラウンドトリップ検証）
+    let (list_stdout, list_stderr, list_code) =
+        run_shikomi(xdg.path(), vault_dir.path(), &["--ipc", "list"]);
+    assert_eq!(
+        list_code,
+        Some(0),
+        "list should succeed: stdout={list_stdout} stderr={list_stderr}"
+    );
+    assert!(
+        list_stdout.contains(&new_id),
+        "list stdout should contain the new id {new_id}: {list_stdout}"
+    );
+    assert!(
+        list_stdout.contains("tc011-label"),
+        "list stdout should contain the new label: {list_stdout}"
+    );
+    // text 値はプレビュー出力されるはず（TC-E2E-011 期待）
+    assert!(
+        list_stdout.contains("tc011-value"),
+        "text value should appear in list preview: {list_stdout}"
+    );
+    // 横串
+    assert!(!add_stderr.contains(SECRET_MARKER));
+    assert!(!list_stdout.contains(SECRET_MARKER));
+    assert!(!list_stderr.contains(SECRET_MARKER));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-012: --ipc add (secret --stdin) で SECRET 非露出
+// -------------------------------------------------------------------
+#[test]
+fn tc_e2e_012_ipc_add_secret_stdin_never_echoes_marker() {
+    let xdg = tight_tempdir();
+    let vault_dir = tight_tempdir();
+    seed_empty_vault(vault_dir.path());
+    let guard = DaemonGuard::spawn(xdg.path(), vault_dir.path());
+
+    let bin = assert_cmd::cargo::cargo_bin("shikomi");
+    let mut child = Command::new(bin)
+        .env("XDG_RUNTIME_DIR", xdg.path())
+        .env("SHIKOMI_VAULT_DIR", vault_dir.path())
+        .args([
+            "--ipc",
+            "add",
+            "--kind",
+            "secret",
+            "--label",
+            "tc012-secret",
+            "--stdin",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn shikomi cli");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        writeln!(stdin, "{SECRET_MARKER}").expect("write stdin");
+    }
+    let output = child.wait_with_output().expect("wait");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "add secret should succeed: stdout={stdout} stderr={stderr} daemon_stderr={}",
+        guard.stderr()
+    );
+    // 横串：CLI stdout/stderr + daemon stderr 全てに SECRET_MARKER 非含有
+    assert!(
+        !stdout.contains(SECRET_MARKER),
+        "CLI stdout leaked secret: {stdout}"
+    );
+    assert!(
+        !stderr.contains(SECRET_MARKER),
+        "CLI stderr leaked secret: {stderr}"
+    );
+    let dlog = guard.stderr();
+    assert!(
+        !dlog.contains(SECRET_MARKER),
+        "daemon stderr leaked secret: {dlog}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-013: --ipc edit --label NEW で list 反映
+// -------------------------------------------------------------------
+#[test]
+fn tc_e2e_013_ipc_edit_label_then_list_shows_new_label() {
+    let xdg = tight_tempdir();
+    let vault_dir = tight_tempdir();
+    seed_empty_vault(vault_dir.path());
+    let _guard = DaemonGuard::spawn(xdg.path(), vault_dir.path());
+
+    // 事前 add
+    let (add_stdout, _, _) = run_shikomi(
+        xdg.path(),
+        vault_dir.path(),
+        &[
+            "--ipc",
+            "add",
+            "--kind",
+            "text",
+            "--label",
+            "tc013-old",
+            "--value",
+            "v",
+        ],
+    );
+    let id = extract_uuid_after("added: ", &add_stdout);
+
+    // edit
+    let (edit_stdout, edit_stderr, edit_code) = run_shikomi(
+        xdg.path(),
+        vault_dir.path(),
+        &["--ipc", "edit", "--id", &id, "--label", "tc013-new"],
+    );
+    assert_eq!(
+        edit_code,
+        Some(0),
+        "edit should succeed: stdout={edit_stdout} stderr={edit_stderr}"
+    );
+    assert!(
+        edit_stdout.contains(&id),
+        "edit stdout should echo id: {edit_stdout}"
+    );
+
+    // 反映確認
+    let (list_stdout, _, _) = run_shikomi(xdg.path(), vault_dir.path(), &["--ipc", "list"]);
+    assert!(
+        list_stdout.contains("tc013-new"),
+        "list should show the new label: {list_stdout}"
+    );
+    assert!(
+        !list_stdout.contains("tc013-old"),
+        "list should NOT contain the old label: {list_stdout}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-014: --ipc remove --yes で list から消える
+// -------------------------------------------------------------------
+#[test]
+fn tc_e2e_014_ipc_remove_yes_then_list_shows_no_record() {
+    let xdg = tight_tempdir();
+    let vault_dir = tight_tempdir();
+    seed_empty_vault(vault_dir.path());
+    let _guard = DaemonGuard::spawn(xdg.path(), vault_dir.path());
+
+    // 事前 add
+    let (add_stdout, _, _) = run_shikomi(
+        xdg.path(),
+        vault_dir.path(),
+        &[
+            "--ipc",
+            "add",
+            "--kind",
+            "text",
+            "--label",
+            "tc014-doomed",
+            "--value",
+            "v",
+        ],
+    );
+    let id = extract_uuid_after("added: ", &add_stdout);
+
+    // 削除前 list で存在確認
+    let (list_before, _, _) = run_shikomi(xdg.path(), vault_dir.path(), &["--ipc", "list"]);
+    assert!(list_before.contains(&id));
+
+    // remove --yes
+    let (rm_stdout, rm_stderr, rm_code) = run_shikomi(
+        xdg.path(),
+        vault_dir.path(),
+        &["--ipc", "remove", "--id", &id, "--yes"],
+    );
+    assert_eq!(
+        rm_code,
+        Some(0),
+        "remove should succeed: stdout={rm_stdout} stderr={rm_stderr}"
+    );
+    assert!(
+        rm_stdout.contains(&id),
+        "remove stdout should echo id: {rm_stdout}"
+    );
+
+    // 削除後 list から消えている
+    let (list_after, _, _) = run_shikomi(xdg.path(), vault_dir.path(), &["--ipc", "list"]);
+    assert!(
+        !list_after.contains(&id),
+        "list should not contain removed id: {list_after}"
+    );
+    assert!(
+        !list_after.contains("tc014-doomed"),
+        "list should not contain removed label: {list_after}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-015: --ipc edit --id <非存在> → exit 1 + RecordNotFound 経路
+// -------------------------------------------------------------------
+#[test]
+fn tc_e2e_015_ipc_edit_nonexistent_id_returns_user_error() {
+    let xdg = tight_tempdir();
+    let vault_dir = tight_tempdir();
+    seed_empty_vault(vault_dir.path());
+    let guard = DaemonGuard::spawn(xdg.path(), vault_dir.path());
+
+    let (stdout, stderr, code) = run_shikomi(
+        xdg.path(),
+        vault_dir.path(),
+        &[
+            "--ipc",
+            "edit",
+            // 全 0 の UUID v7 — vault に存在しない
+            "--id",
+            "00000000-0000-0000-0000-000000000000",
+            "--label",
+            "anything",
+        ],
+    );
+    assert!(
+        code.unwrap_or(0) != 0,
+        "edit on non-existent id should fail: exit={code:?} stdout={stdout} stderr={stderr}"
+    );
+    // ユーザー観測可能なメッセージ：「見つからない」「not found」「record」のいずれかを期待
+    let lower = stderr.to_lowercase();
+    assert!(
+        lower.contains("not found") || lower.contains("見つかりません") || lower.contains("record"),
+        "stderr should mention not-found or record: {stderr}"
+    );
+    // 横串
+    assert!(!stdout.contains(SECRET_MARKER));
+    assert!(!stderr.contains(SECRET_MARKER));
+    assert!(!guard.stderr().contains(SECRET_MARKER));
+}

--- a/crates/shikomi-infra/src/persistence/error.rs
+++ b/crates/shikomi-infra/src/persistence/error.rs
@@ -4,6 +4,8 @@
 
 use std::path::PathBuf;
 
+use shikomi_core::ipc::IpcErrorCode;
+use shikomi_core::RecordId;
 use thiserror::Error;
 
 // -------------------------------------------------------------------
@@ -303,6 +305,33 @@ pub enum PersistenceError {
         /// 失敗の人間可読理由（固定文言、絶対パス等を含めない）。
         reason: String,
     },
+
+    /// IPC: 対象 `RecordId` が daemon 側 vault に存在しない。
+    ///
+    /// daemon-ipc Phase 1.5（Issue #30）で追加。`IpcErrorCode::NotFound { id }` の
+    /// CLI 側写像専用バリアント。`reason` 文字列に id を埋めるのではなく、
+    /// 構造化された `RecordId` を保持して presenter 側で安定整形する。
+    ///
+    /// 設計根拠: docs/features/daemon-ipc/basic-design/error.md
+    /// §`IpcErrorCode` バリアントごとの CLI 写像
+    #[error("record not found: {0}")]
+    RecordNotFound(RecordId),
+
+    /// IPC: daemon 側で想定外バグ。
+    ///
+    /// daemon-ipc Phase 1.5（Issue #30）で追加。`IpcErrorCode::Internal { reason }` の
+    /// CLI 側写像専用バリアント。`InvalidLabel` / `Persistence` / `Domain` 系
+    /// `IpcErrorCode` も Phase 1.5 では本バリアントに寄せる（reason 文字列はそれぞれ
+    /// 固定文言を保持）。`reason` には secret / 絶対パス / PID を含めない契約
+    /// （daemon 側で固定文言化された値のみを格納）。
+    ///
+    /// 設計根拠: docs/features/daemon-ipc/basic-design/error.md
+    /// §`reason` フィールドの設計規約
+    #[error("internal error: {reason}")]
+    Internal {
+        /// 失敗の人間可読理由（固定文言、secret / 絶対パス / PID を含めない）。
+        reason: String,
+    },
 }
 
 // -------------------------------------------------------------------
@@ -325,5 +354,64 @@ impl From<shikomi_core::DomainError> for PersistenceError {
             },
             source: Some(e),
         }
+    }
+}
+
+/// daemon が返した `IpcErrorCode` を `PersistenceError` に写像する。
+///
+/// daemon-ipc Phase 1.5（Issue #30）で追加。`NotFound` のみ専用バリアント
+/// `RecordNotFound(id)` に写像し、`InvalidLabel` / `Persistence` / `Domain` /
+/// `Internal` および unknown variant は `Internal { reason }` に集約する。
+/// `reason` 文字列は **daemon 側で固定文言化された値をそのまま保持**する
+/// （CLI 側で再フォーマットせず、secret / 絶対パス / PID 漏洩経路を構造的に遮断）。
+///
+/// 設計根拠: docs/features/daemon-ipc/basic-design/error.md
+/// §`IpcErrorCode` バリアントごとの CLI 写像
+impl From<IpcErrorCode> for PersistenceError {
+    fn from(code: IpcErrorCode) -> Self {
+        match code {
+            IpcErrorCode::EncryptionUnsupported => Self::UnsupportedYet {
+                feature: "encrypted vault persistence",
+                tracking_issue: None,
+            },
+            IpcErrorCode::NotFound { id } => Self::RecordNotFound(id),
+            IpcErrorCode::InvalidLabel { reason }
+            | IpcErrorCode::Persistence { reason }
+            | IpcErrorCode::Domain { reason }
+            | IpcErrorCode::Internal { reason } => Self::Internal { reason },
+            // `IpcErrorCode` は `#[non_exhaustive]`。cross-crate での将来バリアント
+            // 追加に備えた防御的 wildcard。固定文言で `Internal` に集約する。
+            _ => Self::Internal {
+                reason: "unknown error code".to_owned(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_record_not_found_display_carries_record_id_only() {
+        let id = RecordId::new(Uuid::now_v7()).expect("valid uuid v7");
+        let err = PersistenceError::RecordNotFound(id);
+        let rendered = err.to_string();
+        assert!(rendered.starts_with("record not found:"));
+        // 絶対パス・PID・タイムスタンプ等を含まないことの構造的保証
+        assert!(!rendered.contains('/'));
+        assert!(!rendered.contains("pid"));
+    }
+
+    #[test]
+    fn test_internal_display_carries_reason_only() {
+        let err = PersistenceError::Internal {
+            reason: "persistence error".into(),
+        };
+        let rendered = err.to_string();
+        assert_eq!(rendered, "internal error: persistence error");
+        assert!(!rendered.contains('/'));
+        assert!(!rendered.contains("pid"));
     }
 }

--- a/crates/shikomi-infra/tests/from_ipc_error_code_phase15.rs
+++ b/crates/shikomi-infra/tests/from_ipc_error_code_phase15.rs
@@ -1,0 +1,172 @@
+//! `From<IpcErrorCode> for PersistenceError` 6 バリアント完全網羅 UT (Phase 1.5)
+//! — test-design/unit.md §2.13 TC-UT-110〜114b
+//!
+//! 案 D で確定した写像規約:
+//! - `EncryptionUnsupported` → `UnsupportedYet`
+//! - `NotFound { id }`        → `RecordNotFound(id)`（**Issue #30 新バリアント**）
+//! - `InvalidLabel/Persistence/Domain/Internal` → 全て `Internal { reason }` に集約
+//!   （実装担当の方針 X 採用、reason 文字列は **daemon 側固定文言** をそのまま保持）
+//!
+//! 横串: 全 Display 出力に SECRET / 絶対パス / PID 等が漏れていないこと
+//!
+//! 対応 Issue: #30 / PR #32
+
+use shikomi_core::ipc::IpcErrorCode;
+use shikomi_core::RecordId;
+use shikomi_infra::persistence::PersistenceError;
+use uuid::Uuid;
+
+const SECRET_MARKER: &str = "SECRET_TEST_VALUE";
+
+fn assert_no_leak(rendered: &str) {
+    assert!(
+        !rendered.contains(SECRET_MARKER),
+        "secret marker leaked: {rendered}"
+    );
+    assert!(
+        !rendered.contains("/home/"),
+        "absolute home path leaked: {rendered}"
+    );
+    assert!(
+        !rendered.to_lowercase().contains("pid="),
+        "pid leaked: {rendered}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-UT-110: EncryptionUnsupported → UnsupportedYet 写像
+// -------------------------------------------------------------------
+#[test]
+fn tc_ut_110_encryption_unsupported_maps_to_unsupported_yet() {
+    let pe: PersistenceError = IpcErrorCode::EncryptionUnsupported.into();
+    match pe {
+        PersistenceError::UnsupportedYet { feature, .. } => {
+            assert!(
+                feature.to_lowercase().contains("encrypt"),
+                "feature should describe encryption: {feature}"
+            );
+        }
+        other => panic!("expected UnsupportedYet, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-UT-111: NotFound { id } → RecordNotFound(id)（id 構造保持）
+// -------------------------------------------------------------------
+#[test]
+fn tc_ut_111_not_found_maps_to_record_not_found_preserving_id() {
+    let id = RecordId::new(Uuid::now_v7()).expect("v7");
+    let pe: PersistenceError = IpcErrorCode::NotFound { id: id.clone() }.into();
+    match pe {
+        PersistenceError::RecordNotFound(returned_id) => {
+            assert_eq!(returned_id, id);
+        }
+        other => panic!("expected RecordNotFound, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-UT-112: InvalidLabel { reason } → Internal { reason }（方針 X 集約）
+// -------------------------------------------------------------------
+#[test]
+fn tc_ut_112_invalid_label_maps_to_internal_preserving_reason() {
+    let pe: PersistenceError = IpcErrorCode::InvalidLabel {
+        reason: "invalid label".to_owned(),
+    }
+    .into();
+    match pe {
+        PersistenceError::Internal { reason } => {
+            assert_eq!(reason, "invalid label");
+            assert_no_leak(&reason);
+        }
+        other => panic!("expected Internal, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-UT-113: Persistence { reason } → Internal { reason }（方針 X 集約）
+// -------------------------------------------------------------------
+#[test]
+fn tc_ut_113_persistence_maps_to_internal_preserving_reason() {
+    let pe: PersistenceError = IpcErrorCode::Persistence {
+        reason: "persistence error".to_owned(),
+    }
+    .into();
+    match pe {
+        PersistenceError::Internal { reason } => {
+            assert_eq!(reason, "persistence error");
+            assert_no_leak(&reason);
+        }
+        other => panic!("expected Internal, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-UT-114: Domain { reason } → Internal { reason }（方針 X 集約）
+// -------------------------------------------------------------------
+#[test]
+fn tc_ut_114_domain_maps_to_internal_preserving_reason() {
+    let pe: PersistenceError = IpcErrorCode::Domain {
+        reason: "duplicate record id".to_owned(),
+    }
+    .into();
+    match pe {
+        PersistenceError::Internal { reason } => {
+            assert_eq!(reason, "duplicate record id");
+            assert_no_leak(&reason);
+        }
+        other => panic!("expected Internal, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// TC-UT-114b: Internal { reason } → Internal { reason }（identity）
+// -------------------------------------------------------------------
+#[test]
+fn tc_ut_114b_internal_maps_to_internal_identity() {
+    let pe: PersistenceError = IpcErrorCode::Internal {
+        reason: "unexpected error".to_owned(),
+    }
+    .into();
+    match pe {
+        PersistenceError::Internal { reason } => {
+            assert_eq!(reason, "unexpected error");
+            assert_no_leak(&reason);
+        }
+        other => panic!("expected Internal, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------
+// 横串: Display 出力に secret / 絶対パス / PID が出ないこと
+// -------------------------------------------------------------------
+#[test]
+fn tc_ut_114c_display_outputs_never_leak_sensitive_strings() {
+    let cases: Vec<PersistenceError> = vec![
+        IpcErrorCode::EncryptionUnsupported.into(),
+        IpcErrorCode::NotFound {
+            id: RecordId::new(Uuid::now_v7()).unwrap(),
+        }
+        .into(),
+        IpcErrorCode::InvalidLabel {
+            reason: "invalid label".to_owned(),
+        }
+        .into(),
+        IpcErrorCode::Persistence {
+            reason: "persistence error".to_owned(),
+        }
+        .into(),
+        IpcErrorCode::Domain {
+            reason: "domain error".to_owned(),
+        }
+        .into(),
+        IpcErrorCode::Internal {
+            reason: "unexpected error".to_owned(),
+        }
+        .into(),
+    ];
+    for case in &cases {
+        let rendered = case.to_string();
+        assert_no_leak(&rendered);
+    }
+}

--- a/docs/features/cli-vault-commands/detailed-design/composition-root.md
+++ b/docs/features/cli-vault-commands/detailed-design/composition-root.md
@@ -113,15 +113,70 @@
 2. `run()` で「最低 1 つの更新フラグ必須」検証: `(args.label.is_some() || args.value.is_some() || args.stdin) == false` なら `CliError::UsageError("at least one of --label/--value/--stdin is required")`
 3. `RecordId::try_from_str(&args.id)?` → `CliError::InvalidId`
 4. `args.label.as_deref().map(|s| RecordLabel::try_new(s.to_string())).transpose()?` → `CliError::InvalidLabel`
-5. value 取得（`run_add` と同様、ただし `Option<SecretString>` に包む）
-6. `let input = EditInput { id, label, value };`
-7. shell 履歴警告: 既存レコード（まだ load していないので警告判定は `args.value.is_some() && args.stdin == false` だけで済ますか、load 後の既存 kind と照合するかは実装時判断。設計方針は前者（`run_add` と挙動を揃える））
-8. `let now = OffsetDateTime::now_utc();`
-9. `match handle`:
-   - `RepositoryHandle::Sqlite(repo)` → `let id = usecase::edit::edit_record(repo, input, now)?;`
-   - `RepositoryHandle::Ipc(ipc)` → `let id = ipc.edit_record(input.id, input.label, input.value, now)?;`
-10. `println!("{}", render_updated(&id, locale))`
-11. `Ok(())`
+5. **既存 kind の解決（経路別、Issue #30 で方針 B：fail-secure 採用）**:
+   - `RepositoryHandle::Sqlite(repo)` → `repo.load()?` → `find_record(&id)` で既存 `Record::kind()` を取得（既存通り）
+   - `RepositoryHandle::Ipc(ipc)` → **既存 kind 不明**として扱い、value 取得経路を **fail-secure**（`RecordKind::Secret` 相当）に固定する。詳細は §Secret エコーバック対策（方針 B）参照
+6. value 取得（kind 解決結果に応じて分岐）:
+   - `args.value.is_some()` → `SecretString::from_string(args.value.clone().unwrap())`
+   - `args.stdin == true` → 解決済み kind が `Secret` → `read_password`（**非エコー**）／ `Text` → `read_line`（エコーあり）
+   - `args.value.is_none() && args.stdin == false` → `Option<SecretString>::None`
+7. `let input = EditInput { id, label, value };`
+8. shell 履歴警告: `args.value.is_some() && args.stdin == false` で `eprintln!("{}", render_shell_history_warning(locale))`（`run_add` と挙動を揃える）
+9. `let now = OffsetDateTime::now_utc();`
+10. `match handle`:
+    - `RepositoryHandle::Sqlite(repo)` → `let id = usecase::edit::edit_record(repo, input, now)?;`
+    - `RepositoryHandle::Ipc(ipc)` → `let id = ipc.edit_record(input.id, input.label, input.value, now)?;`
+11. `println!("{}", render_updated(&id, locale))`
+12. `Ok(())`
+
+## `run_edit` の Secret エコーバック対策（方針 B：fail-secure、Issue #30 で確定）
+
+### 問題
+
+`run_edit` の value 取得経路（ステップ 6）では、`--stdin` 指定時に既存レコードの `RecordKind` を見て、`Secret` なら `read_password`（非エコー）、`Text` なら `read_line`（エコーあり）を選択する。
+
+- **Sqlite 経路**: `repo.load()?` → `find_record(&id)` で既存 kind を取得可能
+- **IPC 経路**: PR #32 初期実装で「daemon round-trip コスト回避」を理由に既存 kind 取得を省略 → `Text` 既定で `read_line` に落としていた
+
+これは TTY で `shikomi --ipc edit --id <既存 Secret 行> --stdin` を実行した場合、**既存 Secret kind であっても新 value が画面エコーされる**脆弱経路を生む（ペテルギウス指摘）。
+
+### 採用方針: 方針 B — fail-secure（既存 kind 不明時は保守的に Secret 扱い）
+
+リーダー判断により方針 B を採用。実装は以下:
+
+| ステップ | Sqlite 経路 | IPC 経路（方針 B） |
+|---------|-----------|------------------|
+| 既存 kind 取得 | `repo.load()` → `find_record(&id)` で取得 | **取得しない** |
+| 不明扱い | 該当なし（必ず取得成功 / `RecordNotFound` で early return） | **「不明 = Secret 相当」として扱う** |
+| `--stdin` 経路の入力読取 | 既存 kind が `Secret` → `read_password` / `Text` → `read_line` | **常に `read_password`（非エコー）に固定** |
+
+### 採用した方針 A / C を不採用とした理由
+
+| 案 | 内容 | 不採用理由 |
+|----|------|----------|
+| 案 A | IPC 経路でも `list_summaries()` を呼んで既存 kind を取得（`run_remove` の label 取得と同方針、DRY） | `--ipc edit` の通常動作に**毎回 1 IPC 往復**を加算する。vault 規模が大きい場合は 16 MiB フレーム境界に近づく副作用も発生。`run_remove` は label 表示のため必須だが、`edit` は kind 解決のためだけに full-list を取得するのは重い |
+| 案 C | 設計書で「IPC 経路の意図的緩和」を明文化 + テスト追加 | セキュリティ機能を「コスト最適化のため握り潰す」記述になる。Fail Fast / fail-secure 原則に反し、設計書の規律を腐らせる |
+| **案 B（採用）** | **既存 kind 不明時は保守的に Secret 扱いで `read_password` を強制** | 副作用ゼロ（IPC 往復追加なし）、セキュリティ最優先、ユーザ体験への影響は「Text レコードの編集時も非エコー入力になる」軽微な UX 劣化のみ。後続 feature で `IpcRequest::FindRecord { id }` 単体取得バリアントを追加して案 A に移行する余地を残す（YAGNI） |
+
+### 実装契約
+
+- **CLI 側 `run_edit` の IPC 経路**:
+  - `--stdin` 指定時 → `read_password(&prompt)` を**常に**呼ぶ（既存 kind を見ない）
+  - `--value <STR>` 指定時 → 既存通り `SecretString::from_string(args.value.unwrap())`（`SecretString` で運搬するため secret 性は型で保証）
+  - 既存 kind 取得のための `list_summaries()` 呼出は**行わない**（IPC 往復ゼロ追加）
+- **prompt 文言**: `read_password` 経由でも UX 観点で「Enter new value (input hidden):" 等の prompt を表示する。既存 `read_password` の prompt 引数で完結
+- **daemon 側の挙動**: 受信した `IpcRequest::EditRecord { value: Some(SerializableSecretBytes(_)), .. }` を `RecordPayload::Plaintext(SecretString::from_bytes(_))` で書き戻す。既存 `Record::kind()` は `update_record` の closure 内で**変更しない**（Issue #30 では kind 変更スコープ外、`requirements.md` REQ-CLI-003 注記）。daemon は kind を見ずに payload のみ書き換えるため、CLI 側で kind 不明でも整合性は保たれる
+
+### テストへの影響
+
+- **TC-UT-XXX 追加**（テスト担当へ依頼）: `run_edit` の IPC 経路で `--stdin` 指定時に `read_password` 経路が呼ばれる（`read_line` ではない）ことの構造的検証
+- **TC-E2E-XXX 追加**: TTY 模擬環境（`expect`/`pty` 等）で `shikomi --ipc edit --id <id> --stdin` 実行時、stdin への入力が**端末にエコーされない**ことの観測検証
+
+### Phase 2 / 後続 feature での発展
+
+- 後続 feature `daemon-find-record`（仮、未起票）で `IpcRequest::FindRecord { id }` バリアント追加 → `IpcVaultRepository::find_record_summary(id)` で既存 kind をピンポイント取得可能になる
+- その時点で方針 B から方針 A への移行を再検討（`run_edit` で正確な kind 解決 → Text レコード編集時のエコー復活）
+- 本 Issue #30 では方針 B を採用、後続 feature への移行余地を残す（YAGNI）
 
 ## `run_remove` 関数の内部
 

--- a/docs/features/daemon-ipc/basic-design/error.md
+++ b/docs/features/daemon-ipc/basic-design/error.md
@@ -39,13 +39,27 @@
 | `NotFound { id: RecordId }` | 対象 id（秘密情報なし）| `edit` / `remove` ハンドラで `find_record` が `None` | クライアント側で `MSG-CLI-106` に写像 | **Issue #30 で写像追加**（list 経路では発生不能だったため PR #29 では未対応） |
 | `InvalidLabel { reason: String }` | ハードコード固定文言 `"invalid label"` / `"invalid record id"` | ハンドラで防御的に再検証（クライアント側で検証済みのはずだが念のため） | クライアント側で `MSG-CLI-101` / `102` に写像 | **Issue #30 で写像追加** |
 | `Persistence { reason: String }` | ハードコード固定文言 `"persistence error"` / `"vault corrupted"` / `"vault directory not resolvable"` | `repo.save` 等失敗 | クライアント側で `MSG-CLI-107` / `108` に写像 | PR #29 で写像済み |
-| `Domain { reason: String }` | ハードコード固定文言 `"domain error"` / `"duplicate record id"` | `vault.add_record` 等の集約整合性エラー | クライアント側で `MSG-CLI-109` に写像 | **Issue #30 で写像追加** |
-| `Internal { reason: String }` | ハードコード固定文言 `"unexpected error"` | ハンドラで予期せぬ状態を検出 | クライアント側で `MSG-CLI-109` に写像 | **Issue #30 で写像追加**（PR #29 では `PersistenceError::IpcDecode` 等の既存バリアントに集約していたが、Issue #30 で `PersistenceError::Internal` バリアントを新規追加して正規化） |
+| `Domain { reason: String }` | ハードコード固定文言 `"domain error"` / `"duplicate record id"` | `vault.add_record` 等の集約整合性エラー | クライアント側で `MSG-CLI-109` に写像 | **Issue #30 で写像追加（方針 X）** |
+| `Internal { reason: String }` | ハードコード固定文言 `"unexpected error"` | ハンドラで予期せぬ状態を検出 | クライアント側で `MSG-CLI-109` に写像 | **Issue #30 で写像追加（方針 X）** |
 
-**Issue #30 での `From<IpcErrorCode> for PersistenceError` 写像追加 / `PersistenceError` バリアント追加**:
-- PR #29 段階では list 操作で `EncryptionUnsupported` / `Persistence` のみが**実用上発生**し、`Internal` は未到達のため `PersistenceError::IpcDecode` への寄せ集め写像で十分だった
-- Issue #30 で add/edit/remove が加わることにより、`NotFound` / `InvalidLabel` / `Domain` / `Internal` の 4 バリアント写像が**実用上必要**になる
-- 同時に `shikomi-infra::persistence::error::PersistenceError` 側に **`RecordNotFound(RecordId)` / `Internal { reason: String }` の 2 バリアントを Issue #30 で新規追加**する（`InvalidLabel` / `Domain` / `Persistence` は既存バリアントを再利用）
+**Issue #30 での `From<IpcErrorCode> for PersistenceError` 写像方針（方針 X：Internal 集約戦略）**:
+
+PR #29（list 経路のみ）では `EncryptionUnsupported` / `Persistence` の 2 バリアントが実用発生し、`Internal` 等は `PersistenceError::IpcDecode` への寄せ集め写像で十分だった。Issue #30 で add/edit/remove が加わるため `NotFound` / `InvalidLabel` / `Persistence` / `Domain` / `Internal` の 5 バリアントが新たに発生し得る。リーダー指示「`PersistenceError` への新規追加は `RecordNotFound(RecordId)` / `Internal { reason: String }` の 2 バリアントに留める」を前提に、以下の**方針 X** を採用する:
+
+| 入力 `IpcErrorCode` | 出力 `PersistenceError` | 採用根拠 |
+|--------------------|------------------------|---------|
+| `EncryptionUnsupported` | `EncryptionUnsupported`（既存） | PR #29 既存写像 |
+| `NotFound { id }` | `RecordNotFound(id)`（Issue #30 新規） | NotFound は CLI 側で `MSG-CLI-106` に分岐させる必要があり、独立バリアント必須 |
+| `InvalidLabel { reason }` | **`Internal { reason }`（集約）** | 旧設計の "個別 InvalidLabel バリアント新規追加" 案を**廃止**。daemon が固定文言（`"invalid label"`）で reason を構築済みのため、CLI 側で `MSG-CLI-101/102` への分岐を**reason 文字列マッチ**で行う、または `MSG-CLI-109`（汎用 Internal）に流す。前者を採用する場合も `PersistenceError` の型バリアントを増やさず、`reason` の値で識別する |
+| `Persistence { reason }` | **`Internal { reason }`（集約）** | 同上、daemon 側固定文言（`"persistence error"` / `"vault corrupted"` / `"vault directory not resolvable"`）で識別可能 |
+| `Domain { reason }` | **`Internal { reason }`（集約）** | 同上、daemon 側固定文言（`"domain error"` / `"duplicate record id"`）で識別可能 |
+| `Internal { reason }` | `Internal { reason }`（Issue #30 新規） | そのまま |
+
+**方針 X の意図**:
+- `PersistenceError` への新規バリアント追加を**最小限（2 バリアント）**に抑え、infra crate の API 表面拡大を防ぐ
+- daemon 側の `IpcErrorCode.reason` がハードコード固定文言契約のため、文字列値で識別する経路は安定
+- CLI 側の `MSG-CLI-101/102/107/108/109` への分岐は `presenter::error::render_error` 内で `PersistenceError::Internal { reason }` を `match reason.as_str()` する固定マッチで行う（**動的フォーマットは禁止**、reason 比較対象は固定文言の有限集合）
+- `RecordNotFound` のみ独立バリアントを与える理由: id を強型で運搬する必要があり、`reason: String` では型情報が落ちるため
 - 詳細は `../detailed-design/ipc-vault-repository.md §エラー写像` を単一真実源とする
 
 **`reason` フィールドの設計規約（絶対規則、服部平次指摘への対応）**:

--- a/docs/features/daemon-ipc/detailed-design/ipc-vault-repository.md
+++ b/docs/features/daemon-ipc/detailed-design/ipc-vault-repository.md
@@ -244,20 +244,33 @@ PR #29 の方針を維持し、Issue #30 でも変更なし:
 
 ## エラー写像（`IpcErrorCode → PersistenceError`、`PersistenceError → CliError`）
 
-### `IpcErrorCode → PersistenceError`（**Issue #30 で写像表確定**）
+### `IpcErrorCode → PersistenceError`（**Issue #30 で写像表確定、方針 X：Internal 集約**）
 
-`crates/shikomi-cli/src/io/ipc_vault_repository.rs` 内に `From<IpcErrorCode> for PersistenceError` を実装する（`shikomi-infra` 側ではなく `shikomi-cli` 側に配置、IPC 由来コードの写像責務は CLI 側に閉じる）:
+`crates/shikomi-infra/src/persistence/error.rs` 内に `From<IpcErrorCode> for PersistenceError` を実装する（orphan rule 回避のため infra 側に配置、`shikomi-cli` から `From` を再利用）:
 
 | 入力 `IpcErrorCode` | 出力 `PersistenceError` |
 |--------------------|------------------------|
 | `EncryptionUnsupported` | `EncryptionUnsupported`（既存バリアント） |
 | `NotFound { id }` | `RecordNotFound(id)`（**Issue #30 で `PersistenceError` に新規追加**） |
-| `InvalidLabel { reason }` | `InvalidLabel(reason)`（既存または新規追加） |
-| `Persistence { reason }` | `Persistence { reason }`（既存または新規追加、固定文言のみ受け入れ） |
-| `Domain { reason }` | `Domain { reason }`（既存または新規追加） |
+| `InvalidLabel { reason }` | **`Internal { reason }`（方針 X：集約）** |
+| `Persistence { reason }` | **`Internal { reason }`（方針 X：集約）** |
+| `Domain { reason }` | **`Internal { reason }`（方針 X：集約）** |
 | `Internal { reason }` | `Internal { reason }`（**Issue #30 で `PersistenceError` に新規追加**） |
 
-**注記**: PR #29 段階では list 操作で `EncryptionUnsupported` / `Persistence` のみが**実用上発生**し、`Internal` は未到達のため `PersistenceError::IpcDecode` への寄せ集め写像で十分だった。Issue #30 で add/edit/remove が加わることにより `NotFound` / `InvalidLabel` / `Domain` / `Internal` の 4 バリアント写像が**実用上必要**になる。同時に `shikomi-infra::persistence::error::PersistenceError` 側に **`RecordNotFound(RecordId)` / `Internal { reason: String }` の 2 バリアントを Issue #30 で新規追加**する（`InvalidLabel` / `Domain` / `Persistence` は既存バリアントを再利用）。test-design `test-design/unit.md §3.9` および basic-design `../basic-design/error.md §IpcErrorCode バリアント詳細` の記述と整合済み。
+**方針 X（Internal 集約戦略）の採用理由**:
+
+旧設計（Issue #30 の初期案）では `PersistenceError` に `InvalidLabel` / `Domain` 等の個別バリアントを追加して6個別写像を実現する案だった。リーダー指示「`PersistenceError` への新規追加は `RecordNotFound(RecordId)` / `Internal { reason: String }` の 2 バリアントに留める」に従い、以下の**方針 X**を採用:
+
+- **infra crate の API 表面拡大を最小化**: `PersistenceError` 新規バリアントは 2 個（`RecordNotFound` / `Internal`）のみ
+- **CLI 側 `presenter::error::render_error` で文字列マッチ識別**: daemon が `IpcErrorCode.reason` をハードコード固定文言（`"invalid label"` / `"persistence error"` / `"domain error"` 等の有限集合）で構築する契約のため、CLI 側で `match reason.as_str()` の固定マッチによる `MSG-CLI-101/102/107/108/109` 分岐が安定実装可能
+- **`reason` 文字列の動的フォーマット禁止契約は維持**: 比較対象の文字列は daemon 側の固定文言と同一値、`format!` での加工は CLI 側でも一切行わない
+- **`RecordNotFound` のみ独立バリアントの理由**: id を `RecordId` 強型で運搬する必要があり、`reason: String` では型情報が落ちる（`MSG-CLI-106` 表示時に id 値が必要）
+
+**`PersistenceError` への新規バリアント追加（最小 2 個）**:
+- `RecordNotFound(RecordId)` — IPC 経路の `NotFound { id }` 受信時の写像先
+- `Internal { reason: String }` — IPC 経路の `InvalidLabel` / `Persistence` / `Domain` / `Internal` 受信時の写像先（`reason` は固定文言）
+
+詳細整合: test-design `test-design/unit.md §3.9` および basic-design `../basic-design/error.md §IpcErrorCode バリアント詳細` の方針 X 記述と一致。実装は `crates/shikomi-infra/src/persistence/error.rs` の `From<IpcErrorCode>` 実装、PR #32 commit `e41a5a3` の `error.rs:355-372` で確定済み。
 
 ### `PersistenceError → CliError`（既存に追加）
 

--- a/docs/features/daemon-ipc/test-design/unit.md
+++ b/docs/features/daemon-ipc/test-design/unit.md
@@ -214,10 +214,17 @@
 |-------|--------------------|------------------------|
 | TC-UT-110 | `EncryptionUnsupported` | `PersistenceError::EncryptionUnsupported`（既存バリアント） |
 | TC-UT-111 | `NotFound { id }` | `PersistenceError::RecordNotFound(id)`（**Issue #30 新規追加バリアント**） |
-| TC-UT-112 | `InvalidLabel { reason: "invalid label" }` | `PersistenceError::InvalidLabel("invalid label".into())`（既存または新規） |
-| TC-UT-113 | `Persistence { reason: "persistence error" }` | `PersistenceError::Persistence { reason: "persistence error".into() }`（既存または新規、固定文言保持） |
-| TC-UT-114 | `Domain { reason: "domain error" }` | `PersistenceError::Domain { reason }`（既存または新規） |
-| TC-UT-114b | `Internal { reason: "unexpected error" }` | `PersistenceError::Internal { reason }`（**Issue #30 新規追加バリアント**） |
+| TC-UT-112 | `InvalidLabel { reason: "invalid label" }` | **`PersistenceError::Internal { reason: "invalid label".into() }`（方針 X：Internal 集約、固定文言保持）** |
+| TC-UT-113 | `Persistence { reason: "persistence error" }` | **`PersistenceError::Internal { reason: "persistence error".into() }`（方針 X：Internal 集約、固定文言保持）** |
+| TC-UT-114 | `Domain { reason: "domain error" }` | **`PersistenceError::Internal { reason: "domain error".into() }`（方針 X：Internal 集約、固定文言保持）** |
+| TC-UT-114b | `Internal { reason: "unexpected error" }` | `PersistenceError::Internal { reason: "unexpected error".into() }`（**Issue #30 新規追加バリアント**、方針 X 集約先と同一型） |
+
+**方針 X（Internal 集約）採用に伴う TC-UT-112/113/114 期待値変更**:
+- 旧仕様（`PersistenceError::InvalidLabel(_)` / `Persistence { reason }` / `Domain { reason }` の個別バリアント）から、新仕様 **`PersistenceError::Internal { reason }`（集約バリアント）** に変更
+- リーダー指示「`PersistenceError` への新規追加は `RecordNotFound` / `Internal` の 2 バリアントに留める」に整合
+- daemon 側 `IpcErrorCode.reason` がハードコード固定文言（`"invalid label"` / `"persistence error"` / `"domain error"` 等の有限集合）を構築する契約のため、`reason.as_str()` の固定マッチで presenter 段の `MSG-CLI-101/102/107/108/109` 分岐が機能する
+- TC-UT-114b と TC-UT-112/113/114 の出力型は**全て `PersistenceError::Internal { reason }`** に統一されるが、`reason` の文字列値が異なるため後段で区別可能
+- 設計書写像表（`../basic-design/error.md §IpcErrorCode バリアント詳細` / `../detailed-design/ipc-vault-repository.md §エラー写像`）と一致
 
 **横串アサート**: 全 6 写像の出力 `Display` 文字列が secret マーカー `SECRET_TEST_VALUE` / 絶対パス `/home/` / lock holder PID 文字列を**含まない**（`predicates::str::contains(...).not()`）。固定文言契約の構造的検証。
 

--- a/scripts/ci/audit-secret-paths.sh
+++ b/scripts/ci/audit-secret-paths.sh
@@ -14,10 +14,13 @@
 # - TC-CI-023/024: daemon panic hook 内で tracing / payload 参照禁止
 # - TC-CI-026: `crates/shikomi-cli/src/` 配下の `unsafe {` が `io/windows_sid.rs` 限定
 # - TC-CI-027: `SHIKOMI_DAEMON_SKIP_*` env 読取コードが本番 src/ に 0 件
+# - TC-CI-028: PR #29 の `--ipc add/edit/remove` runtime reject 文字列が src/ に 0 件（Phase 1.5-α）
+# - TC-CI-029: `crates/shikomi-cli/src/io/ipc_{vault_repository,client}.rs` で `Uuid::*` 生成 0 件（Phase 1.5-β）
+# - TC-CI-030: `IpcVaultRepository` が `VaultRepository` trait を実装する `impl` ブロックが 0 件（Phase 1.5-γ）
 #
 # 設計根拠:
 # - docs/features/cli-vault-commands/test-design/ci.md §1.1
-# - docs/features/daemon-ipc/test-design/ci.md §1〜2
+# - docs/features/daemon-ipc/test-design/ci.md §1〜2 / §[Phase 1.5] TC-CI-028〜030
 
 set -euo pipefail
 
@@ -169,5 +172,47 @@ if matches="$(grep -rnE 'env::var.*SHIKOMI_DAEMON_SKIP|std::env::var.*SHIKOMI_DA
     fail "TC-CI-027 FAIL: SHIKOMI_DAEMON_SKIP_* env 読取コードが本番 src/ に存在します"
 fi
 echo "[TC-CI-027] PASS"
+
+# --- TC-CI-028 [Phase 1.5-α] ----------------------------------------
+# PR #29 の `--ipc add/edit/remove` runtime reject 文字列が src/ に残っていない
+# ことを構造的に保証する。Issue #30 で `RepositoryHandle` 経路ディスパッチに
+# 切り替え、reject 経路は完全撤去された。tests/ 配下は対象外（TC-E2E-016 の
+# `.not()` 検証で正当用途として出現する）。
+echo "[TC-CI-028] PR#29 runtime reject message removed from src/"
+if matches="$(grep -rnE 'currently supports only the.*list.*subcommand|--ipc currently supports only' \
+    crates/shikomi-cli/src/ \
+    --include='*.rs' 2>/dev/null)"; then
+    echo "$matches"
+    fail "TC-CI-028 FAIL: PR #29 reject message still in src/"
+fi
+echo "[TC-CI-028] PASS"
+
+# --- TC-CI-029 [Phase 1.5-β] ----------------------------------------
+# id 生成は daemon 側に集約（`shikomi-daemon/src/ipc/handler/add.rs` の唯一の
+# `Uuid::now_v7()`）。CLI 側 IPC モジュール（`ipc_vault_repository.rs` /
+# `ipc_client.rs`）で UUID を生成すると「嘘 ID 出荷」案 C 構造が再発するため、
+# 静的 grep で構造的に遮断する。`IpcResponse::Added { id }` 受信で完結する契約。
+echo "[TC-CI-029] No Uuid generation in CLI IPC modules"
+if matches="$(grep -rnE 'Uuid::now_v7|Uuid::new_v[0-9]|uuid::Uuid::new' \
+    crates/shikomi-cli/src/io/ipc_vault_repository.rs \
+    crates/shikomi-cli/src/io/ipc_client.rs 2>/dev/null)"; then
+    echo "$matches"
+    fail "TC-CI-029 FAIL: UUID generation found in CLI IPC modules"
+fi
+echo "[TC-CI-029] PASS"
+
+# --- TC-CI-030 [Phase 1.5-γ] ----------------------------------------
+# `IpcVaultRepository` は `VaultRepository` trait を**実装しない**ことが案 D の
+# 構造契約。実装してしまうと `Box<dyn VaultRepository>` 経路で「嘘の Plaintext
+# 注入 / 嘘 ID 出荷 / 常に true な exists()」案 C が再発する。`compile_fail`
+# doctest（TC-UT-119）と二重防衛。
+echo "[TC-CI-030] IpcVaultRepository does NOT implement VaultRepository"
+if matches="$(grep -rnE 'impl[[:space:]]+VaultRepository[[:space:]]+for[[:space:]]+IpcVaultRepository|impl[[:space:]]+shikomi_infra::VaultRepository[[:space:]]+for[[:space:]]+IpcVaultRepository' \
+    crates/shikomi-cli/src/ \
+    --include='*.rs' 2>/dev/null)"; then
+    echo "$matches"
+    fail "TC-CI-030 FAIL: IpcVaultRepository implements VaultRepository (case D contract violated)"
+fi
+echo "[TC-CI-030] PASS"
 
 echo "ALL secret-path audits PASS"


### PR DESCRIPTION
## Summary

工程3（実装）。Issue #30 (daemon-ipc Phase 1.5) を案 D（`VaultRepository` trait 非実装 + `RepositoryHandle` enum dispatch）で実装。PR #29 の `--ipc add/edit/remove` runtime reject 経路を構造的に撤去し、4 操作 (list/add/edit/remove) を IPC 透過化。

- `RepositoryHandle` enum を `lib.rs` に non-public で導入（Box 不要、stack 配置）
- `IpcVaultRepository` に 3 専用メソッド追加（`add_record` / `edit_record` / `remove_record`）。trait 非実装は維持
- id 生成は **daemon 側に集約**（CLI 側 IPC モジュールで `Uuid::*` 0 件、TC-CI-029）
- `PersistenceError::RecordNotFound(RecordId)` / `Internal { reason: String }` の 2 バリアント追加 + `From<IpcErrorCode>` 写像
- TC-UT-119 `compile_fail` doctest + TC-CI-028/029/030 grep 監査の二重防衛

## 設計準拠

| 設計書 | 準拠ポイント |
|--------|------------|
| `daemon-ipc/detailed-design/ipc-vault-repository.md §案 D` | `IpcVaultRepository` の trait 非実装 + 4 専用メソッド |
| `cli-vault-commands/detailed-design/composition-root.md §RepositoryHandle enum` | non-public enum、`#[non_exhaustive]` なし、`match` 網羅性検査活用 |
| `daemon-ipc/basic-design/error.md §IpcErrorCode 写像` | `NotFound` のみ専用、他は `Internal { reason }` 集約（方針 X） |
| `daemon-ipc/basic-design/flows.md §`shikomi --ipc remove`` | `--yes` でも `list_summaries` で id 存在確認、Fail Fast 経路統一 |

## ローカル品質ゲート（rust:1.80-slim docker, stable 1.95.0）

- `cargo fmt --check`: ✅
- `cargo clippy --workspace --all-targets --all-features`: ✅（新規 error 0）
- `cargo test --workspace --all-targets`: **341 passed / 0 failed / 2 ignored**（PR #29 の 333 から +8）
- `cargo test --doc -p shikomi-cli`: ✅（TC-UT-119 compile_fail doctest 1 passed）
- `bash scripts/ci/audit-secret-paths.sh`: ✅ **14/14 PASS**（既存 11 + Phase 1.5 の TC-CI-028/029/030）

## 変更ファイル（7 files, +550 / -179）

| ファイル | 変更内容 |
|---------|---------|
| `crates/shikomi-core/src/ipc/secret_bytes.rs` | `from_secret_string` 追加 |
| `crates/shikomi-infra/src/persistence/error.rs` | `RecordNotFound` / `Internal` 2 バリアント + `From<IpcErrorCode>` |
| `crates/shikomi-cli/src/io/ipc_vault_repository.rs` | 3 専用メソッド追加 + 案 D docstring + TC-UT-119 doctest |
| `crates/shikomi-cli/src/lib.rs` | `RepositoryHandle` enum + `run_*` シグネチャ刷新 + reject 撤去 |
| `crates/shikomi-cli/src/error.rs` | `RecordNotFound` 写像 1 行 + 2 単体テスト |
| `crates/shikomi-cli/src/presenter/warning.rs` | `render_ipc_opt_in_notice` (MSG-CLI-051 英日) |
| `scripts/ci/audit-secret-paths.sh` | TC-CI-028/029/030 3 防衛線追加 |

## テスト担当への確認観点（マユリ向け）

1. **TC-UT-110〜114b**: `From<IpcErrorCode>` 写像。`InvalidLabel` / `Persistence` / `Domain` は方針 X で `Internal { reason }` に寄せたため、テスト設計書の期待値（個別バリアント想定箇所がもしあれば）を `PersistenceError::Internal { reason: <fixed> }` に統一してください
2. **TC-UT-100〜108**: `add_record` / `edit_record` / `remove_record` の round-trip。スタブ daemon を `tokio::io::duplex` で立てるための `IpcClient` / `IpcVaultRepository` の test ヘルパ可視化はまだ未実装（必要に応じて `pub(crate) fn from_framed` / `from_runtime_and_client` を追加要請してください）
3. **TC-UT-115〜117**: `RepositoryHandle` dispatch の網羅性。`enum` を `pub(crate)` にする要否確認
4. **TC-UT-118**: 嘘 ID 出荷の構造的不在（スタブが返す `Added { id }` がそのまま戻る）
5. **TC-UT-119**: `compile_fail` doctest は本 PR で実装済 + 通過確認済み

## スコープ外（後続 Issue）

- `IpcRequest::FindRecord` 拡張（`list_summaries` 全件取得 → id 単発取得への最適化、16 MiB 境界フォールバック）
- `daemon-vault-init`: IPC 経路の vault 未作成時の自動初期化
- スタブ daemon の `duplex` 結合テストヘルパ整備（テスト担当の領域）

Refs #30