### PR TITLE
feat(vault-encryption): implement Sub-A crypto domain types (Issue #39)

### DIFF
--- a/crates/shikomi-core/src/crypto/header_aead.rs
+++ b/crates/shikomi-core/src/crypto/header_aead.rs
@@ -45,7 +45,7 @@ impl HeaderAeadKey {
 
     /// crate 内部からのみ生バイト参照を取り出す (ヘッダ AEAD 検証関数 = Sub-D 用)。
     pub(crate) fn expose_within_crate(&self) -> &[u8; KEY_LEN] {
-        self.inner.expose_secret().as_ref()
+        &**self.inner.expose_secret()
     }
 }
 

--- a/crates/shikomi-core/src/crypto/header_aead.rs
+++ b/crates/shikomi-core/src/crypto/header_aead.rs
@@ -1,0 +1,84 @@
+//! `HeaderAeadKey` — vault ヘッダ独立 AEAD タグ検証用鍵 (KEK_pw 流用)。
+//!
+//! Sub-0 凍結: ヘッダ AEAD タグの鍵は `KekPw` 流用。`kdf_params` 改竄は
+//! KDF 出力変化として AEAD タグ不一致で間接検出される。
+//! 鍵経路を型レベルで明示するために独立型として定義する。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/crypto-types.md`
+
+use core::fmt;
+
+use secrecy::{ExposeSecret, SecretBox};
+use zeroize::Zeroizing;
+
+use crate::crypto::key::{Kek, KekKindPw, KEY_LEN};
+
+/// vault ヘッダ独立 AEAD タグ検証用鍵 (32 byte)。
+///
+/// `KekPw` から `from_kek_pw` 経由でのみ派生する。`KekRecovery` を渡そうとすると
+/// 関数シグネチャの型不一致でコンパイルエラーになる (Sub-0 凍結の鍵経路を型で明示)。
+///
+/// `Drop` 時に内部 32B を zeroize。`Clone` / `Display` / `Serialize` / `PartialEq` / `Eq` は未実装。
+///
+/// ```compile_fail
+/// use shikomi_core::crypto::{HeaderAeadKey, Kek, KekKindRecovery};
+/// let recovery = Kek::<KekKindRecovery>::from_array([0u8; 32]);
+/// // KekRecovery を渡すとコンパイルエラー (契約 C-6: ヘッダ AEAD = KEK_pw 流用のみ)
+/// let _ = HeaderAeadKey::from_kek_pw(&recovery);
+/// ```
+pub struct HeaderAeadKey {
+    inner: SecretBox<Zeroizing<[u8; KEY_LEN]>>,
+}
+
+impl HeaderAeadKey {
+    /// `KekPw` のバイトをコピーして `HeaderAeadKey` を派生する。
+    ///
+    /// 元の `KekPw` は呼出側スコープで生き続ける (参照のみ取得)。
+    /// `HeaderAeadKey` は独立した `SecretBox` を保有し、`Drop` で独立に zeroize される。
+    #[must_use]
+    pub fn from_kek_pw(kek: &Kek<KekKindPw>) -> Self {
+        let bytes = *kek.expose_within_crate();
+        Self {
+            inner: SecretBox::new(Box::new(Zeroizing::new(bytes))),
+        }
+    }
+
+    /// crate 内部からのみ生バイト参照を取り出す (ヘッダ AEAD 検証関数 = Sub-D 用)。
+    pub(crate) fn expose_within_crate(&self) -> &[u8; KEY_LEN] {
+        self.inner.expose_secret().as_ref()
+    }
+}
+
+impl fmt::Debug for HeaderAeadKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED HEADER AEAD KEY]")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_kek_pw_constructs_without_panic() {
+        let kek = Kek::<KekKindPw>::from_array([0u8; KEY_LEN]);
+        let _ = HeaderAeadKey::from_kek_pw(&kek);
+    }
+
+    #[test]
+    fn debug_returns_fixed_redacted_string() {
+        let kek = Kek::<KekKindPw>::from_array([0xCDu8; KEY_LEN]);
+        let h = HeaderAeadKey::from_kek_pw(&kek);
+        assert_eq!(format!("{h:?}"), "[REDACTED HEADER AEAD KEY]");
+    }
+
+    #[test]
+    fn from_kek_pw_copies_bytes_independently_from_source_kek() {
+        let kek = Kek::<KekKindPw>::from_array([0x5Au8; KEY_LEN]);
+        let h = HeaderAeadKey::from_kek_pw(&kek);
+        // 派生後も元 KEK は使用可能 (参照のみ取得しているため)
+        assert_eq!(kek.expose_within_crate(), &[0x5Au8; KEY_LEN]);
+        // 派生先も同じバイト列を持つ
+        assert_eq!(h.expose_within_crate(), &[0x5Au8; KEY_LEN]);
+    }
+}

--- a/crates/shikomi-core/src/crypto/header_aead.rs
+++ b/crates/shikomi-core/src/crypto/header_aead.rs
@@ -45,7 +45,7 @@ impl HeaderAeadKey {
 
     /// crate 内部からのみ生バイト参照を取り出す (ヘッダ AEAD 検証関数 = Sub-D 用)。
     pub(crate) fn expose_within_crate(&self) -> &[u8; KEY_LEN] {
-        &**self.inner.expose_secret()
+        self.inner.expose_secret()
     }
 }
 

--- a/crates/shikomi-core/src/crypto/key.rs
+++ b/crates/shikomi-core/src/crypto/key.rs
@@ -1,0 +1,218 @@
+//! 鍵階層型 — `Vek` / `Kek<KekKindPw>` / `Kek<KekKindRecovery>`。
+//!
+//! - `Vek`: Vault Encryption Key 本体 (32 byte 固定)。
+//! - `Kek<Kind>`: Key Encryption Key。phantom-typed で `KekKindPw` / `KekKindRecovery` を区別する。
+//!   外部 crate での `KekKind` 実装は Sealed trait で禁止 (誤用混入の構造封鎖)。
+//!
+//! いずれも `secrecy::SecretBox<Zeroizing<[u8; 32]>>` を内包し、`Drop` 時に 32B を zeroize する。
+//! `Clone` / `Copy` / `Display` / `serde::Serialize` / `PartialEq` / `Eq` は **意図的に未実装**
+//! (契約 C-2/C-4/C-5)。`Debug` は `[REDACTED VEK]` / `[REDACTED KEK<Pw>]` /
+//! `[REDACTED KEK<Recovery>]` の固定文字列を返す (契約 C-3)。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/crypto-types.md`
+
+use core::fmt;
+use core::marker::PhantomData;
+
+use secrecy::{ExposeSecret, SecretBox};
+use zeroize::Zeroizing;
+
+/// 鍵バイト長 (AES-256 鍵長 = 32 byte)。
+pub(crate) const KEY_LEN: usize = 32;
+
+// -------------------------------------------------------------------
+// Sealed trait — 外部 crate での KekKind 実装禁止
+// -------------------------------------------------------------------
+
+mod sealed {
+    /// 外部 crate からの実装を禁止する Sealed trait。
+    ///
+    /// 鍵用途の追加は必ず `shikomi-core` 側で `KekKind` の実装を追加する形にする
+    /// (Sub-A 設計改訂を経由)。
+    pub trait Sealed {}
+}
+
+/// `Kek<Kind>` の用途マーカー trait。Sealed のため外部 crate からは実装できない。
+pub trait KekKind: 'static + sealed::Sealed {}
+
+/// マスターパスワード由来 KEK のマーカー (Argon2id 出力)。
+pub struct KekKindPw;
+
+/// リカバリ・ニーモニック由来 KEK のマーカー (PBKDF2-HMAC-SHA512 + HKDF-SHA256 出力)。
+pub struct KekKindRecovery;
+
+impl sealed::Sealed for KekKindPw {}
+impl KekKind for KekKindPw {}
+impl sealed::Sealed for KekKindRecovery {}
+impl KekKind for KekKindRecovery {}
+
+// -------------------------------------------------------------------
+// Vek
+// -------------------------------------------------------------------
+
+/// Vault Encryption Key (32 byte AES-256 鍵)。
+///
+/// 内部表現は `SecretBox<Zeroizing<[u8; 32]>>`。`Drop` で 32B を確定的に zeroize する。
+/// CSPRNG 由来の `[u8; 32]` を `from_array` で受け取って構築する (no-I/O 制約)。
+///
+/// # Forbidden traits (compile-time enforced)
+///
+/// `Clone`, `Copy`, `Display`, `serde::Serialize`, `serde::Deserialize`, `PartialEq`, `Eq` は
+/// **意図的に未実装**。下記は `compile_fail` doc test で防御する。
+///
+/// ```compile_fail
+/// use shikomi_core::crypto::Vek;
+/// let v = Vek::from_array([0u8; 32]);
+/// let _ = v.clone();
+/// ```
+///
+/// ```compile_fail
+/// use shikomi_core::crypto::Vek;
+/// let v = Vek::from_array([0u8; 32]);
+/// let _ = format!("{}", v);
+/// ```
+pub struct Vek {
+    inner: SecretBox<Zeroizing<[u8; KEY_LEN]>>,
+}
+
+impl Vek {
+    /// 32 byte の鍵バイト列から `Vek` を構築する。
+    ///
+    /// `bytes` は本関数のスコープ抜けで Rust の所有権ルールにより消去対象になる。
+    /// 呼出側は CSPRNG から取得直後に本関数へ移動し、ローカル変数に長く保持しないこと。
+    #[must_use]
+    pub fn from_array(bytes: [u8; KEY_LEN]) -> Self {
+        Self {
+            inner: SecretBox::new(Box::new(Zeroizing::new(bytes))),
+        }
+    }
+
+    /// crate 内部からのみ生バイト参照を取り出す。
+    ///
+    /// `pub(crate)` 可視性。`shikomi-infra` 等の外部 crate からは呼出不可
+    /// (= 外部 crate に VEK 生バイトを渡す API は存在しない)。
+    pub(crate) fn expose_within_crate(&self) -> &[u8; KEY_LEN] {
+        self.inner.expose_secret().as_ref()
+    }
+}
+
+impl fmt::Debug for Vek {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED VEK]")
+    }
+}
+
+// -------------------------------------------------------------------
+// Kek<Kind>
+// -------------------------------------------------------------------
+
+/// Key Encryption Key (32 byte)。phantom-typed で `KekKindPw` / `KekKindRecovery` を区別する。
+///
+/// `Kek<KekKindPw>` は Argon2id 由来の KEK、`Kek<KekKindRecovery>` は PBKDF2+HKDF 由来の KEK。
+/// 同一バイト長だが用途が異なるため、関数シグネチャの取り違えをコンパイルエラーで弾く。
+///
+/// `Drop` で 32B を zeroize。`Clone` / `Display` / `Serialize` / `PartialEq` / `Eq` は未実装。
+///
+/// ```compile_fail
+/// use shikomi_core::crypto::{Kek, KekKindPw, KekKindRecovery};
+/// fn want_pw(_: &Kek<KekKindPw>) {}
+/// let k = Kek::<KekKindRecovery>::from_array([0u8; 32]);
+/// want_pw(&k); // 型不一致でコンパイルエラー (契約 C-6)
+/// ```
+pub struct Kek<Kind: KekKind> {
+    inner: SecretBox<Zeroizing<[u8; KEY_LEN]>>,
+    _kind: PhantomData<fn() -> Kind>,
+}
+
+impl<Kind: KekKind> Kek<Kind> {
+    /// 32 byte の鍵バイト列から `Kek<Kind>` を構築する。
+    #[must_use]
+    pub fn from_array(bytes: [u8; KEY_LEN]) -> Self {
+        Self {
+            inner: SecretBox::new(Box::new(Zeroizing::new(bytes))),
+            _kind: PhantomData,
+        }
+    }
+
+    /// crate 内部からのみ生バイト参照を取り出す。
+    pub(crate) fn expose_within_crate(&self) -> &[u8; KEY_LEN] {
+        self.inner.expose_secret().as_ref()
+    }
+}
+
+impl fmt::Debug for Kek<KekKindPw> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED KEK<Pw>]")
+    }
+}
+
+impl fmt::Debug for Kek<KekKindRecovery> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED KEK<Recovery>]")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------
+    // Vek
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn vek_from_array_constructs_without_panic() {
+        let _ = Vek::from_array([0u8; KEY_LEN]);
+    }
+
+    #[test]
+    fn vek_debug_returns_redacted_fixed_string() {
+        let v = Vek::from_array([0xAAu8; KEY_LEN]);
+        let s = format!("{v:?}");
+        assert_eq!(s, "[REDACTED VEK]");
+    }
+
+    #[test]
+    fn vek_debug_does_not_expose_secret_bytes() {
+        let v = Vek::from_array([0xAAu8; KEY_LEN]);
+        let s = format!("{v:?}");
+        assert!(!s.contains("AA"), "Debug must not expose secret bytes: {s}");
+    }
+
+    #[test]
+    fn vek_expose_within_crate_returns_original_bytes() {
+        let bytes = [0x42u8; KEY_LEN];
+        let v = Vek::from_array(bytes);
+        assert_eq!(v.expose_within_crate(), &bytes);
+    }
+
+    // -----------------------------------------------------------------
+    // Kek<KekKindPw>
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn kek_pw_debug_returns_pw_marker() {
+        let k = Kek::<KekKindPw>::from_array([0u8; KEY_LEN]);
+        assert_eq!(format!("{k:?}"), "[REDACTED KEK<Pw>]");
+    }
+
+    #[test]
+    fn kek_recovery_debug_returns_recovery_marker() {
+        let k = Kek::<KekKindRecovery>::from_array([0u8; KEY_LEN]);
+        assert_eq!(format!("{k:?}"), "[REDACTED KEK<Recovery>]");
+    }
+
+    #[test]
+    fn kek_pw_expose_within_crate_returns_original_bytes() {
+        let bytes = [0x33u8; KEY_LEN];
+        let k = Kek::<KekKindPw>::from_array(bytes);
+        assert_eq!(k.expose_within_crate(), &bytes);
+    }
+
+    #[test]
+    fn kek_recovery_expose_within_crate_returns_original_bytes() {
+        let bytes = [0x77u8; KEY_LEN];
+        let k = Kek::<KekKindRecovery>::from_array(bytes);
+        assert_eq!(k.expose_within_crate(), &bytes);
+    }
+}

--- a/crates/shikomi-core/src/crypto/key.rs
+++ b/crates/shikomi-core/src/crypto/key.rs
@@ -92,7 +92,9 @@ impl Vek {
     /// `pub(crate)` 可視性。`shikomi-infra` 等の外部 crate からは呼出不可
     /// (= 外部 crate に VEK 生バイトを渡す API は存在しない)。
     pub(crate) fn expose_within_crate(&self) -> &[u8; KEY_LEN] {
-        self.inner.expose_secret().as_ref()
+        // `expose_secret()` returns `&Zeroizing<[u8; KEY_LEN]>`. Two levels of `Deref` strip
+        // both the SecretBox guard and Zeroizing wrapper to reach the fixed-length array.
+        &**self.inner.expose_secret()
     }
 }
 
@@ -136,7 +138,7 @@ impl<Kind: KekKind> Kek<Kind> {
 
     /// crate 内部からのみ生バイト参照を取り出す。
     pub(crate) fn expose_within_crate(&self) -> &[u8; KEY_LEN] {
-        self.inner.expose_secret().as_ref()
+        &**self.inner.expose_secret()
     }
 }
 

--- a/crates/shikomi-core/src/crypto/key.rs
+++ b/crates/shikomi-core/src/crypto/key.rs
@@ -92,9 +92,9 @@ impl Vek {
     /// `pub(crate)` 可視性。`shikomi-infra` 等の外部 crate からは呼出不可
     /// (= 外部 crate に VEK 生バイトを渡す API は存在しない)。
     pub(crate) fn expose_within_crate(&self) -> &[u8; KEY_LEN] {
-        // `expose_secret()` returns `&Zeroizing<[u8; KEY_LEN]>`. Two levels of `Deref` strip
-        // both the SecretBox guard and Zeroizing wrapper to reach the fixed-length array.
-        &**self.inner.expose_secret()
+        // `expose_secret()` returns `&Zeroizing<[u8; KEY_LEN]>`. Deref coercion to the
+        // declared return type `&[u8; KEY_LEN]` strips the Zeroizing wrapper.
+        self.inner.expose_secret()
     }
 }
 
@@ -138,7 +138,7 @@ impl<Kind: KekKind> Kek<Kind> {
 
     /// crate 内部からのみ生バイト参照を取り出す。
     pub(crate) fn expose_within_crate(&self) -> &[u8; KEY_LEN] {
-        &**self.inner.expose_secret()
+        self.inner.expose_secret()
     }
 }
 

--- a/crates/shikomi-core/src/crypto/mod.rs
+++ b/crates/shikomi-core/src/crypto/mod.rs
@@ -1,0 +1,19 @@
+//! 暗号ドメイン型のエントリ。鍵階層・Fail-Secure 型・パスワード認証境界を集約する。
+//!
+//! 本モジュールは pure Rust / no-I/O 制約を維持し、`rand_core::OsRng` や
+//! `getrandom` への呼出を一切持たない。CSPRNG が必要な構築は呼び出し側
+//! (`shikomi-infra::crypto::Rng`) から `[u8; N]` を受け取るコンストラクタで提供する。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/index.md`
+
+pub mod header_aead;
+pub mod key;
+pub mod password;
+pub mod recovery;
+pub mod verified;
+
+pub use header_aead::HeaderAeadKey;
+pub use key::{Kek, KekKind, KekKindPw, KekKindRecovery, Vek};
+pub use password::{MasterPassword, PasswordStrengthGate, WeakPasswordFeedback};
+pub use recovery::RecoveryMnemonic;
+pub use verified::{verify_aead_decrypt, CryptoOutcome, Plaintext, Verified};

--- a/crates/shikomi-core/src/crypto/password.rs
+++ b/crates/shikomi-core/src/crypto/password.rs
@@ -1,0 +1,208 @@
+//! パスワード認証境界 — `MasterPassword` / `PasswordStrengthGate` trait / `WeakPasswordFeedback`。
+//!
+//! `MasterPassword::new` は `&dyn PasswordStrengthGate` の通過を必須とする (契約 C-8)。
+//! 強度ゲートの具体実装 (zxcvbn) は Sub-D の `shikomi-infra` 側に置く (Clean Architecture)。
+//! 本モジュールは trait シグネチャと `WeakPasswordFeedback` 構造体のみ提供する。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/password.md`
+
+use core::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::CryptoError;
+use crate::secret::SecretBytes;
+
+// -------------------------------------------------------------------
+// MasterPassword
+// -------------------------------------------------------------------
+
+/// ユーザ入力のマスターパスワードを保持する型。
+///
+/// 構築時に `PasswordStrengthGate::validate` を必ず通過する (契約 C-8)。
+/// 内部は `SecretBytes` ベースで `Drop` 時に zeroize される。
+///
+/// # Forbidden traits
+///
+/// `Clone` / `Copy` / `Display` / `serde::Serialize` / `PartialEq` / `Eq` は未実装。
+///
+/// ```compile_fail
+/// use shikomi_core::crypto::MasterPassword;
+/// // Display 未実装 — println! でフォーマット指定子 {} は通らない
+/// fn check(p: &MasterPassword) { let _ = format!("{}", p); }
+/// ```
+pub struct MasterPassword {
+    inner: SecretBytes,
+}
+
+impl MasterPassword {
+    /// 強度ゲートを通過した文字列から `MasterPassword` を構築する (契約 C-8)。
+    ///
+    /// # Errors
+    ///
+    /// `gate.validate(&s)` が `Err(WeakPasswordFeedback)` を返した場合は
+    /// `CryptoError::WeakPassword(feedback)` を返し、`MasterPassword` は構築されない。
+    /// 入力 `s` は本関数内で `into_bytes()` 経由で消費されるため、呼出側は別途
+    /// 保持していたコピーを `zeroize` で消す責務を負う (Sub-D 境界で明示)。
+    pub fn new(s: String, gate: &dyn PasswordStrengthGate) -> Result<Self, CryptoError> {
+        gate.validate(&s).map_err(CryptoError::WeakPassword)?;
+        let bytes = s.into_bytes();
+        Ok(Self {
+            inner: SecretBytes::from_vec(bytes),
+        })
+    }
+
+    /// crate 内部からのみ生バイト列を取り出す (Sub-B Argon2id 入力に渡すため)。
+    pub(crate) fn expose_secret_bytes_within_crate(&self) -> &[u8] {
+        self.inner.expose_secret()
+    }
+}
+
+impl fmt::Debug for MasterPassword {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED MASTER PASSWORD]")
+    }
+}
+
+// -------------------------------------------------------------------
+// PasswordStrengthGate trait
+// -------------------------------------------------------------------
+
+/// パスワード強度判定 trait (dyn-safe)。
+///
+/// shikomi-core では trait シグネチャのみ定義する。実装 (zxcvbn 強度 ≥ 3 等) は
+/// Sub-D の `shikomi-infra::crypto::ZxcvbnGate` 担当 (Clean Architecture)。
+///
+/// # 実装が遵守すべき契約 (Sub-D 設計書 §`PasswordStrengthGate` trait 参照)
+///
+/// 1. 強度判定の合否しか trait シグネチャに表れない (内部スコア値・辞書は外に漏らさない)。
+/// 2. `validate` は決して panic しない (`WeakPasswordFeedback` または `Ok(())` に収束)。
+/// 3. 副作用なし (`&self`, I/O なし)。
+pub trait PasswordStrengthGate {
+    /// パスワード文字列の強度を判定する。弱い場合は `WeakPasswordFeedback` を返す。
+    ///
+    /// # Errors
+    ///
+    /// 強度不足の場合は `WeakPasswordFeedback` (`warning` + `suggestions`) を返す。
+    fn validate(&self, password: &str) -> Result<(), WeakPasswordFeedback>;
+}
+
+// -------------------------------------------------------------------
+// WeakPasswordFeedback
+// -------------------------------------------------------------------
+
+/// 弱パスワード検出時に MSG-S08 (Fail Kindly) で利用する構造データ。
+///
+/// `warning` / `suggestions` は zxcvbn の `feedback` をそのまま英語 raw のまま運ぶ。
+/// **i18n 翻訳は呼出側 (Sub-D / Sub-F) の責務** (設計書 §i18n 戦略責務分離)。
+///
+/// `warning` が `None` の場合に「無音でユーザに渡す」実装は契約として禁止。
+/// Sub-D は `suggestions` 先頭文 / 強度スコア値 / 既定文の代替警告文を提示する責務を負う
+/// (設計書 §`warning=None` 時の代替警告文契約)。
+///
+/// `Serialize` / `Deserialize` は IPC 経由で daemon→CLI/GUI に渡すために実装する
+/// (鍵バイト列とは異なり警告文自体は秘密でない)。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WeakPasswordFeedback {
+    /// zxcvbn の `feedback.warning` (主要な警告文)。`None` の場合あり。
+    pub warning: Option<String>,
+    /// zxcvbn の `feedback.suggestions` (改善提案リスト)。空ベクタも有効。
+    pub suggestions: Vec<String>,
+}
+
+impl WeakPasswordFeedback {
+    /// 警告と改善提案を指定して構築する。
+    #[must_use]
+    pub fn new(warning: Option<String>, suggestions: Vec<String>) -> Self {
+        Self {
+            warning,
+            suggestions,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 常に Ok を返すテスト用ゲート。
+    struct AlwaysAcceptGate;
+    impl PasswordStrengthGate for AlwaysAcceptGate {
+        fn validate(&self, _password: &str) -> Result<(), WeakPasswordFeedback> {
+            Ok(())
+        }
+    }
+
+    /// 常に Err を返すテスト用ゲート。
+    struct AlwaysRejectGate;
+    impl PasswordStrengthGate for AlwaysRejectGate {
+        fn validate(&self, _password: &str) -> Result<(), WeakPasswordFeedback> {
+            Err(WeakPasswordFeedback::new(
+                Some("test reject".to_string()),
+                vec!["use longer".to_string()],
+            ))
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // MasterPassword (C-8)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn master_password_new_accepts_when_gate_returns_ok() {
+        let p = MasterPassword::new("anything".to_string(), &AlwaysAcceptGate).unwrap();
+        assert_eq!(p.expose_secret_bytes_within_crate(), b"anything");
+    }
+
+    #[test]
+    fn master_password_new_rejects_when_gate_returns_err_with_weak_password_feedback() {
+        let err = MasterPassword::new("weak".to_string(), &AlwaysRejectGate).unwrap_err();
+        match err {
+            CryptoError::WeakPassword(fb) => {
+                assert_eq!(fb.warning.as_deref(), Some("test reject"));
+                assert_eq!(fb.suggestions, vec!["use longer".to_string()]);
+            }
+            other => panic!("expected WeakPassword, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn master_password_new_invokes_gate_dynamically_via_dyn_dispatch() {
+        let gate: &dyn PasswordStrengthGate = &AlwaysAcceptGate;
+        assert!(MasterPassword::new("ok".to_string(), gate).is_ok());
+    }
+
+    #[test]
+    fn master_password_debug_returns_fixed_redacted_string() {
+        let p = MasterPassword::new("secret-pw".to_string(), &AlwaysAcceptGate).unwrap();
+        let s = format!("{p:?}");
+        assert_eq!(s, "[REDACTED MASTER PASSWORD]");
+        assert!(!s.contains("secret-pw"));
+    }
+
+    // -----------------------------------------------------------------
+    // WeakPasswordFeedback
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn weak_password_feedback_supports_warning_none_for_sub_d_fallback_contract() {
+        // warning=None の入力を許容する (Sub-D が fallback 警告文を提示する責務)
+        let fb = WeakPasswordFeedback::new(None, vec!["add uppercase".to_string()]);
+        assert!(fb.warning.is_none());
+        assert_eq!(fb.suggestions.len(), 1);
+    }
+
+    #[test]
+    fn weak_password_feedback_supports_empty_suggestions() {
+        let fb = WeakPasswordFeedback::new(Some("too short".to_string()), Vec::new());
+        assert!(fb.suggestions.is_empty());
+    }
+
+    /// `Serialize` / `Deserialize` derive の存在を型レベルで担保する。
+    /// (実際の round-trip 検証は Sub-E の IPC 結合テストで実施)
+    #[test]
+    fn weak_password_feedback_implements_serialize_and_deserialize_traits() {
+        fn assert_serde<T: serde::Serialize + serde::de::DeserializeOwned>() {}
+        assert_serde::<WeakPasswordFeedback>();
+    }
+}

--- a/crates/shikomi-core/src/crypto/password.rs
+++ b/crates/shikomi-core/src/crypto/password.rs
@@ -45,7 +45,8 @@ impl MasterPassword {
     /// 入力 `s` は本関数内で `into_bytes()` 経由で消費されるため、呼出側は別途
     /// 保持していたコピーを `zeroize` で消す責務を負う (Sub-D 境界で明示)。
     pub fn new(s: String, gate: &dyn PasswordStrengthGate) -> Result<Self, CryptoError> {
-        gate.validate(&s).map_err(CryptoError::WeakPassword)?;
+        gate.validate(&s)
+            .map_err(|fb| CryptoError::WeakPassword(Box::new(fb)))?;
         let bytes = s.into_bytes();
         Ok(Self {
             inner: SecretBytes::from_vec(bytes),
@@ -163,6 +164,18 @@ mod tests {
                 assert_eq!(fb.suggestions, vec!["use longer".to_string()]);
             }
             other => panic!("expected WeakPassword, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn master_password_new_returns_boxed_feedback_to_keep_crypto_error_small() {
+        // CryptoError::WeakPassword は Box<WeakPasswordFeedback> を保持する。
+        // この型形状そのものをコンパイル時に固定する (回帰防止)。
+        let err = MasterPassword::new("x".to_string(), &AlwaysRejectGate).unwrap_err();
+        if let CryptoError::WeakPassword(boxed) = err {
+            let _: Box<WeakPasswordFeedback> = boxed;
+        } else {
+            panic!("expected WeakPassword variant");
         }
     }
 

--- a/crates/shikomi-core/src/crypto/recovery.rs
+++ b/crates/shikomi-core/src/crypto/recovery.rs
@@ -50,7 +50,7 @@ impl RecoveryMnemonic {
 
     /// crate 内部からのみ単語配列への参照を取り出す (Sub-B BIP-39 検証用)。
     pub(crate) fn expose_within_crate(&self) -> &[String; MNEMONIC_WORD_COUNT] {
-        &**self.words.expose_secret()
+        self.words.expose_secret()
     }
 
     /// 24 語固定。

--- a/crates/shikomi-core/src/crypto/recovery.rs
+++ b/crates/shikomi-core/src/crypto/recovery.rs
@@ -50,7 +50,7 @@ impl RecoveryMnemonic {
 
     /// crate 内部からのみ単語配列への参照を取り出す (Sub-B BIP-39 検証用)。
     pub(crate) fn expose_within_crate(&self) -> &[String; MNEMONIC_WORD_COUNT] {
-        self.words.expose_secret().as_ref()
+        &**self.words.expose_secret()
     }
 
     /// 24 語固定。

--- a/crates/shikomi-core/src/crypto/recovery.rs
+++ b/crates/shikomi-core/src/crypto/recovery.rs
@@ -1,0 +1,103 @@
+//! `RecoveryMnemonic` — BIP-39 24 語リカバリ・ニーモニック (Tier-1 揮発、再表示不可)。
+//!
+//! - 配列長 24 を型レベルで強制 (契約 C-12: `[String; 24]` 引数)。
+//! - 各単語の BIP-39 wordlist 検証 / チェックサム検証は Sub-B (`bip39` crate) に委譲。
+//!   Sub-A は文字列の最低限の妥当性 (空でない / ASCII 範囲) のみ確認する。
+//! - `Drop` で各 `String` のヒープバッファを zeroize。
+//! - **再構築不可**: `Clone` 未実装 + 永続化フィールドなしで「初回 1 度のみ表示」契約 (REQ-S13)
+//!   を型レベルで担保する。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/errors-and-contracts.md`
+
+use core::fmt;
+
+use secrecy::{ExposeSecret, SecretBox};
+use zeroize::Zeroizing;
+
+/// BIP-39 24 語固定。
+pub const MNEMONIC_WORD_COUNT: usize = 24;
+
+/// BIP-39 リカバリ・ニーモニック (24 語固定)。
+///
+/// # Forbidden traits
+///
+/// `Clone` / `Copy` / `Display` / `serde::Serialize` / `serde::Deserialize` /
+/// `PartialEq` / `Eq` は **意図的に未実装**。
+/// 特に `Clone` 禁止は REQ-S13「初回 1 度のみ表示・再表示不可」契約の型レベル担保。
+///
+/// ```compile_fail
+/// use shikomi_core::crypto::RecoveryMnemonic;
+/// let words: [String; 24] = std::array::from_fn(|_| "abandon".to_string());
+/// let m = RecoveryMnemonic::from_words(words).unwrap();
+/// let _ = m.clone(); // 契約 C-2 / REQ-S13: Clone 禁止
+/// ```
+pub struct RecoveryMnemonic {
+    words: SecretBox<Zeroizing<[String; MNEMONIC_WORD_COUNT]>>,
+}
+
+impl RecoveryMnemonic {
+    /// 24 語の `String` 配列から `RecoveryMnemonic` を構築する (契約 C-12)。
+    ///
+    /// 配列長 24 を型レベルで強制するのが本コンストラクタの唯一の不変条件 (Sub-A 範囲)。
+    /// 各単語の BIP-39 wordlist 所属検証・チェックサム検証は Sub-B (`bip39` crate) に
+    /// 委譲するため、Sub-A は文字列の値検証を行わず **常に Ok 相当の構築のみ** を提供する。
+    #[must_use]
+    pub fn from_words(words: [String; MNEMONIC_WORD_COUNT]) -> Self {
+        Self {
+            words: SecretBox::new(Box::new(Zeroizing::new(words))),
+        }
+    }
+
+    /// crate 内部からのみ単語配列への参照を取り出す (Sub-B BIP-39 検証用)。
+    pub(crate) fn expose_within_crate(&self) -> &[String; MNEMONIC_WORD_COUNT] {
+        self.words.expose_secret().as_ref()
+    }
+
+    /// 24 語固定。
+    #[must_use]
+    pub const fn word_count() -> usize {
+        MNEMONIC_WORD_COUNT
+    }
+}
+
+impl fmt::Debug for RecoveryMnemonic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED MNEMONIC]")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_words() -> [String; MNEMONIC_WORD_COUNT] {
+        std::array::from_fn(|i| format!("word{i:02}"))
+    }
+
+    #[test]
+    fn from_words_constructs_with_24_words() {
+        let _ = RecoveryMnemonic::from_words(dummy_words());
+    }
+
+    #[test]
+    fn debug_returns_fixed_redacted_string() {
+        let m = RecoveryMnemonic::from_words(dummy_words());
+        let s = format!("{m:?}");
+        assert_eq!(s, "[REDACTED MNEMONIC]");
+        assert!(!s.contains("word00"), "Debug must not expose any word: {s}");
+    }
+
+    #[test]
+    fn expose_within_crate_returns_24_word_array_in_order() {
+        let m = RecoveryMnemonic::from_words(dummy_words());
+        let words = m.expose_within_crate();
+        assert_eq!(words.len(), MNEMONIC_WORD_COUNT);
+        assert_eq!(words[0], "word00");
+        assert_eq!(words[23], "word23");
+    }
+
+    #[test]
+    fn word_count_constant_is_24() {
+        assert_eq!(RecoveryMnemonic::word_count(), 24);
+    }
+}

--- a/crates/shikomi-core/src/crypto/verified.rs
+++ b/crates/shikomi-core/src/crypto/verified.rs
@@ -263,13 +263,15 @@ mod tests {
         // 設計上の禁止は Boy Scout PR レビューで担保 (設計書 §設計意図)。
         let outcome: CryptoOutcome<u32> =
             CryptoOutcome::Verified(Verified::new_from_aead_decrypt(1));
+        // `#[non_exhaustive]` の wildcard arm は外部 crate からの呼出時に必要だが、
+        // 同一 crate 内では全バリアント列挙すれば exhaustive と扱われ、`_` は unreachable。
+        // ここでは Verified 第一パターンが意味的に書けてしまうことを示す例として扱う。
         let _ = match outcome {
             CryptoOutcome::Verified(_) => "ok",
             CryptoOutcome::TagMismatch => "tag",
             CryptoOutcome::NonceLimit => "nonce",
             CryptoOutcome::KdfFailed(_) => "kdf",
             CryptoOutcome::WeakPassword(_) => "weak",
-            _ => "unknown (non_exhaustive)",
         };
     }
 }

--- a/crates/shikomi-core/src/crypto/verified.rs
+++ b/crates/shikomi-core/src/crypto/verified.rs
@@ -1,0 +1,275 @@
+//! Fail-Secure 型 — `Plaintext` / `Verified<T>` / `verify_aead_decrypt` / `CryptoOutcome<T>`。
+//!
+//! - `Plaintext`: AEAD 復号後の平文を保持する型。コンストラクタは
+//!   `pub(in crate::crypto::verified)` 限定 (Rev1 で `pub(crate)` から絞り込み)。
+//!   `Verified::new_from_aead_decrypt` を実装する**同一モジュール内**からのみ構築可。
+//! - `Verified<T>`: AEAD 検証済みマーカー (caller-asserted)。
+//!   `Verified::new_from_aead_decrypt` は `pub(crate)` のため shikomi-infra から構築不可。
+//! - `verify_aead_decrypt(closure)`: shikomi-infra の AES-GCM 復号クロージャを包む
+//!   呼出側主張マーカー関数。
+//! - `CryptoOutcome<T>`: 失敗バリアント先頭 + `Verified` 末尾の網羅 match を強制する列挙。
+//!
+//! 構造的封鎖の三段防御 (`detailed-design/nonce-and-aead.md` §`verify_aead_decrypt`):
+//! 1. **型レベル**: `Verified::new_from_aead_decrypt` は `pub(crate)` で外部 crate 構築不可。
+//! 2. **モジュール内**: `Plaintext::new_within_module` は `pub(in crate::crypto::verified)` で
+//!    `Verified::new_from_aead_decrypt` と同一モジュール内のみ構築可。
+//! 3. **呼出側契約**: `verify_aead_decrypt(|| ...)` クロージャ内で AEAD 検証実行を契約宣言。
+//!    Sub-C PR レビューで「クロージャ内が aes-gcm の検証 API を呼んでいるか」を必須確認。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/nonce-and-aead.md`
+
+use core::fmt;
+
+use crate::crypto::password::WeakPasswordFeedback;
+use crate::error::KdfErrorKind;
+use crate::secret::SecretBytes;
+
+// -------------------------------------------------------------------
+// Plaintext
+// -------------------------------------------------------------------
+
+/// AEAD 復号後の平文。`Verified<Plaintext>` 経由でのみ取り出される。
+///
+/// コンストラクタ `new_within_module` の可視性は `pub(in crate::crypto::verified)`
+/// — `Verified::new_from_aead_decrypt` を実装する**同一モジュール内**のみで構築可。
+///
+/// `expose_secret` は `pub` (クリップボード投入等で外部 crate read アクセス必要)、
+/// ただし**新規構築不可**。
+///
+/// # Forbidden traits
+///
+/// `Clone` / `Copy` / `Display` / `serde::Serialize` / `PartialEq` / `Eq` 未実装。
+///
+/// ```compile_fail
+/// use shikomi_core::crypto::Plaintext;
+/// // pub(in crate::crypto::verified) のため外部 crate からは呼べない
+/// let _ = Plaintext::new_within_module(b"fake".to_vec());
+/// ```
+pub struct Plaintext {
+    inner: SecretBytes,
+}
+
+impl Plaintext {
+    /// `pub(in crate::crypto::verified)` 限定。`Verified::new_from_aead_decrypt` 経路のみで使う。
+    ///
+    /// 外部 crate および shikomi-core 内の他モジュール (`crypto::key` 等) からも呼出不可。
+    /// この絞り込みにより「未検証 ciphertext を `Plaintext` として扱う」事故を構造封鎖する。
+    pub(in crate::crypto::verified) fn new_within_module(bytes: Vec<u8>) -> Self {
+        Self {
+            inner: SecretBytes::from_vec(bytes),
+        }
+    }
+
+    /// 平文バイト列への参照を返す。読み取りは外部 crate から許可。
+    #[must_use]
+    pub fn expose_secret(&self) -> &[u8] {
+        self.inner.expose_secret()
+    }
+}
+
+impl fmt::Debug for Plaintext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED PLAINTEXT]")
+    }
+}
+
+// -------------------------------------------------------------------
+// Verified<T>
+// -------------------------------------------------------------------
+
+/// AEAD 検証済み (caller-asserted) マーカー。`Verified<Plaintext>` が主用途。
+///
+/// コンストラクタ `new_from_aead_decrypt` は `pub(crate)` のため、
+/// **shikomi-infra を含む外部 crate からは直接構築不可**。
+/// shikomi-infra は `verify_aead_decrypt(|| ...)` 経由でのみ `Verified<T>` を得る。
+///
+/// # Forbidden traits
+///
+/// `Clone` / `Copy` / `Display` / `serde::Serialize` / `PartialEq` / `Eq` 未実装。
+/// `Clone` 禁止により AEAD 検証マーカーの複製攻撃面拡大を防ぐ。
+///
+/// ```compile_fail
+/// use shikomi_core::crypto::{Plaintext, Verified};
+/// // 外部 crate からは pub(crate) コンストラクタを呼べない (契約 C-7)
+/// let _ = Verified::new_from_aead_decrypt(Plaintext::new_within_module(vec![]));
+/// ```
+pub struct Verified<T> {
+    inner: T,
+}
+
+impl<T> Verified<T> {
+    /// `pub(crate)` 限定。AEAD 復号成功直後にのみ呼ばれる契約。
+    ///
+    /// 外部 crate (shikomi-infra 含む) からは構築不可。
+    pub(crate) fn new_from_aead_decrypt(inner: T) -> Self {
+        Self { inner }
+    }
+
+    /// 内包する T を所有権付きで取り出す (検証済み平文を消費して投入する経路)。
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    /// 内包する T への参照を返す (検証済み平文を非消費で読む経路)。
+    pub fn as_inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Verified<T> {
+    /// 内部 T の Debug 出力に委譲する。
+    /// `T = Plaintext` の場合は `Verified<Plaintext> { inner: [REDACTED PLAINTEXT] }` となり、
+    /// `Plaintext::Debug` の固定文字列で秘密が漏れない。
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Verified")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+// -------------------------------------------------------------------
+// verify_aead_decrypt — caller-asserted marker wrapper
+// -------------------------------------------------------------------
+
+/// shikomi-infra の AES-GCM 復号クロージャを包む呼出側主張マーカー関数。
+///
+/// クロージャ実行が `Ok(T)` を返したとき `Verified<T>` で包んで返す。
+/// shikomi-infra (Sub-C) は AES-GCM 復号 + GMAC タグ検証を本クロージャ内で実装し、
+/// 検証失敗時は `Err(E)` を返すことで `verify_aead_decrypt` 全体が `Err(E)` となる。
+///
+/// **本関数の保証範囲は型レベルではなく契約レベル** (詳細は設計書
+/// §`verify_aead_decrypt` ラッパ関数の契約)。Sub-C 実装が AEAD 検証を skip した場合、
+/// 型システムでは検出できない。三段防御の三段目 (Sub-C PR レビュー) で構造的に検出する責務。
+///
+/// # Errors
+///
+/// クロージャが返した `Err(E)` をそのまま伝播する。
+pub fn verify_aead_decrypt<F, T, E>(decrypt_fn: F) -> Result<Verified<T>, E>
+where
+    F: FnOnce() -> Result<T, E>,
+{
+    decrypt_fn().map(Verified::new_from_aead_decrypt)
+}
+
+// -------------------------------------------------------------------
+// CryptoOutcome<T>
+// -------------------------------------------------------------------
+
+/// 暗号操作の結果列挙。失敗バリアント先頭 + `Verified` 末尾で網羅 match を強制する。
+///
+/// 設計書 §設計意図:
+/// - `match` の第一アームに `Verified` を置く実装は PR レビューで却下する (Boy Scout Rule)。
+/// - `#[non_exhaustive]` で将来バリアント追加時の漏れを `match` 警告で検出。
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CryptoOutcome<T> {
+    /// AEAD 認証タグ検証失敗 (vault.db 改竄の可能性)。MSG-S10 経路。
+    TagMismatch,
+    /// `NonceCounter::increment` 上限到達。MSG-S11 経路。
+    NonceLimit,
+    /// KDF 計算失敗 (Argon2id / PBKDF2 / HKDF)。MSG-S09 KDF カテゴリ。
+    KdfFailed(KdfErrorKind),
+    /// `MasterPassword::new` 構築失敗。MSG-S08 (Fail Kindly)。
+    WeakPassword(WeakPasswordFeedback),
+    /// 正常系: AEAD 検証成功 + 平文取得 (`T = Plaintext` が主用途)。
+    Verified(Verified<T>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------
+    // Plaintext
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn plaintext_debug_returns_fixed_redacted_string() {
+        let p = Plaintext::new_within_module(b"secret-bytes".to_vec());
+        let s = format!("{p:?}");
+        assert_eq!(s, "[REDACTED PLAINTEXT]");
+        assert!(!s.contains("secret-bytes"));
+    }
+
+    #[test]
+    fn plaintext_expose_secret_returns_original_bytes() {
+        let p = Plaintext::new_within_module(vec![1u8, 2, 3, 4]);
+        assert_eq!(p.expose_secret(), &[1u8, 2, 3, 4]);
+    }
+
+    // -----------------------------------------------------------------
+    // Verified<T> (C-7 構築可視性)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn verified_into_inner_returns_inner_value() {
+        let v = Verified::new_from_aead_decrypt(42u32);
+        assert_eq!(v.into_inner(), 42u32);
+    }
+
+    #[test]
+    fn verified_as_inner_returns_reference_without_consuming() {
+        let v = Verified::new_from_aead_decrypt("abc".to_string());
+        assert_eq!(v.as_inner(), "abc");
+        // as_inner は &self なので消費せず再アクセス可能
+        assert_eq!(v.into_inner(), "abc".to_string());
+    }
+
+    #[test]
+    fn verified_plaintext_debug_propagates_redacted_marker_from_inner() {
+        let p = Plaintext::new_within_module(b"secret".to_vec());
+        let v = Verified::new_from_aead_decrypt(p);
+        let s = format!("{v:?}");
+        assert!(s.contains("[REDACTED PLAINTEXT]"), "got: {s}");
+        assert!(!s.contains("secret"), "got: {s}");
+    }
+
+    // -----------------------------------------------------------------
+    // verify_aead_decrypt (caller-asserted marker)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn verify_aead_decrypt_wraps_ok_value_into_verified() {
+        let result: Result<Verified<u32>, ()> = verify_aead_decrypt(|| Ok(7));
+        let v = result.unwrap();
+        assert_eq!(v.into_inner(), 7);
+    }
+
+    #[test]
+    fn verify_aead_decrypt_propagates_err_from_closure() {
+        let result: Result<Verified<u32>, &'static str> = verify_aead_decrypt(|| Err("boom"));
+        assert_eq!(result.unwrap_err(), "boom");
+    }
+
+    // -----------------------------------------------------------------
+    // CryptoOutcome<T>
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn crypto_outcome_supports_all_documented_variants() {
+        // 5 バリアント全て構築可能であること (実装抜け回帰防止)
+        let _ = CryptoOutcome::<Plaintext>::TagMismatch;
+        let _ = CryptoOutcome::<Plaintext>::NonceLimit;
+        let _ = CryptoOutcome::<Plaintext>::KdfFailed(KdfErrorKind::Argon2id);
+        let _ = CryptoOutcome::<Plaintext>::WeakPassword(WeakPasswordFeedback::new(None, vec![]));
+        let _ = CryptoOutcome::<Plaintext>::Verified(Verified::new_from_aead_decrypt(
+            Plaintext::new_within_module(vec![]),
+        ));
+    }
+
+    #[test]
+    fn crypto_outcome_match_with_verified_first_is_legal_but_discouraged() {
+        // 型システムは Verified 第一パターンを許容する (lint 強制不可)。
+        // 設計上の禁止は Boy Scout PR レビューで担保 (設計書 §設計意図)。
+        let outcome: CryptoOutcome<u32> =
+            CryptoOutcome::Verified(Verified::new_from_aead_decrypt(1));
+        let _ = match outcome {
+            CryptoOutcome::Verified(_) => "ok",
+            CryptoOutcome::TagMismatch => "tag",
+            CryptoOutcome::NonceLimit => "nonce",
+            CryptoOutcome::KdfFailed(_) => "kdf",
+            CryptoOutcome::WeakPassword(_) => "weak",
+            _ => "unknown (non_exhaustive)",
+        };
+    }
+}

--- a/crates/shikomi-core/src/crypto/verified.rs
+++ b/crates/shikomi-core/src/crypto/verified.rs
@@ -170,7 +170,8 @@ pub enum CryptoOutcome<T> {
     /// KDF 計算失敗 (Argon2id / PBKDF2 / HKDF)。MSG-S09 KDF カテゴリ。
     KdfFailed(KdfErrorKind),
     /// `MasterPassword::new` 構築失敗。MSG-S08 (Fail Kindly)。
-    WeakPassword(WeakPasswordFeedback),
+    /// `Box` で `CryptoOutcome` enum 全体のサイズを抑える (詳細は `CryptoError::WeakPassword` 参照)。
+    WeakPassword(Box<WeakPasswordFeedback>),
     /// 正常系: AEAD 検証成功 + 平文取得 (`T = Plaintext` が主用途)。
     Verified(Verified<T>),
 }
@@ -251,7 +252,10 @@ mod tests {
         let _ = CryptoOutcome::<Plaintext>::TagMismatch;
         let _ = CryptoOutcome::<Plaintext>::NonceLimit;
         let _ = CryptoOutcome::<Plaintext>::KdfFailed(KdfErrorKind::Argon2id);
-        let _ = CryptoOutcome::<Plaintext>::WeakPassword(WeakPasswordFeedback::new(None, vec![]));
+        let _ = CryptoOutcome::<Plaintext>::WeakPassword(Box::new(WeakPasswordFeedback::new(
+            None,
+            vec![],
+        )));
         let _ = CryptoOutcome::<Plaintext>::Verified(Verified::new_from_aead_decrypt(
             Plaintext::new_within_module(vec![]),
         ));

--- a/crates/shikomi-core/src/error.rs
+++ b/crates/shikomi-core/src/error.rs
@@ -185,8 +185,13 @@ pub enum VaultConsistencyReason {
 pub enum CryptoError {
     /// `MasterPassword::new` が `PasswordStrengthGate::validate` で拒否された。
     /// 内包する `WeakPasswordFeedback` をそのまま MSG-S08 に渡す（Fail Kindly）。
+    ///
+    /// `Box` でヒープ移送して `CryptoError` enum 全体のサイズを抑える
+    /// (clippy::result_large_err 対策。`WeakPasswordFeedback` は
+    /// `Option<String> + Vec<String>` で約 48B あるため、`DomainError` /
+    /// `PersistenceError` の連鎖サイズ膨張を防ぐ目的でヒープに逃がす)。
     #[error("weak password rejected by strength gate")]
-    WeakPassword(crate::crypto::password::WeakPasswordFeedback),
+    WeakPassword(Box<crate::crypto::password::WeakPasswordFeedback>),
 
     /// AEAD 復号タグ検証失敗（vault.db 改竄の可能性）。MSG-S10 経路。
     #[error("AEAD authentication tag verification failed")]

--- a/crates/shikomi-core/src/error.rs
+++ b/crates/shikomi-core/src/error.rs
@@ -1,6 +1,7 @@
 //! ドメインエラー型。
 //!
 //! 全モジュールが返す `DomainError` と、各バリアントの詳細理由を列挙する。
+//! 暗号特化エラーは `CryptoError` に集約し、`DomainError::Crypto` で内包する。
 
 use thiserror::Error;
 
@@ -44,9 +45,19 @@ pub enum DomainError {
     #[error("{0}")]
     VaultConsistencyError(VaultConsistencyReason),
 
-    /// MSG-DEV-005: `NonceCounter` が上限 (`u32::MAX`) に達した。rekey が必要。
-    #[error("nonce counter exhausted; rekey required")]
-    NonceOverflow,
+    /// MSG-DEV-005: `NonceCounter` が上限 (`1u64 << 32`) に達した。
+    /// rekey が必要 (NIST SP 800-38D §8.3 random nonce birthday bound)。
+    ///
+    /// Sub-A 凍結文言。Sub-0 で `NonceLimitExceeded` に統一。
+    #[error("nonce counter limit exceeded; rekey required")]
+    NonceLimitExceeded,
+
+    /// 暗号系エラーを内包する透過バリアント。
+    ///
+    /// 暗号操作 (KDF / AEAD / 強度ゲート) の失敗は `CryptoError` 側で詳細化し、
+    /// `DomainError` はその通過点として動作する。
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
 }
 
 // -------------------------------------------------------------------
@@ -61,13 +72,17 @@ pub enum InvalidVaultHeaderReason {
     #[error("kdf_salt length mismatch: expected {expected}, got {got}")]
     KdfSaltLength { expected: usize, got: usize },
 
-    /// `WrappedVek` が空（0 バイト）。
-    #[error("wrapped_vek is empty")]
+    /// `WrappedVek` の `ciphertext` が空（0 バイト）。
+    #[error("wrapped_vek ciphertext is empty")]
     WrappedVekEmpty,
 
-    /// `WrappedVek` が最小長未満（AES-GCM タグ 16 B 以上必要）。
-    #[error("wrapped_vek is too short")]
+    /// `WrappedVek` の `ciphertext` が最小長未満（VEK 32B が最小）。
+    #[error("wrapped_vek ciphertext is too short")]
     WrappedVekTooShort,
+
+    /// `AuthTag` のバイト長が 16 ではない（AES-GCM 認証タグ仕様）。
+    #[error("auth_tag length mismatch: expected 16, got {got}")]
+    AuthTagLength { got: usize },
 }
 
 /// `DomainError::InvalidRecordId` の詳細理由。
@@ -157,6 +172,60 @@ pub enum VaultConsistencyReason {
     InvalidUpdatedAt,
 }
 
+// -------------------------------------------------------------------
+// CryptoError
+// -------------------------------------------------------------------
+
+/// 暗号操作（KDF / AEAD / 強度ゲート / Verified 構築）に特化したエラー。
+///
+/// `DomainError::Crypto(CryptoError)` で `DomainError` に内包される。
+/// 詳細は `docs/features/vault-encryption/detailed-design/errors-and-contracts.md` を参照。
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CryptoError {
+    /// `MasterPassword::new` が `PasswordStrengthGate::validate` で拒否された。
+    /// 内包する `WeakPasswordFeedback` をそのまま MSG-S08 に渡す（Fail Kindly）。
+    #[error("weak password rejected by strength gate")]
+    WeakPassword(crate::crypto::password::WeakPasswordFeedback),
+
+    /// AEAD 復号タグ検証失敗（vault.db 改竄の可能性）。MSG-S10 経路。
+    #[error("AEAD authentication tag verification failed")]
+    AeadTagMismatch,
+
+    /// `NonceCounter::increment` が上限到達。`rekey` 強制（NIST SP 800-38D §8.3）。MSG-S11 経路。
+    #[error("nonce counter exceeded {limit}; rekey required")]
+    NonceLimitExceeded {
+        /// 上限値 (`1u64 << 32`)。
+        limit: u64,
+    },
+
+    /// KDF 計算失敗（Argon2id / PBKDF2 / HKDF）。Sub-B が source エラーを内包する。
+    #[error("KDF computation failed: {kind:?}")]
+    KdfFailed {
+        /// 失敗した KDF の種別。
+        kind: KdfErrorKind,
+        /// 元エラー（Sub-B 実装が `Box<dyn>` 化して内包）。
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// `Plaintext` を `Verified<_>` 経由なしで構築しようとした runtime 検出。
+    /// 通常は `pub(in crate::crypto::verified)` 可視性でコンパイル時に防がれる。
+    #[error("Plaintext requires Verified<_> wrapper")]
+    VerifyRequired,
+}
+
+/// `CryptoError::KdfFailed` の KDF 種別を表す。Sub-B で source エラーを差別化する用途。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum KdfErrorKind {
+    /// Argon2id (Master Password 由来 KEK).
+    Argon2id,
+    /// PBKDF2-HMAC-SHA512 (BIP-39 mnemonic → seed).
+    Pbkdf2,
+    /// HKDF-SHA256 (PBKDF2 seed → KEK_recovery).
+    Hkdf,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -193,8 +262,6 @@ mod tests {
             record_mode: ProtectionMode::Encrypted,
         });
         let msg = format!("{err}");
-        // #[error("{0}")] により VaultConsistencyReason の Display が素通しになる。
-        // ModeMismatch の Display: "vault is in ... mode but record payload is ..."
         assert!(msg.contains("vault") && msg.contains("mode"), "got: {msg}");
     }
 
@@ -205,8 +272,6 @@ mod tests {
         let id = RecordId::new(Uuid::now_v7()).unwrap();
         let err = DomainError::VaultConsistencyError(VaultConsistencyReason::DuplicateId(id));
         let msg = format!("{err}");
-        // 以前は外枠の文言 "vault and record payload mode mismatch" が混入していた。
-        // #[error("{0}")] により DuplicateId の Display だけが出ることを確認する。
         assert!(
             !msg.contains("mode mismatch"),
             "DuplicateId should not contain 'mode mismatch', got: {msg}"
@@ -215,10 +280,10 @@ mod tests {
     }
 
     #[test]
-    fn test_display_nonce_overflow_contains_keyword() {
-        let err = DomainError::NonceOverflow;
+    fn test_display_nonce_limit_exceeded_contains_keyword() {
+        let err = DomainError::NonceLimitExceeded;
         let msg = format!("{err}");
-        assert!(msg.contains("nonce counter exhausted"), "got: {msg}");
+        assert!(msg.contains("nonce counter limit exceeded"), "got: {msg}");
     }
 
     #[test]
@@ -243,5 +308,26 @@ mod tests {
         });
         let msg = format!("{err}");
         assert!(msg.contains("invalid vault header"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_crypto_error_aead_tag_mismatch_displays_known_phrase() {
+        let err = CryptoError::AeadTagMismatch;
+        let msg = format!("{err}");
+        assert!(msg.contains("AEAD"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_crypto_error_nonce_limit_exceeded_includes_limit_value() {
+        let err = CryptoError::NonceLimitExceeded { limit: 1u64 << 32 };
+        let msg = format!("{err}");
+        assert!(msg.contains(&(1u64 << 32).to_string()), "got: {msg}");
+    }
+
+    #[test]
+    fn test_crypto_error_into_domain_error_via_from() {
+        let crypto = CryptoError::AeadTagMismatch;
+        let domain: DomainError = crypto.into();
+        assert!(matches!(domain, DomainError::Crypto(_)));
     }
 }

--- a/crates/shikomi-core/src/lib.rs
+++ b/crates/shikomi-core/src/lib.rs
@@ -1,8 +1,13 @@
 //! shikomi-core — ドメインロジック層
 //!
-//! vault ドメイン型・秘密値ラッパ・ドメインエラーを提供する pure Rust / no-I/O クレート。
-//! 外部 API / OS / DB には一切アクセスしない。
+//! vault ドメイン型・暗号ドメイン型・秘密値ラッパ・ドメインエラーを提供する
+//! pure Rust / no-I/O クレート。外部 API / OS / DB / CSPRNG (`rand_core::OsRng` /
+//! `getrandom`) には一切アクセスしない。
+//!
+//! 暗号鍵階層と Fail-Secure 型は `crypto` モジュール、vault 集約とレコードは `vault`
+//! モジュール、秘密値ラッパは `secret` モジュールに分離する (Clean Architecture)。
 
+pub mod crypto;
 pub mod error;
 pub mod ipc;
 pub mod secret;
@@ -10,12 +15,19 @@ pub mod vault;
 
 // --- ドメインエラー ---
 pub use error::{
-    DomainError, InvalidRecordIdReason, InvalidRecordLabelReason, InvalidRecordPayloadReason,
-    InvalidVaultHeaderReason, VaultConsistencyReason,
+    CryptoError, DomainError, InvalidRecordIdReason, InvalidRecordLabelReason,
+    InvalidRecordPayloadReason, InvalidVaultHeaderReason, KdfErrorKind, VaultConsistencyReason,
 };
 
 // --- 秘密値ラッパ ---
 pub use secret::{SecretBytes, SecretString};
+
+// --- 暗号ドメイン型 (Sub-A 新規) ---
+pub use crypto::{
+    verify_aead_decrypt, CryptoOutcome, HeaderAeadKey, Kek, KekKind, KekKindPw, KekKindRecovery,
+    MasterPassword, PasswordStrengthGate, Plaintext, RecoveryMnemonic, Vek, Verified,
+    WeakPasswordFeedback,
+};
 
 // --- vault 集約・ヘッダ ---
 pub use vault::{ProtectionMode, Vault, VaultHeader, VaultVersion};
@@ -24,7 +36,7 @@ pub use vault::{ProtectionMode, Vault, VaultHeader, VaultVersion};
 pub use vault::{Record, RecordId, RecordKind, RecordLabel, RecordPayload, RecordPayloadEncrypted};
 
 // --- 暗号化関連データ型 ---
-pub use vault::{Aad, CipherText, KdfSalt, NonceBytes, NonceCounter, WrappedVek};
+pub use vault::{Aad, AuthTag, CipherText, KdfSalt, NonceBytes, NonceCounter, WrappedVek};
 
 // --- VekProvider trait ---
 pub use vault::VekProvider;

--- a/crates/shikomi-core/src/vault/crypto_data.rs
+++ b/crates/shikomi-core/src/vault/crypto_data.rs
@@ -1,20 +1,28 @@
 //! 暗号化関連バイト列 newtype 群。
 //!
-//! `KdfSalt` / `WrappedVek` / `CipherText` / `Aad` の 4 型。
+//! `KdfSalt` / `WrappedVek` / `AuthTag` / `CipherText` / `Aad` の 5 型。
 //! いずれも検証済み newtype で、生バイト列の取り違えを型で防ぐ。
+//!
+//! Sub-A Boy Scout Rule: `WrappedVek` の内部構造を `(ciphertext, nonce, tag)` の
+//! 3 フィールドに分離型化 (旧: `Box<[u8]>` 単一)。byte offset 演算を呼出側に漏らさない
+//! (Tell, Don't Ask)。`AuthTag` を新規導入し AES-GCM 認証タグ 16B を独立型として表現する。
 
 use time::OffsetDateTime;
 
 use crate::error::{DomainError, InvalidRecordPayloadReason, InvalidVaultHeaderReason};
 use crate::vault::id::RecordId;
+use crate::vault::nonce::NonceBytes;
 use crate::vault::version::VaultVersion;
 
 /// Argon2id KDF ソルト長（16 byte、OWASP 推奨 16 B 以上）。
 const KDF_SALT_LEN: usize = 16;
 
-/// `WrappedVek` に必要な最小バイト長。
-/// AES-GCM 認証タグが 16 B 固定のため、それ以上でなければ暗号的に不正。
-const WRAPPED_VEK_MIN_LEN: usize = 16;
+/// AES-GCM 認証タグ長 (NIST SP 800-38D §5.2.1.2、128 bit)。
+const AUTH_TAG_LEN: usize = 16;
+
+/// `WrappedVek::ciphertext` の最小バイト長 (VEK 32B が最小)。
+/// AES-GCM 認証タグは別フィールド `AuthTag` に分離されるため本最小には含めない (契約 C-11)。
+const WRAPPED_VEK_CIPHERTEXT_MIN_LEN: usize = 32;
 
 // -------------------------------------------------------------------
 // KdfSalt
@@ -53,41 +61,112 @@ impl KdfSalt {
 }
 
 // -------------------------------------------------------------------
-// WrappedVek
+// AuthTag (新規、Sub-A)
 // -------------------------------------------------------------------
 
-/// VEK（Vault Encryption Key）を暗号化してラップしたバイト列。
+/// AES-256-GCM 認証タグ (16 byte 固定)。
 ///
-/// AES-GCM wrap には認証タグ（16 B）が含まれるため、実態は空ではない。
+/// `WrappedVek` の `tag` フィールド・将来のヘッダ AEAD タグなどで利用する。
+/// 旧来の「ciphertext + tag 連結」を分離型化することで byte offset 演算を呼出側から消す
+/// (Sub-A Boy Scout Rule)。
+#[derive(Debug, Clone)]
+pub struct AuthTag {
+    inner: [u8; AUTH_TAG_LEN],
+}
+
+impl AuthTag {
+    /// バイトスライスから `AuthTag` を構築する。
+    ///
+    /// # Errors
+    /// `bytes.len() != 16` の場合 `DomainError::InvalidVaultHeader(AuthTagLength)` を返す。
+    pub fn try_new(bytes: &[u8]) -> Result<Self, DomainError> {
+        if bytes.len() != AUTH_TAG_LEN {
+            return Err(DomainError::InvalidVaultHeader(
+                InvalidVaultHeaderReason::AuthTagLength { got: bytes.len() },
+            ));
+        }
+        let mut inner = [0u8; AUTH_TAG_LEN];
+        inner.copy_from_slice(bytes);
+        Ok(Self { inner })
+    }
+
+    /// 16 byte 配列から直接構築する (Sub-C AEAD 完了直後の経路で使用)。
+    #[must_use]
+    pub fn from_array(bytes: [u8; AUTH_TAG_LEN]) -> Self {
+        Self { inner: bytes }
+    }
+
+    /// 内包する 16 バイト配列への参照を返す。
+    #[must_use]
+    pub fn as_array(&self) -> &[u8; AUTH_TAG_LEN] {
+        &self.inner
+    }
+}
+
+// -------------------------------------------------------------------
+// WrappedVek (Sub-A: ciphertext + nonce + tag の 3 フィールドに分離)
+// -------------------------------------------------------------------
+
+/// VEK を AES-256-GCM でラップしたデータ。`ciphertext` / `nonce` / `tag` を独立フィールドで保持。
+///
+/// 旧来の単一 `Box<[u8]>` フィールドを Sub-A で 3 フィールド構造に分離した (Boy Scout Rule)。
+/// byte offset 演算は `WrappedVek::new` / `into_parts` に閉じる (Tell, Don't Ask)。
+///
+/// 永続化フォーマットは Sub-D で確定する (本 Sub-A はシリアライズ実装を持たない)。
 #[derive(Debug, Clone)]
 pub struct WrappedVek {
-    inner: Box<[u8]>,
+    ciphertext: Vec<u8>,
+    nonce: NonceBytes,
+    tag: AuthTag,
 }
 
 impl WrappedVek {
-    /// バイト列から `WrappedVek` を構築する。
+    /// 3 要素 (ciphertext / nonce / tag) から `WrappedVek` を構築する (契約 C-11)。
     ///
     /// # Errors
-    /// - 空の場合 `DomainError::InvalidVaultHeader(WrappedVekEmpty)` を返す。
-    /// - 16 バイト未満の場合 `DomainError::InvalidVaultHeader(WrappedVekTooShort)` を返す。
-    pub fn try_new(bytes: Box<[u8]>) -> Result<Self, DomainError> {
-        if bytes.is_empty() {
+    ///
+    /// - `ciphertext` が空: `DomainError::InvalidVaultHeader(WrappedVekEmpty)`
+    /// - `ciphertext` の長さが 32 byte 未満: `DomainError::InvalidVaultHeader(WrappedVekTooShort)`
+    pub fn new(ciphertext: Vec<u8>, nonce: NonceBytes, tag: AuthTag) -> Result<Self, DomainError> {
+        if ciphertext.is_empty() {
             return Err(DomainError::InvalidVaultHeader(
                 InvalidVaultHeaderReason::WrappedVekEmpty,
             ));
         }
-        if bytes.len() < WRAPPED_VEK_MIN_LEN {
+        if ciphertext.len() < WRAPPED_VEK_CIPHERTEXT_MIN_LEN {
             return Err(DomainError::InvalidVaultHeader(
                 InvalidVaultHeaderReason::WrappedVekTooShort,
             ));
         }
-        Ok(Self { inner: bytes })
+        Ok(Self {
+            ciphertext,
+            nonce,
+            tag,
+        })
     }
 
-    /// 内包するバイト列への参照を返す。
+    /// `ciphertext` への参照を返す。
     #[must_use]
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.inner
+    pub fn ciphertext(&self) -> &[u8] {
+        &self.ciphertext
+    }
+
+    /// `nonce` への参照を返す。
+    #[must_use]
+    pub fn nonce(&self) -> &NonceBytes {
+        &self.nonce
+    }
+
+    /// `tag` への参照を返す。
+    #[must_use]
+    pub fn tag(&self) -> &AuthTag {
+        &self.tag
+    }
+
+    /// 3 要素を所有権付きで取り出す (永続化シリアライズ用)。
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<u8>, NonceBytes, AuthTag) {
+        (self.ciphertext, self.nonce, self.tag)
     }
 }
 
@@ -95,7 +174,10 @@ impl WrappedVek {
 // CipherText
 // -------------------------------------------------------------------
 
-/// AES-256-GCM 暗号化済みのレコードペイロード。認証タグを含む。
+/// AES-256-GCM 暗号化済みのレコードペイロード。認証タグを含む (レコード境界での連結保持)。
+///
+/// レコード単位の AEAD 出力フォーマットは vault-persistence (Issue #7) で既に確定済。
+/// 本 Sub-A では構造変更しない (`WrappedVek` のみ Boy Scout 分離)。
 #[derive(Debug, Clone)]
 pub struct CipherText {
     inner: Box<[u8]>,
@@ -207,6 +289,7 @@ impl Aad {
 mod tests {
     use super::*;
     use crate::vault::id::RecordId;
+    use crate::vault::nonce::NonceBytes;
     use crate::vault::version::VaultVersion;
     use time::OffsetDateTime;
     use uuid::Uuid;
@@ -215,64 +298,83 @@ mod tests {
         RecordId::new(Uuid::now_v7()).unwrap()
     }
 
-    // ---------------------------------------------------------------
-    // WrappedVek::try_new 境界値テスト（TC-U06a）
-    // REQ-009 / AC-09（Defense in Depth: 暗号的不正入力のドメイン層排除）
-    // ---------------------------------------------------------------
-
-    /// TC-U06a-01: 空バイト列 → WrappedVekEmpty
-    #[test]
-    fn test_wrapped_vek_try_new_with_empty_bytes_returns_wrapped_vek_empty() {
-        let err = WrappedVek::try_new(vec![].into_boxed_slice()).unwrap_err();
-        assert!(
-            matches!(
-                err,
-                DomainError::InvalidVaultHeader(InvalidVaultHeaderReason::WrappedVekEmpty)
-            ),
-            "Expected WrappedVekEmpty, got: {:?}",
-            err
-        );
+    fn dummy_nonce() -> NonceBytes {
+        NonceBytes::from_random([0u8; 12])
     }
 
-    /// TC-U06a-02: 1 バイト（最小不正値）→ WrappedVekTooShort
-    #[test]
-    fn test_wrapped_vek_try_new_with_1_byte_returns_wrapped_vek_too_short() {
-        let err = WrappedVek::try_new(vec![0u8; 1].into_boxed_slice()).unwrap_err();
-        assert!(
-            matches!(
-                err,
-                DomainError::InvalidVaultHeader(InvalidVaultHeaderReason::WrappedVekTooShort)
-            ),
-            "Expected WrappedVekTooShort for 1-byte input, got: {:?}",
-            err
-        );
-    }
-
-    /// TC-U06a-03: 15 バイト（上限不正値）→ WrappedVekTooShort
-    #[test]
-    fn test_wrapped_vek_try_new_with_15_bytes_returns_wrapped_vek_too_short() {
-        let err = WrappedVek::try_new(vec![0u8; 15].into_boxed_slice()).unwrap_err();
-        assert!(
-            matches!(
-                err,
-                DomainError::InvalidVaultHeader(InvalidVaultHeaderReason::WrappedVekTooShort)
-            ),
-            "Expected WrappedVekTooShort for 15-byte input, got: {:?}",
-            err
-        );
-    }
-
-    /// TC-U06a-04: 16 バイト（最小有効値）→ Ok
-    #[test]
-    fn test_wrapped_vek_try_new_with_16_bytes_ok() {
-        assert!(
-            WrappedVek::try_new(vec![0u8; 16].into_boxed_slice()).is_ok(),
-            "WrappedVek with 16 bytes must succeed"
-        );
+    fn dummy_tag() -> AuthTag {
+        AuthTag::from_array([0u8; 16])
     }
 
     // ---------------------------------------------------------------
-    // Aad テスト
+    // AuthTag
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn auth_tag_from_array_constructs_without_panic() {
+        let _ = AuthTag::from_array([0u8; 16]);
+    }
+
+    #[test]
+    fn auth_tag_try_new_with_16_bytes_ok() {
+        assert!(AuthTag::try_new(&[0u8; 16]).is_ok());
+    }
+
+    #[test]
+    fn auth_tag_try_new_with_15_bytes_returns_auth_tag_length_error() {
+        let err = AuthTag::try_new(&[0u8; 15]).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidVaultHeader(InvalidVaultHeaderReason::AuthTagLength { got: 15 })
+        ));
+    }
+
+    // ---------------------------------------------------------------
+    // WrappedVek::new 境界値テスト (C-11)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn wrapped_vek_new_with_empty_ciphertext_returns_wrapped_vek_empty() {
+        let err = WrappedVek::new(vec![], dummy_nonce(), dummy_tag()).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidVaultHeader(InvalidVaultHeaderReason::WrappedVekEmpty)
+        ));
+    }
+
+    #[test]
+    fn wrapped_vek_new_with_31_bytes_ciphertext_returns_wrapped_vek_too_short() {
+        let err = WrappedVek::new(vec![0u8; 31], dummy_nonce(), dummy_tag()).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidVaultHeader(InvalidVaultHeaderReason::WrappedVekTooShort)
+        ));
+    }
+
+    #[test]
+    fn wrapped_vek_new_with_32_bytes_ciphertext_ok() {
+        assert!(WrappedVek::new(vec![0u8; 32], dummy_nonce(), dummy_tag()).is_ok());
+    }
+
+    #[test]
+    fn wrapped_vek_into_parts_round_trips_with_new() {
+        let w = WrappedVek::new(vec![0xAAu8; 32], dummy_nonce(), dummy_tag()).unwrap();
+        let (ct, n, t) = w.into_parts();
+        assert_eq!(ct, vec![0xAAu8; 32]);
+        assert_eq!(n.as_array(), &[0u8; 12]);
+        assert_eq!(t.as_array(), &[0u8; 16]);
+    }
+
+    #[test]
+    fn wrapped_vek_field_accessors_return_references() {
+        let w = WrappedVek::new(vec![1u8; 32], dummy_nonce(), dummy_tag()).unwrap();
+        assert_eq!(w.ciphertext(), &[1u8; 32]);
+        assert_eq!(w.nonce().as_array(), &[0u8; 12]);
+        assert_eq!(w.tag().as_array(), &[0u8; 16]);
+    }
+
+    // ---------------------------------------------------------------
+    // Aad テスト (既存維持)
     // ---------------------------------------------------------------
 
     #[test]
@@ -283,13 +385,6 @@ mod tests {
 
     #[test]
     fn test_aad_new_with_out_of_range_timestamp_returns_aad_timestamp_out_of_range() {
-        // TC-U11-02: AadTimestampOutOfRange fires when microseconds overflow i64.
-        // Overflow threshold: seconds > i64::MAX / 1_000_000 ≈ 9_223_372_036_854.
-        // time 0.3 limits representable years to [-9999, 9999]; max unix timestamp
-        // ≈ year 9999 ≈ 2.53×10^11 s → max microseconds ≈ 2.53×10^17 << i64::MAX.
-        // Therefore AadTimestampOutOfRange is unreachable within time 0.3's range.
-        // If time 0.3 cannot represent the threshold timestamp, the test is
-        // vacuously satisfied (defensive path cannot be triggered with this crate).
         let threshold = i64::MAX / 1_000_000 + 1;
         if let Ok(far_future) = OffsetDateTime::from_unix_timestamp(threshold) {
             let id = make_id();
@@ -301,8 +396,6 @@ mod tests {
                 )
             ));
         }
-        // else: time 0.3 cannot represent this timestamp; the error variant is
-        // dead code in practice — test is vacuously satisfied.
     }
 
     #[test]
@@ -314,11 +407,6 @@ mod tests {
 
     #[test]
     fn test_aad_to_canonical_bytes_golden_value() {
-        // Golden value test: known RecordId + VaultVersion::CURRENT + UNIX_EPOCH
-        // Expected 26 bytes:
-        //   [0..16]: UUID bytes MSB first
-        //   [16..18]: u16=1 big-endian = [0x00, 0x01]
-        //   [18..26]: i64=0 big-endian = [0x00; 8]
         let uuid_bytes = [
             0x01u8, 0x8f, 0x12, 0x34, 0x56, 0x78, 0x7a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78,
             0x90, 0x12,
@@ -334,10 +422,6 @@ mod tests {
             0x00, 0x01, // u16=1 BE [16..18]
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // i64=0 BE [18..26]
         ];
-        assert_eq!(
-            canonical, expected,
-            "Golden value mismatch: got {:02x?}, expected {:02x?}",
-            canonical, expected
-        );
+        assert_eq!(canonical, expected);
     }
 }

--- a/crates/shikomi-core/src/vault/header.rs
+++ b/crates/shikomi-core/src/vault/header.rs
@@ -169,6 +169,8 @@ use InvalidVaultHeaderReason as _;
 mod tests {
     use super::*;
     use crate::error::DomainError;
+    use crate::vault::crypto_data::AuthTag;
+    use crate::vault::nonce::NonceBytes;
     use time::OffsetDateTime;
 
     fn now() -> OffsetDateTime {
@@ -180,7 +182,12 @@ mod tests {
     }
 
     fn valid_wrapped_vek() -> WrappedVek {
-        WrappedVek::try_new(vec![0u8; 48].into_boxed_slice()).unwrap()
+        WrappedVek::new(
+            vec![0u8; 32],
+            NonceBytes::from_random([0u8; 12]),
+            AuthTag::from_array([0u8; 16]),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -220,13 +227,23 @@ mod tests {
 
     #[test]
     fn test_new_encrypted_with_empty_wrapped_vek_pw_returns_error() {
-        let err = WrappedVek::try_new(vec![].into_boxed_slice()).unwrap_err();
+        let err = WrappedVek::new(
+            vec![],
+            NonceBytes::from_random([0u8; 12]),
+            AuthTag::from_array([0u8; 16]),
+        )
+        .unwrap_err();
         assert!(matches!(err, DomainError::InvalidVaultHeader(_)));
     }
 
     #[test]
     fn test_new_encrypted_with_empty_wrapped_vek_recovery_returns_error() {
-        let err = WrappedVek::try_new(vec![].into_boxed_slice()).unwrap_err();
+        let err = WrappedVek::new(
+            vec![],
+            NonceBytes::from_random([0u8; 12]),
+            AuthTag::from_array([0u8; 16]),
+        )
+        .unwrap_err();
         assert!(matches!(err, DomainError::InvalidVaultHeader(_)));
     }
 

--- a/crates/shikomi-core/src/vault/mod.rs
+++ b/crates/shikomi-core/src/vault/mod.rs
@@ -8,7 +8,7 @@ pub mod protection_mode;
 pub mod record;
 pub mod version;
 
-pub use crypto_data::{Aad, CipherText, KdfSalt, WrappedVek};
+pub use crypto_data::{Aad, AuthTag, CipherText, KdfSalt, WrappedVek};
 pub use header::{VaultHeader, VaultHeaderEncrypted, VaultHeaderPlaintext};
 pub use id::RecordId;
 pub use nonce::{NonceBytes, NonceCounter};
@@ -16,8 +16,8 @@ pub use protection_mode::ProtectionMode;
 pub use record::{Record, RecordKind, RecordLabel, RecordPayload, RecordPayloadEncrypted};
 pub use version::VaultVersion;
 
+use crate::crypto::Vek;
 use crate::error::{DomainError, VaultConsistencyReason};
-use crate::secret::SecretBytes;
 
 // -------------------------------------------------------------------
 // VekProvider trait
@@ -27,36 +27,36 @@ use crate::secret::SecretBytes;
 ///
 /// 実装は `shikomi-infra` に置く（Dependency Inversion）。
 /// `shikomi-core` はこの trait シグネチャのみを所有し、暗号実装に依存しない。
+///
+/// Sub-A 改訂 (Boy Scout Rule): 引数型 `&SecretBytes` を `&Vek` に置換。
+/// `Vek` は Clone 禁止のため、`reencrypt_all` は `&mut self, records` のみを取り、
+/// 内部で `self.new_vek()` を呼び出して新 VEK を参照する責務を負う
+/// (借用衝突回避。Sub-B で具象実装を新設する際の前提)。
 pub trait VekProvider {
     /// プロバイダが保持する新 VEK への参照を返す。
-    ///
-    /// `Vault::rekey_with` が呼び出し元（`shikomi-infra`）の提供する VEK を受け取るために使う。
-    fn new_vek(&self) -> &SecretBytes;
+    fn new_vek(&self) -> &Vek;
 
     /// 全レコードを新 VEK で再暗号化する（in-place）。
     ///
+    /// 実装は内部で `self.new_vek()` を呼び出して新 VEK を参照する。
     /// 部分失敗した場合は `DomainError::VaultConsistencyError(RekeyPartialFailure)` を返す。
     /// 呼び出し元は `SQLite` トランザクションでアトミック更新を保証すること。
     ///
     /// # Errors
     /// 再暗号化失敗時に `DomainError` を返す。
-    fn reencrypt_all(
-        &mut self,
-        records: &mut [Record],
-        new_vek: &SecretBytes,
-    ) -> Result<(), DomainError>;
+    fn reencrypt_all(&mut self, records: &mut [Record]) -> Result<(), DomainError>;
 
     /// 新 VEK をパスワード由来の KEK でラップした `WrappedVek` を返す。
     ///
     /// # Errors
     /// KDF / 暗号化失敗時に `DomainError` を返す。
-    fn derive_new_wrapped_pw(&self, vek: &SecretBytes) -> Result<WrappedVek, DomainError>;
+    fn derive_new_wrapped_pw(&self, vek: &Vek) -> Result<WrappedVek, DomainError>;
 
     /// 新 VEK をリカバリ由来の KEK でラップした `WrappedVek` を返す。
     ///
     /// # Errors
     /// KDF / 暗号化失敗時に `DomainError` を返す。
-    fn derive_new_wrapped_recovery(&self, vek: &SecretBytes) -> Result<WrappedVek, DomainError>;
+    fn derive_new_wrapped_recovery(&self, vek: &Vek) -> Result<WrappedVek, DomainError>;
 }
 
 // -------------------------------------------------------------------
@@ -207,12 +207,11 @@ impl Vault {
             ));
         }
 
-        // VEK を provider から取得（clone で借用競合を回避）
-        let new_vek: SecretBytes = provider.new_vek().clone();
-
-        let new_wrapped_pw = provider.derive_new_wrapped_pw(&new_vek)?;
-        let new_wrapped_recovery = provider.derive_new_wrapped_recovery(&new_vek)?;
-        provider.reencrypt_all(&mut self.records, &new_vek)?;
+        // Vek は Clone 禁止 (Sub-A 契約 C-2)。`new_vek()` の参照を順次の借用で消費する。
+        // derive_new_wrapped_* は &self、reencrypt_all は &mut self を取るため借用衝突しない。
+        let new_wrapped_pw = provider.derive_new_wrapped_pw(provider.new_vek())?;
+        let new_wrapped_recovery = provider.derive_new_wrapped_recovery(provider.new_vek())?;
+        provider.reencrypt_all(&mut self.records)?;
 
         // ヘッダの wrapped VEK を更新
         if let VaultHeader::Encrypted(ref mut enc) = self.header {

--- a/crates/shikomi-core/src/vault/nonce.rs
+++ b/crates/shikomi-core/src/vault/nonce.rs
@@ -1,29 +1,51 @@
-//! nonce 管理（NonceBytes / `NonceCounter`）。
+//! nonce 管理 — `NonceBytes` (96 bit per-record nonce) と `NonceCounter` (暗号化回数監視)。
 //!
-//! AES-256-GCM の 96-bit IV は「8B CSPRNG prefix + 4B u32 counter (big-endian)」で構成する。
-//! `NonceCounter` は pure Rust / no-I/O：乱数 prefix は構築時に呼び出し側が供給する。
+//! Sub-A 凍結 (`docs/features/vault-encryption/detailed-design/nonce-and-aead.md`):
+//!
+//! - `NonceBytes` (12 byte): per-record AEAD nonce。**完全 random 12B** が CSPRNG 由来で
+//!   呼び出し側 (`shikomi-infra::crypto::Rng`) から `[u8; 12]` として供給される。
+//!   `from_random([u8; 12])` で構築 (失敗しない、型レベルで長さ強制 = 契約 C-10)。
+//!   既存 `try_new(&[u8])` は永続化からの復元用に維持する。
+//!
+//! - `NonceCounter`: 「**この VEK で何回暗号化したか**」を u64 で数える単独カウンタ。
+//!   nonce 値生成には**関与しない**。上限 `1u64 << 32` (NIST SP 800-38D §8.3 random nonce
+//!   birthday bound)。`increment` で加算 → 上限到達で `Err(NonceLimitExceeded)` (契約 C-9)。
+//!
+//! Boy Scout Rule: 旧 `next() -> NonceBytes` API は削除。旧 `random_prefix: [u8; 8]`
+//! フィールドも削除 (random nonce 採用で prefix 共有不要)。
 
 use crate::error::{DomainError, InvalidRecordPayloadReason};
 
-/// `NonceBytes` の固定長（NIST SP 800-38D §5.2.1.1、96 bit）。
+/// `NonceBytes` の固定長 (NIST SP 800-38D §5.2.1.1、96 bit)。
 const NONCE_LEN: usize = 12;
-/// CSPRNG prefix の長さ。
-const PREFIX_LEN: usize = 8;
 
 // -------------------------------------------------------------------
 // NonceBytes
 // -------------------------------------------------------------------
 
-/// AES-256-GCM の nonce（96 bit = 12 byte）。
+/// AES-256-GCM の per-record nonce (96 bit = 12 byte)。
 ///
-/// レイアウト: `[0..8]` = CSPRNG prefix、`[8..12]` = u32 counter (big-endian)。
+/// Sub-0 凍結: random nonce 戦略 (NIST SP 800-38D §8.3 birthday bound)。
+/// `shikomi-infra::crypto::Rng::generate_nonce_bytes()` が CSPRNG から `[u8; 12]` を
+/// 取得して `from_random` に渡す。`shikomi-core` 側は CSPRNG を呼ばない (no-I/O 制約)。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NonceBytes {
     inner: [u8; NONCE_LEN],
 }
 
 impl NonceBytes {
-    /// バイトスライスから `NonceBytes` を構築する。
+    /// CSPRNG 由来の 12 byte 配列から `NonceBytes` を構築する (契約 C-10)。
+    ///
+    /// 引数が `[u8; 12]` のため**型レベルで長さが強制され失敗しない**。
+    /// `from_random` という関数名で「これは CSPRNG 由来である」という呼出側契約を明示する
+    /// (ad-hoc な `[0u8; 12]` 等の決定論値構築はテスト用途以外で禁止、
+    /// CI grep ルールは Sub-B / Sub-D で確定)。
+    #[must_use]
+    pub fn from_random(bytes: [u8; NONCE_LEN]) -> Self {
+        Self { inner: bytes }
+    }
+
+    /// バイトスライスから `NonceBytes` を構築する (永続化からの復元用)。
     ///
     /// # Errors
     /// `bytes.len() != 12` の場合 `DomainError::InvalidRecordPayload(NonceLength)` を返す。
@@ -52,63 +74,55 @@ impl NonceBytes {
 // NonceCounter
 // -------------------------------------------------------------------
 
-/// nonce を単調増加カウンタで管理する。
+/// 「この VEK での暗号化回数」を u64 で数える単独カウンタ。
 ///
-/// nonce = `random_prefix` (8B) ‖ `counter` (4B big-endian)。
-/// カウンタが `u32::MAX` に達した次の `next()` 呼び出しで
-/// `DomainError::NonceOverflow` を返し rekey を強制する。
-///
-/// 乱数生成は `shikomi-core` の責務外（pure Rust / no-I/O）。
-/// `random_prefix` は呼び出し側（`shikomi-infra`）が OS CSPRNG から供給する。
+/// nonce 値生成には**関与しない** (Sub-A 凍結で責務再定義、Boy Scout Rule)。
+/// 上限到達で `increment` が `Err(NonceLimitExceeded)` を返し、呼出側は
+/// `vault rekey` フロー (Sub-F) を起動する責務を負う (契約 C-9)。
+#[derive(Debug)]
 pub struct NonceCounter {
-    counter: u32,
-    random_prefix: [u8; PREFIX_LEN],
+    count: u64,
 }
 
 impl NonceCounter {
+    /// 上限値 (NIST SP 800-38D §8.3 random nonce birthday bound = `2^32`)。
+    pub const LIMIT: u64 = 1u64 << 32;
+
     /// カウンタを 0 から開始する新規 `NonceCounter` を生成する。
-    ///
-    /// `random_prefix` は 8 バイトの CSPRNG 乱数。
     #[must_use]
-    pub fn new(random_prefix: [u8; PREFIX_LEN]) -> Self {
-        Self {
-            counter: 0,
-            random_prefix,
-        }
+    pub fn new() -> Self {
+        Self { count: 0 }
     }
 
-    /// 永続化したカウンタ値から `NonceCounter` を再開する。
-    ///
-    /// vault をロードして nonce を引き継ぐ際に使用する。
+    /// 永続化したカウンタ値から `NonceCounter` を再開する (vault unlock 時)。
     #[must_use]
-    pub fn resume(random_prefix: [u8; PREFIX_LEN], counter: u32) -> Self {
-        Self {
-            counter,
-            random_prefix,
-        }
+    pub fn resume(count: u64) -> Self {
+        Self { count }
     }
 
-    /// 現在のカウンタ値から `NonceBytes` を生成し、カウンタをインクリメントする。
+    /// 暗号化 1 回ごとに呼び出して加算する (契約 C-9)。
     ///
     /// # Errors
-    /// カウンタが `u32::MAX` の場合 `DomainError::NonceOverflow` を返す。
-    /// この状態では vault の rekey が必要（NIST SP 800-38D §8.3 準拠）。
-    #[allow(clippy::should_implement_trait)] // 設計で `next()` と命名されており、Iterator は不適切
-    pub fn next(&mut self) -> Result<NonceBytes, DomainError> {
-        if self.counter == u32::MAX {
-            return Err(DomainError::NonceOverflow);
+    /// `count >= LIMIT` の場合 `DomainError::NonceLimitExceeded` を返し、加算しない。
+    /// この状態では vault の `rekey` が必要。
+    pub fn increment(&mut self) -> Result<(), DomainError> {
+        if self.count >= Self::LIMIT {
+            return Err(DomainError::NonceLimitExceeded);
         }
-        let mut bytes = [0u8; NONCE_LEN];
-        bytes[..PREFIX_LEN].copy_from_slice(&self.random_prefix);
-        bytes[PREFIX_LEN..].copy_from_slice(&self.counter.to_be_bytes());
-        self.counter += 1;
-        Ok(NonceBytes { inner: bytes })
+        self.count += 1;
+        Ok(())
     }
 
-    /// 現在のカウンタ値を返す（永続化用）。
+    /// 現在のカウント値を返す (永続化用)。
     #[must_use]
-    pub fn current_counter(&self) -> u32 {
-        self.counter
+    pub fn current(&self) -> u64 {
+        self.count
+    }
+}
+
+impl Default for NonceCounter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -116,73 +130,86 @@ impl NonceCounter {
 mod tests {
     use super::*;
 
+    // -----------------------------------------------------------------
+    // NonceBytes
+    // -----------------------------------------------------------------
+
     #[test]
-    fn test_nonce_counter_new_starts_at_zero() {
-        let counter = NonceCounter::new([0u8; 8]);
-        assert_eq!(counter.current_counter(), 0u32);
+    fn nonce_bytes_from_random_constructs_without_panic() {
+        let _ = NonceBytes::from_random([0u8; NONCE_LEN]);
     }
 
     #[test]
-    fn test_nonce_counter_next_returns_12_byte_nonce() {
-        let mut counter = NonceCounter::new([0u8; 8]);
-        let nonce = counter.next().unwrap();
-        assert_eq!(nonce.as_array().len(), 12);
+    fn nonce_bytes_from_random_preserves_input_bytes() {
+        let bytes = [0xABu8; NONCE_LEN];
+        let n = NonceBytes::from_random(bytes);
+        assert_eq!(n.as_array(), &bytes);
     }
 
     #[test]
-    fn test_nonce_counter_current_counter_increments_after_next() {
-        let mut counter = NonceCounter::new([0u8; 8]);
-        counter.next().unwrap();
-        assert_eq!(counter.current_counter(), 1u32);
+    fn nonce_bytes_try_new_with_12_bytes_ok() {
+        assert!(NonceBytes::try_new(&[0u8; NONCE_LEN]).is_ok());
     }
 
     #[test]
-    fn test_nonce_counter_resume_starts_at_given_counter() {
-        let counter = NonceCounter::resume([0u8; 8], 42);
-        assert_eq!(counter.current_counter(), 42u32);
+    fn nonce_bytes_try_new_with_wrong_length_returns_nonce_length_error() {
+        let err = NonceBytes::try_new(&[0u8; 11]).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::InvalidRecordPayload(InvalidRecordPayloadReason::NonceLength {
+                expected: 12,
+                got: 11,
+            })
+        ));
+    }
+
+    // -----------------------------------------------------------------
+    // NonceCounter (C-9)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn nonce_counter_new_starts_at_zero() {
+        let c = NonceCounter::new();
+        assert_eq!(c.current(), 0);
     }
 
     #[test]
-    fn test_nonce_counter_next_at_max_minus_one_succeeds() {
-        let mut counter = NonceCounter::resume([0u8; 8], u32::MAX - 1);
-        assert!(counter.next().is_ok());
+    fn nonce_counter_resume_starts_at_given_value() {
+        let c = NonceCounter::resume(42);
+        assert_eq!(c.current(), 42);
     }
 
     #[test]
-    fn test_nonce_counter_next_at_max_returns_nonce_overflow() {
-        let mut counter = NonceCounter::resume([0u8; 8], u32::MAX);
-        let err = counter.next().unwrap_err();
-        assert!(matches!(err, DomainError::NonceOverflow));
+    fn nonce_counter_increment_advances_by_one() {
+        let mut c = NonceCounter::new();
+        c.increment().unwrap();
+        assert_eq!(c.current(), 1);
     }
 
     #[test]
-    fn test_nonce_counter_next_prefix_bytes_match_random_prefix() {
-        let prefix = [0xABu8; 8];
-        let mut counter = NonceCounter::new(prefix);
-        let nonce = counter.next().unwrap();
-        assert_eq!(&nonce.as_array()[0..8], &prefix);
+    fn nonce_counter_limit_constant_is_2_pow_32() {
+        assert_eq!(NonceCounter::LIMIT, 1u64 << 32);
     }
 
     #[test]
-    fn test_nonce_counter_next_counter_bytes_are_big_endian() {
-        let mut counter = NonceCounter::new([0u8; 8]);
-        let n1 = counter.next().unwrap();
-        let n2 = counter.next().unwrap();
-        let n3 = counter.next().unwrap();
-        assert_eq!(
-            &n1.as_array()[8..12],
-            &[0x00u8, 0x00, 0x00, 0x00],
-            "1st: counter=0"
-        );
-        assert_eq!(
-            &n2.as_array()[8..12],
-            &[0x00u8, 0x00, 0x00, 0x01],
-            "2nd: counter=1"
-        );
-        assert_eq!(
-            &n3.as_array()[8..12],
-            &[0x00u8, 0x00, 0x00, 0x02],
-            "3rd: counter=2"
-        );
+    fn nonce_counter_increment_just_below_limit_succeeds() {
+        let mut c = NonceCounter::resume(NonceCounter::LIMIT - 1);
+        assert!(c.increment().is_ok());
+        assert_eq!(c.current(), NonceCounter::LIMIT);
+    }
+
+    #[test]
+    fn nonce_counter_increment_at_limit_returns_nonce_limit_exceeded() {
+        let mut c = NonceCounter::resume(NonceCounter::LIMIT);
+        let err = c.increment().unwrap_err();
+        assert!(matches!(err, DomainError::NonceLimitExceeded));
+        // 加算されないこと
+        assert_eq!(c.current(), NonceCounter::LIMIT);
+    }
+
+    #[test]
+    fn nonce_counter_default_starts_at_zero() {
+        let c = NonceCounter::default();
+        assert_eq!(c.current(), 0);
     }
 }

--- a/crates/shikomi-core/src/vault/tests.rs
+++ b/crates/shikomi-core/src/vault/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
+use crate::crypto::Vek;
 use crate::error::{DomainError, VaultConsistencyReason};
-use crate::secret::{SecretBytes, SecretString};
-use crate::vault::crypto_data::{Aad, CipherText, KdfSalt, WrappedVek};
+use crate::secret::SecretString;
+use crate::vault::crypto_data::{Aad, AuthTag, CipherText, KdfSalt, WrappedVek};
 use crate::vault::id::RecordId;
 use crate::vault::nonce::NonceBytes;
 use crate::vault::record::{
@@ -16,15 +17,23 @@ fn make_plaintext_header() -> VaultHeader {
     VaultHeader::new_plaintext(VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).unwrap()
 }
 
+fn make_wrapped_vek() -> WrappedVek {
+    WrappedVek::new(
+        vec![0u8; 32],
+        NonceBytes::from_random([0u8; 12]),
+        AuthTag::from_array([0u8; 16]),
+    )
+    .unwrap()
+}
+
 fn make_encrypted_header() -> VaultHeader {
     let salt = KdfSalt::try_new(&[0u8; 16]).unwrap();
-    let wrapped = WrappedVek::try_new(vec![0u8; 48].into_boxed_slice()).unwrap();
     VaultHeader::new_encrypted(
         VaultVersion::CURRENT,
         OffsetDateTime::UNIX_EPOCH,
         salt,
-        wrapped.clone(),
-        wrapped,
+        make_wrapped_vek(),
+        make_wrapped_vek(),
     )
     .unwrap()
 }
@@ -66,7 +75,7 @@ fn make_encrypted_record(id: Option<RecordId>) -> Record {
 // DummyVekProvider for rekey tests
 struct DummyVekProvider {
     should_fail: bool,
-    vek: SecretBytes,
+    vek: Vek,
     wrapped: WrappedVek,
 }
 
@@ -74,22 +83,18 @@ impl DummyVekProvider {
     fn new(should_fail: bool) -> Self {
         Self {
             should_fail,
-            vek: SecretBytes::from_boxed_slice(vec![0u8; 32].into_boxed_slice()),
-            wrapped: WrappedVek::try_new(vec![0u8; 48].into_boxed_slice()).unwrap(),
+            vek: Vek::from_array([0u8; 32]),
+            wrapped: make_wrapped_vek(),
         }
     }
 }
 
 impl VekProvider for DummyVekProvider {
-    fn new_vek(&self) -> &SecretBytes {
+    fn new_vek(&self) -> &Vek {
         &self.vek
     }
 
-    fn reencrypt_all(
-        &mut self,
-        _records: &mut [Record],
-        _new_vek: &SecretBytes,
-    ) -> Result<(), DomainError> {
+    fn reencrypt_all(&mut self, _records: &mut [Record]) -> Result<(), DomainError> {
         if self.should_fail {
             Err(DomainError::VaultConsistencyError(
                 VaultConsistencyReason::RekeyPartialFailure,
@@ -99,7 +104,7 @@ impl VekProvider for DummyVekProvider {
         }
     }
 
-    fn derive_new_wrapped_pw(&self, _vek: &SecretBytes) -> Result<WrappedVek, DomainError> {
+    fn derive_new_wrapped_pw(&self, _vek: &Vek) -> Result<WrappedVek, DomainError> {
         if self.should_fail {
             Err(DomainError::VaultConsistencyError(
                 VaultConsistencyReason::RekeyPartialFailure,
@@ -109,7 +114,7 @@ impl VekProvider for DummyVekProvider {
         }
     }
 
-    fn derive_new_wrapped_recovery(&self, _vek: &SecretBytes) -> Result<WrappedVek, DomainError> {
+    fn derive_new_wrapped_recovery(&self, _vek: &Vek) -> Result<WrappedVek, DomainError> {
         if self.should_fail {
             Err(DomainError::VaultConsistencyError(
                 VaultConsistencyReason::RekeyPartialFailure,

--- a/crates/shikomi-core/tests/nonce_overflow.rs
+++ b/crates/shikomi-core/tests/nonce_overflow.rs
@@ -1,25 +1,32 @@
-//! 結合テスト: `NonceCounter` オーバーフロー検知（TC-I05）
-//! REQ-010 / AC-05, AC-06
+//! 結合テスト: `NonceCounter` 上限到達検知 (TC-I05)
+//!
+//! Sub-A 凍結後の API:
+//! - `NonceCounter::resume(count: u64) -> Self`
+//! - `NonceCounter::increment(&mut self) -> Result<(), DomainError>`
+//! - 上限 `NonceCounter::LIMIT = 1u64 << 32` (NIST SP 800-38D §8.3 random nonce birthday bound)
 
 use shikomi_core::{DomainError, NonceCounter};
 
-/// TC-I05: `NonceCounter` が `u32::MAX` 到達で `NonceOverflow` を返す
+/// TC-I05: `NonceCounter` が `LIMIT` 到達で `NonceLimitExceeded` を返す。
 #[test]
-fn test_nonce_counter_overflow_at_max_from_public_api() {
-    let mut counter = NonceCounter::resume([0u8; 8], u32::MAX);
-    let err = counter.next().unwrap_err();
+fn test_nonce_counter_increment_at_limit_returns_nonce_limit_exceeded_from_public_api() {
+    let mut counter = NonceCounter::resume(NonceCounter::LIMIT);
+    let err = counter.increment().unwrap_err();
     assert!(
-        matches!(err, DomainError::NonceOverflow),
-        "Expected NonceOverflow, got: {err:?}"
+        matches!(err, DomainError::NonceLimitExceeded),
+        "Expected NonceLimitExceeded, got: {err:?}"
     );
+    // 加算されないこと (Fail Fast: 失敗時は状態不変)
+    assert_eq!(counter.current(), NonceCounter::LIMIT);
 }
 
-/// TC-I05 補足: `u32::MAX` - 1 では成功する（境界値直前）
+/// TC-I05 補足: `LIMIT - 1` では成功し、`current()` が `LIMIT` に到達する。
 #[test]
-fn test_nonce_counter_next_at_max_minus_one_succeeds_from_public_api() {
-    let mut counter = NonceCounter::resume([0u8; 8], u32::MAX - 1);
+fn test_nonce_counter_increment_at_limit_minus_one_succeeds_from_public_api() {
+    let mut counter = NonceCounter::resume(NonceCounter::LIMIT - 1);
     assert!(
-        counter.next().is_ok(),
-        "next() at u32::MAX - 1 must succeed"
+        counter.increment().is_ok(),
+        "increment() at LIMIT - 1 must succeed"
     );
+    assert_eq!(counter.current(), NonceCounter::LIMIT);
 }

--- a/crates/shikomi-infra/src/persistence/sqlite/mapping/header.rs
+++ b/crates/shikomi-infra/src/persistence/sqlite/mapping/header.rs
@@ -1,13 +1,23 @@
 //! `VaultHeader` ↔ `SQLite` 行のマッピング。
+//!
+//! Sub-A 改訂: `WrappedVek` の内部構造分離型化に伴い、暗号化ヘッダの BLOB シリアライズ
+//! 形式は **Sub-D で `bincode` 等の正式フォーマットに確定する**。
+//! Sub-A 〜 Sub-C 期間中、暗号化ヘッダの永続化は型レベルで未実装とし、本マッピング層は
+//! `UnsupportedYet { feature: "encrypted vault header (Sub-D)" }` を即返す。
+//! `repository::save_inner` / `repository::load` も Encrypted モードを Fail Fast で
+//! 弾いており、本層は二重防御として動作する。
 
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
-use shikomi_core::{KdfSalt, ProtectionMode, VaultHeader, VaultVersion, WrappedVek};
+use shikomi_core::{ProtectionMode, VaultHeader, VaultVersion};
 
 use crate::persistence::error::{CorruptedReason, PersistenceError};
 
 use super::{params::HeaderParams, Mapping};
+
+/// Sub-D で実装予定の暗号化ヘッダ永続化の追跡 Issue 番号 (Epic #37 / Sub-D #42)。
+const TRACKING_ISSUE_ENCRYPTED_HEADER: Option<u32> = Some(42);
 
 impl Mapping {
     /// `VaultHeader` → `HeaderParams` に変換する。
@@ -15,6 +25,8 @@ impl Mapping {
     /// # Errors
     ///
     /// - `created_at` の RFC3339 フォーマット失敗: `PersistenceError::Corrupted`
+    /// - 暗号化モードヘッダ: `PersistenceError::UnsupportedYet`
+    ///   (Sub-D で `WrappedVek` の正式 BLOB シリアライザを実装するまで未対応)
     pub(crate) fn vault_header_to_params(
         header: &VaultHeader,
     ) -> Result<HeaderParams, PersistenceError> {
@@ -42,21 +54,10 @@ impl Mapping {
                 wrapped_vek_by_pw: None,
                 wrapped_vek_by_recovery: None,
             }),
-            ProtectionMode::Encrypted => {
-                let kdf_salt = header.kdf_salt().map(|s| s.as_array().to_vec());
-                let wrapped_vek_by_pw = header.wrapped_vek_by_pw().map(|w| w.as_bytes().to_vec());
-                let wrapped_vek_by_recovery = header
-                    .wrapped_vek_by_recovery()
-                    .map(|w| w.as_bytes().to_vec());
-                Ok(HeaderParams {
-                    protection_mode,
-                    vault_version,
-                    created_at_rfc3339,
-                    kdf_salt,
-                    wrapped_vek_by_pw,
-                    wrapped_vek_by_recovery,
-                })
-            }
+            ProtectionMode::Encrypted => Err(PersistenceError::UnsupportedYet {
+                feature: "encrypted vault header (Sub-D)",
+                tracking_issue: TRACKING_ISSUE_ENCRYPTED_HEADER,
+            }),
         }
     }
 
@@ -67,8 +68,8 @@ impl Mapping {
     /// - 保護モード不明: `PersistenceError::Corrupted`
     /// - vault バージョン範囲外: `PersistenceError::Corrupted`
     /// - RFC3339 パース失敗: `PersistenceError::Corrupted`
-    /// - 暗号化フィールドが NULL: `PersistenceError::Corrupted`
-    /// - ドメイン型の構築失敗: `PersistenceError::Corrupted`
+    /// - 暗号化モード行: `PersistenceError::UnsupportedYet`
+    ///   (Sub-D で `WrappedVek` の正式 BLOB デシリアライザを実装するまで未対応)
     pub(crate) fn row_to_vault_header(
         row: &rusqlite::Row<'_>,
     ) -> Result<VaultHeader, PersistenceError> {
@@ -135,89 +136,10 @@ impl Mapping {
                     },
                     source: Some(e),
                 }),
-            ProtectionMode::Encrypted => {
-                // Col 3: kdf_salt (BLOB)
-                let kdf_salt_raw: Option<Vec<u8>> = row
-                    .get(3)
-                    .map_err(|e| PersistenceError::Sqlite { source: e })?;
-                let kdf_salt_bytes = kdf_salt_raw.ok_or_else(|| PersistenceError::Corrupted {
-                    table: "vault_header",
-                    row_key: Some("1".to_string()),
-                    reason: CorruptedReason::NullViolation { column: "kdf_salt" },
-                    source: None,
-                })?;
-                let kdf_salt =
-                    KdfSalt::try_new(&kdf_salt_bytes).map_err(|e| PersistenceError::Corrupted {
-                        table: "vault_header",
-                        row_key: Some("1".to_string()),
-                        reason: CorruptedReason::InvalidRowCombination {
-                            detail: e.to_string(),
-                        },
-                        source: Some(e),
-                    })?;
-
-                // Col 4: wrapped_vek_by_pw (BLOB)
-                let pw_raw: Option<Vec<u8>> = row
-                    .get(4)
-                    .map_err(|e| PersistenceError::Sqlite { source: e })?;
-                let pw_bytes = pw_raw.ok_or_else(|| PersistenceError::Corrupted {
-                    table: "vault_header",
-                    row_key: Some("1".to_string()),
-                    reason: CorruptedReason::NullViolation {
-                        column: "wrapped_vek_by_pw",
-                    },
-                    source: None,
-                })?;
-                let wrapped_vek_by_pw =
-                    WrappedVek::try_new(pw_bytes.into_boxed_slice()).map_err(|e| {
-                        PersistenceError::Corrupted {
-                            table: "vault_header",
-                            row_key: Some("1".to_string()),
-                            reason: CorruptedReason::InvalidRowCombination {
-                                detail: e.to_string(),
-                            },
-                            source: Some(e),
-                        }
-                    })?;
-
-                // Col 5: wrapped_vek_by_recovery (BLOB)
-                let rec_raw: Option<Vec<u8>> = row
-                    .get(5)
-                    .map_err(|e| PersistenceError::Sqlite { source: e })?;
-                let rec_bytes = rec_raw.ok_or_else(|| PersistenceError::Corrupted {
-                    table: "vault_header",
-                    row_key: Some("1".to_string()),
-                    reason: CorruptedReason::NullViolation {
-                        column: "wrapped_vek_by_recovery",
-                    },
-                    source: None,
-                })?;
-                let wrapped_vek_by_recovery = WrappedVek::try_new(rec_bytes.into_boxed_slice())
-                    .map_err(|e| PersistenceError::Corrupted {
-                        table: "vault_header",
-                        row_key: Some("1".to_string()),
-                        reason: CorruptedReason::InvalidRowCombination {
-                            detail: e.to_string(),
-                        },
-                        source: Some(e),
-                    })?;
-
-                VaultHeader::new_encrypted(
-                    vault_version,
-                    created_at,
-                    kdf_salt,
-                    wrapped_vek_by_pw,
-                    wrapped_vek_by_recovery,
-                )
-                .map_err(|e| PersistenceError::Corrupted {
-                    table: "vault_header",
-                    row_key: Some("1".to_string()),
-                    reason: CorruptedReason::InvalidRowCombination {
-                        detail: e.to_string(),
-                    },
-                    source: Some(e),
-                })
-            }
+            ProtectionMode::Encrypted => Err(PersistenceError::UnsupportedYet {
+                feature: "encrypted vault header (Sub-D)",
+                tracking_issue: TRACKING_ISSUE_ENCRYPTED_HEADER,
+            }),
         }
     }
 }

--- a/crates/shikomi-infra/tests/integration_error.rs
+++ b/crates/shikomi-infra/tests/integration_error.rs
@@ -2,7 +2,7 @@
 //! 異常系・エラーハンドリング
 mod helpers;
 use helpers::{make_plaintext_vault, make_repo};
-use shikomi_core::{KdfSalt, Vault, VaultHeader, VaultVersion, WrappedVek};
+use shikomi_core::{AuthTag, KdfSalt, NonceBytes, Vault, VaultHeader, VaultVersion, WrappedVek};
 use shikomi_infra::persistence::{PersistenceError, VaultRepository};
 use tempfile::TempDir;
 use time::OffsetDateTime;
@@ -10,6 +10,18 @@ use time::OffsetDateTime;
 // ---------------------------------------------------------------------------
 // TC-I03: 暗号化モード vault を save → UnsupportedYet
 // ---------------------------------------------------------------------------
+
+fn make_dummy_wrapped_vek() -> WrappedVek {
+    // Sub-A 凍結後の WrappedVek は ciphertext + nonce + tag の 3 フィールド構造。
+    // 暗号化モード永続化は Sub-D で確定するため、本テストは構造の妥当な dummy 値で
+    // VaultHeader::new_encrypted を構築できることのみ確認する。
+    WrappedVek::new(
+        vec![0u8; 32],
+        NonceBytes::from_random([0u8; 12]),
+        AuthTag::from_array([0u8; 16]),
+    )
+    .unwrap()
+}
 
 /// TC-I03 — 暗号化モード vault を save すると `UnsupportedYet` が返る。
 ///
@@ -20,14 +32,12 @@ fn tc_i03_encrypted_vault_save_unsupported() {
     let repo = make_repo(dir.path());
 
     let kdf_salt = KdfSalt::try_new(&[0u8; 16]).unwrap();
-    let wrapped_pw = WrappedVek::try_new(vec![0u8; 48].into_boxed_slice()).unwrap();
-    let wrapped_rec = WrappedVek::try_new(vec![0u8; 48].into_boxed_slice()).unwrap();
     let header = VaultHeader::new_encrypted(
         VaultVersion::CURRENT,
         OffsetDateTime::now_utc(),
         kdf_salt,
-        wrapped_pw,
-        wrapped_rec,
+        make_dummy_wrapped_vek(),
+        make_dummy_wrapped_vek(),
     )
     .unwrap();
     let vault = Vault::new(header);


### PR DESCRIPTION
## Summary

Sub-A 工程3（実装）— Issue #39 の Sub-A 設計書（PR #45/#46/#47/#48 で凍結）に従い、
`shikomi-core::crypto` 配下に暗号ドメイン型 12 種 + `PasswordStrengthGate` trait
+ `CryptoOutcome<T>` / `CryptoError` を新規実装し、契約 C-1〜C-13 を網羅。

### 新規追加 (`crates/shikomi-core/src/crypto/`)

- **`key.rs`**: `Vek` / `Kek<KekKindPw>` / `Kek<KekKindRecovery>` + Sealed `KekKind` trait
- **`header_aead.rs`**: `HeaderAeadKey`（`from_kek_pw` のみ — Sub-0 凍結の鍵経路を型レベル明示）
- **`password.rs`**: `MasterPassword` / `PasswordStrengthGate`（dyn-safe trait、impl は Sub-D）/ `WeakPasswordFeedback`（`warning=None` フォールバック契約 + i18n は Sub-D）
- **`recovery.rs`**: `RecoveryMnemonic`（24 語固定、`Clone` 禁止 = REQ-S13 単回表示契約）
- **`verified.rs`**: `Plaintext`（`pub(in crate::crypto::verified)` 限定）/ `Verified<T>`（`pub(crate)` caller-asserted marker）/ `verify_aead_decrypt` クロージャ wrapper / `CryptoOutcome<T>`（`#[non_exhaustive]`、失敗バリアント先頭）

### 既存改訂（Boy Scout Rule）

- **`error.rs`**: `NonceOverflow` → `NonceLimitExceeded` rename（Sub-0 凍結文言）/ `Crypto(CryptoError)` 透過 variant 追加 / `CryptoError` + `KdfErrorKind` 新規 / `InvalidVaultHeaderReason::AuthTagLength` 追加
- **`vault/nonce.rs`**: `NonceCounter` 責務再定義（u64 暗号化回数監視、`LIMIT = 1u64 << 32`、`increment()`）。旧 `next()` / `random_prefix` 削除。`NonceBytes::from_random([u8; 12])` 追加
- **`vault/crypto_data.rs`**: `WrappedVek` を `(ciphertext, nonce, tag)` の 3 フィールドに分離。`AuthTag`（16B AES-GCM 認証タグ）新規型
- **`vault/mod.rs`**: `VekProvider` の引数型 `&SecretBytes` → `&Vek` 置換。`reencrypt_all` の `vek` 引数を削除（`Vek` Clone 禁止に伴う借用衝突回避、provider が内部で `self.new_vek()` を呼ぶ責務）。`Vault::rekey_with` ロジック調整

### 契約 C-1〜C-13 カバレッジ

| 契約 | 強制方法 |
|-----|--------|
| C-1 Drop zeroize | `SecretBox<Zeroizing<...>>` / `SecretBytes` 経由 |
| C-2 Clone 不可 | derive せず + `compile_fail` doc test |
| C-3 Debug `[REDACTED ...]` | 手書き `impl Debug` で固定文字列 + ユニットテストで戻り値検証 |
| C-4 Display 不可 | 未実装 + `compile_fail` doc test |
| C-5 Serialize 不可 | 未実装（`WeakPasswordFeedback` のみ IPC 用に implement） |
| C-6 Kek 混合不可 | phantom-typed + Sealed trait + `compile_fail` doc test |
| C-7 Verified 構築 `pub(crate)` | `Verified::new_from_aead_decrypt` 可視性 + `Plaintext::new_within_module` を `pub(in crate::crypto::verified)` で同一モジュール内に閉じる二段防御 |
| C-8 MasterPassword 強度ゲート | `MasterPassword::new(s, &dyn PasswordStrengthGate)` シグネチャ + `AlwaysAcceptGate` / `AlwaysRejectGate` テスト |
| C-9 NonceCounter 上限 | `if count >= LIMIT { Err(NonceLimitExceeded) }` + `LIMIT - 1` / `LIMIT` 境界値テスト |
| C-10 NonceBytes::from_random 失敗しない | 引数 `[u8; 12]` 型レベル長さ強制 |
| C-11 WrappedVek 境界条件 | `is_empty` / `len < 32` 分岐 + 境界値テスト |
| C-12 RecoveryMnemonic 24 語 | 引数 `[String; 24]` 型レベル長さ強制 |
| C-13 NonceOverflow → NonceLimitExceeded rename | grep / cargo check で variant 名統一 |

### Cross-crate 影響

- **`shikomi-infra/src/persistence/sqlite/mapping/header.rs`**: 暗号化 vault ヘッダの BLOB シリアライズフォーマットは Sub-D で確定するため、save/load パスで `UnsupportedYet { feature: "encrypted vault header (Sub-D)", tracking_issue: Some(42) }` を返却。`repository::save_inner` / `repository::load` も既に Encrypted モードを Fail Fast で弾いており、本層は二重防御。
- **`shikomi-infra/tests/integration_error.rs`**: TC-I03 setup が新 `WrappedVek::new(ciphertext, nonce, tag)` シェイプを使うよう調整。

### CI 依存に関する注記（透明性）

本サンドボックス環境に **C リンカ (`cc` / `gcc`) が無く** apt インストールも不可のため、
ローカルでの `cargo check` / `cargo build` / `cargo test` は実行できませんでした。
**CI が本ブランチで初回エンドツーエンドビルドを実施する形**になります。
ローカルでは `cargo fmt --all -- --check` (リンカ不要) のみ実行・通過済み。
CI 失敗時は速やかに修正コミットを追加します。

## Test plan

- [ ] CI: `lint` (cargo fmt --check + workspace clippy) が pass
- [ ] CI: `unit-core` (cargo test -p shikomi-core) が pass
- [ ] CI: `test-infra` / `test-infra-windows` (cargo test -p shikomi-infra) が pass
- [ ] CI: `audit` (cargo deny + secret 経路監査) が pass
- [ ] CI: `commit-msg-windows` / `pr-title-check` / `branch-policy` が pass

Closes #39