### PR TITLE
test(vault-encryption): execute Sub-C 26 TC + proptest 1000 cases (#41)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,42 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +67,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -224,6 +266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +304,43 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -330,6 +415,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +462,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -630,6 +764,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +905,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +929,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -969,6 +1142,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1210,18 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1250,6 +1447,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scc"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,9 +1657,11 @@ version = "0.1.0"
 name = "shikomi-infra"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "argon2",
  "bip39",
  "cfg-if",
+ "criterion",
  "dirs",
  "fs4",
  "getrandom 0.2.17",
@@ -1646,6 +1854,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,6 +2034,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +2086,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1971,6 +2209,15 @@ checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2404,7 +2651,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "fancy-regex",
- "itertools",
+ "itertools 0.14.0",
  "lazy_static",
  "regex",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,5 @@ zxcvbn          = { version = "3",    default-features = false, features = ["def
 # 単一 derive 時間を計測し、median を 750 ms (p95 ≤ 1.0 s の proxy) と比較する。
 # `bench-kdf` ワークフロー (`.github/workflows/bench-kdf.yml`) で 3 OS gating。
 criterion       = { version = "0.5", default-features = false }
+# Sub-C (#41) AEAD アダプタ。AES-256-GCM (RustCrypto)、tech-stack §4.7 凍結。
+aes-gcm         = { version = "0.10", default-features = false, features = ["alloc", "aes", "zeroize"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,8 @@ zxcvbn          = { version = "3",    default-features = false, features = ["def
 criterion       = { version = "0.5", default-features = false }
 # Sub-C (#41) AEAD アダプタ。AES-256-GCM (RustCrypto)、tech-stack §4.7 凍結。
 aes-gcm         = { version = "0.10", default-features = false, features = ["alloc", "aes", "zeroize"] }
+# Sub-C (#41) test-design TC-C-P01 / TC-C-P02 用 proptest。1000 ケースで
+# AAD 入れ替え検出 + encrypt/decrypt 往復不変条件を property 検証する。
+# Bug-C-001 顛末: 銀ちゃん impl は単発 fixture 検証のみで proptest 不在、
+# テスト工程でマユリが Boy Scout 補強として 1000 ケース proptest を追加。
+proptest        = { version = "1", default-features = false, features = ["std"] }

--- a/crates/shikomi-core/src/crypto/aead_key.rs
+++ b/crates/shikomi-core/src/crypto/aead_key.rs
@@ -1,0 +1,86 @@
+//! `AeadKey` trait — 鍵バイトをクロージャインジェクション経由で AEAD adapter に貸す。
+//!
+//! Sub-B Rev2 で凍結した「鍵バイト型は `pub(crate)` 維持」契約を破壊せず、
+//! shikomi-infra::crypto::aead から鍵バイトに借用越境する正規経路を提供する
+//! (verify_aead_decrypt の caller-asserted マーカーと完全同型思想)。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/nonce-and-aead.md` §`AeadKey` trait
+
+use crate::crypto::header_aead::HeaderAeadKey;
+use crate::crypto::key::{Kek, KekKindPw, KekKindRecovery, Vek};
+
+/// AEAD 鍵 (32B = 256bit) クロージャインジェクション trait。
+///
+/// **dyn-safe ではない** (`impl FnOnce<R>` のため `&dyn AeadKey` 不可)。これは意図的:
+/// trait オブジェクト化で attacker-readable 経路 + 最適化機会喪失を構造禁止する
+/// (`nonce-and-aead.md` §`AeadKey` trait 設計判断)。
+///
+/// 実装は `Vek` / `Kek<KekKindPw>` / `Kek<KekKindRecovery>` / `HeaderAeadKey`。
+/// いずれも内部 `expose_within_crate()` (`pub(crate)`) を `f` に渡すだけのワンライナー。
+pub trait AeadKey {
+    /// 鍵バイト 32B にクロージャ `f` を適用し、`f` の戻り値を返す。
+    ///
+    /// 鍵バイトは shikomi-core 側の `SecretBox<Zeroizing<[u8; 32]>>` 内に
+    /// 留まり、`f` 実行中のみ借用が貸し出される。`f` 実行後の bytes 借用は
+    /// 失効するが、鍵自体の zeroize は呼出元 `Self` の Drop で実施される
+    /// (本メソッド内では再 zeroize しない、性能劣化回避)。
+    fn with_secret_bytes<R>(&self, f: impl FnOnce(&[u8; 32]) -> R) -> R;
+}
+
+impl AeadKey for Vek {
+    fn with_secret_bytes<R>(&self, f: impl FnOnce(&[u8; 32]) -> R) -> R {
+        f(self.expose_within_crate())
+    }
+}
+
+impl AeadKey for Kek<KekKindPw> {
+    fn with_secret_bytes<R>(&self, f: impl FnOnce(&[u8; 32]) -> R) -> R {
+        f(self.expose_within_crate())
+    }
+}
+
+impl AeadKey for Kek<KekKindRecovery> {
+    fn with_secret_bytes<R>(&self, f: impl FnOnce(&[u8; 32]) -> R) -> R {
+        f(self.expose_within_crate())
+    }
+}
+
+impl AeadKey for HeaderAeadKey {
+    fn with_secret_bytes<R>(&self, f: impl FnOnce(&[u8; 32]) -> R) -> R {
+        f(self.expose_within_crate())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vek_with_secret_bytes_invokes_closure_with_32b_array() {
+        let v = Vek::from_array([0x42u8; 32]);
+        let captured = v.with_secret_bytes(|bytes| bytes[0]);
+        assert_eq!(captured, 0x42);
+    }
+
+    #[test]
+    fn kek_pw_with_secret_bytes_passes_underlying_bytes() {
+        let k = Kek::<KekKindPw>::from_array([0xABu8; 32]);
+        let sum: u32 = k.with_secret_bytes(|bytes| bytes.iter().map(|&b| u32::from(b)).sum());
+        assert_eq!(sum, 0xAB * 32);
+    }
+
+    #[test]
+    fn kek_recovery_with_secret_bytes_passes_underlying_bytes() {
+        let k = Kek::<KekKindRecovery>::from_array([0x77u8; 32]);
+        let v = k.with_secret_bytes(|bytes| bytes[31]);
+        assert_eq!(v, 0x77);
+    }
+
+    #[test]
+    fn header_aead_key_with_secret_bytes_passes_kek_pw_derived_bytes() {
+        let kek = Kek::<KekKindPw>::from_array([0x5Au8; 32]);
+        let h = HeaderAeadKey::from_kek_pw(&kek);
+        let v = h.with_secret_bytes(|bytes| bytes[0]);
+        assert_eq!(v, 0x5A);
+    }
+}

--- a/crates/shikomi-core/src/crypto/mod.rs
+++ b/crates/shikomi-core/src/crypto/mod.rs
@@ -6,14 +6,18 @@
 //!
 //! 設計書: `docs/features/vault-encryption/detailed-design/index.md`
 
+pub mod aead_key;
 pub mod header_aead;
 pub mod key;
 pub mod password;
 pub mod recovery;
 pub mod verified;
 
+pub use aead_key::AeadKey;
 pub use header_aead::HeaderAeadKey;
 pub use key::{Kek, KekKind, KekKindPw, KekKindRecovery, Vek};
 pub use password::{MasterPassword, PasswordStrengthGate, WeakPasswordFeedback};
 pub use recovery::RecoveryMnemonic;
-pub use verified::{verify_aead_decrypt, CryptoOutcome, Plaintext, Verified};
+pub use verified::{
+    verify_aead_decrypt, verify_aead_decrypt_to_plaintext, CryptoOutcome, Plaintext, Verified,
+};

--- a/crates/shikomi-core/src/crypto/verified.rs
+++ b/crates/shikomi-core/src/crypto/verified.rs
@@ -151,6 +151,34 @@ where
     decrypt_fn().map(Verified::new_from_aead_decrypt)
 }
 
+/// `verify_aead_decrypt` の `Plaintext` 特化版 (Sub-C 新規)。
+///
+/// shikomi-infra::crypto::aead::AesGcmAeadAdapter が AEAD 検証成功時にのみ呼ぶ
+/// 正規経路。`Plaintext::new_within_module` は `pub(in crate::crypto::verified)`
+/// 限定可視性のため shikomi-infra から直接構築不可だが、本関数経由で `Vec<u8>` を
+/// 渡せば AEAD 検証済み `Verified<Plaintext>` を取得できる。
+///
+/// 三段防御 (Sub-A 凍結):
+/// - 第一層 (型レベル): `Verified::new_from_aead_decrypt` が `pub(crate)` 限定
+/// - 第二層 (モジュール内): `Plaintext::new_within_module` が
+///   `pub(in crate::crypto::verified)` 限定
+/// - 第三層 (呼出側契約): 本関数のクロージャ内で AEAD 検証実行を契約宣言
+///   (Sub-C `AesGcmAeadAdapter::decrypt_record` / `unwrap_vek` が
+///   `decrypt_in_place_detached` でタグ検証成功時のみ本関数を呼ぶ)
+///
+/// # Errors
+///
+/// `decrypt_fn` が `Err(E)` を返した場合は `Err(E)` を伝播 (AEAD 検証失敗)。
+pub fn verify_aead_decrypt_to_plaintext<F, E>(decrypt_fn: F) -> Result<Verified<Plaintext>, E>
+where
+    F: FnOnce() -> Result<Vec<u8>, E>,
+{
+    let bytes = decrypt_fn()?;
+    Ok(Verified::new_from_aead_decrypt(
+        Plaintext::new_within_module(bytes),
+    ))
+}
+
 // -------------------------------------------------------------------
 // CryptoOutcome<T>
 // -------------------------------------------------------------------
@@ -240,6 +268,34 @@ mod tests {
     fn verify_aead_decrypt_propagates_err_from_closure() {
         let result: Result<Verified<u32>, &'static str> = verify_aead_decrypt(|| Err("boom"));
         assert_eq!(result.unwrap_err(), "boom");
+    }
+
+    // -----------------------------------------------------------------
+    // verify_aead_decrypt_to_plaintext (Sub-C 新規)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn verify_aead_decrypt_to_plaintext_wraps_ok_bytes_into_verified_plaintext() {
+        let result: Result<Verified<Plaintext>, ()> =
+            verify_aead_decrypt_to_plaintext(|| Ok(b"hello".to_vec()));
+        let v = result.unwrap();
+        assert_eq!(v.as_inner().expose_secret(), b"hello");
+    }
+
+    #[test]
+    fn verify_aead_decrypt_to_plaintext_propagates_err_from_closure() {
+        let result: Result<Verified<Plaintext>, &'static str> =
+            verify_aead_decrypt_to_plaintext(|| Err("aead-fail"));
+        assert_eq!(result.unwrap_err(), "aead-fail");
+    }
+
+    #[test]
+    fn verify_aead_decrypt_to_plaintext_accepts_empty_bytes() {
+        // 0 byte plaintext は AES-GCM 仕様上有効 (ciphertext は tag のみ)。
+        let result: Result<Verified<Plaintext>, ()> =
+            verify_aead_decrypt_to_plaintext(|| Ok(Vec::new()));
+        let v = result.unwrap();
+        assert_eq!(v.into_inner().expose_secret(), b"");
     }
 
     // -----------------------------------------------------------------

--- a/crates/shikomi-core/src/lib.rs
+++ b/crates/shikomi-core/src/lib.rs
@@ -22,11 +22,11 @@ pub use error::{
 // --- 秘密値ラッパ ---
 pub use secret::{SecretBytes, SecretString};
 
-// --- 暗号ドメイン型 (Sub-A 新規) ---
+// --- 暗号ドメイン型 (Sub-A 新規 / Sub-C 拡張) ---
 pub use crypto::{
-    verify_aead_decrypt, CryptoOutcome, HeaderAeadKey, Kek, KekKind, KekKindPw, KekKindRecovery,
-    MasterPassword, PasswordStrengthGate, Plaintext, RecoveryMnemonic, Vek, Verified,
-    WeakPasswordFeedback,
+    verify_aead_decrypt, verify_aead_decrypt_to_plaintext, AeadKey, CryptoOutcome, HeaderAeadKey,
+    Kek, KekKind, KekKindPw, KekKindRecovery, MasterPassword, PasswordStrengthGate, Plaintext,
+    RecoveryMnemonic, Vek, Verified, WeakPasswordFeedback,
 };
 
 // --- vault 集約・ヘッダ ---

--- a/crates/shikomi-infra/Cargo.toml
+++ b/crates/shikomi-infra/Cargo.toml
@@ -42,6 +42,9 @@ uuid         = { workspace = true }
 # `cargo bench -p shikomi-infra --bench kdf_bench` で起動、
 # `.github/workflows/bench-kdf.yml` の `bench-kdf` ジョブが 3 OS で gating。
 criterion    = { workspace = true }
+# Sub-C (#41) test-design TC-C-P01 / TC-C-P02 property test (1000 ケース)。
+# 詳細は `tests/aead_property.rs` と test-design.md §12.7。
+proptest     = { workspace = true }
 
 # Sub-B (#40) BC-3 リリースブロッカ。Argon2id `FROZEN_OWASP_2024_05` の
 # 単一 derive 時間 median を 750ms 閾値 (p95 ≤ 1.0s の proxy) で検証する。

--- a/crates/shikomi-infra/Cargo.toml
+++ b/crates/shikomi-infra/Cargo.toml
@@ -27,6 +27,10 @@ getrandom     = { workspace = true }
 zxcvbn        = { workspace = true }
 secrecy       = { workspace = true }
 zeroize       = { workspace = true }
+# Sub-C (#41) AEAD アダプタ (AES-256-GCM)。`subtle` は aes-gcm が transitive で
+# 引くため**直接追加しない** (nonce-and-aead.md §`subtle` v2.5+ 制約: tag 比較は
+# aes-gcm 内部の constant-time 経路に委譲)。
+aes-gcm       = { workspace = true }
 
 [dev-dependencies]
 tempfile     = { workspace = true }

--- a/crates/shikomi-infra/src/crypto/aead/aes_gcm.rs
+++ b/crates/shikomi-infra/src/crypto/aead/aes_gcm.rs
@@ -1,0 +1,404 @@
+//! `AesGcmAeadAdapter` — AES-256-GCM AEAD アダプタ (RustCrypto `aes-gcm`)。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/nonce-and-aead.md`
+//!         §`AesGcmAeadAdapter`
+//!
+//! ## 採用 API
+//!
+//! - `aes_gcm::Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&[u8; 32]))`
+//! - `AeadInPlace::encrypt_in_place_detached(&Nonce, &[u8] AAD, &mut [u8] buf) -> Result<Tag, Error>`
+//! - `AeadInPlace::decrypt_in_place_detached(&Nonce, &[u8] AAD, &mut [u8] buf, &Tag) -> Result<(), Error>`
+//!
+//! ciphertext と tag は **物理的に分離**して扱う (`WrappedVek` の構造分離型化と整合、
+//! Tell-Don't-Ask)。`Aead::encrypt` / `Aead::decrypt` の連結返却 API は使わない。
+//!
+//! ## 三段防御整合
+//!
+//! - 鍵バイトは `AeadKey::with_secret_bytes` クロージャ経由で借り受ける
+//!   (TC-C-I01: `expose_within_crate` を adapter 内で呼ばない)
+//! - tag 比較は `aes-gcm` 内部の constant-time 経路に委譲
+//!   (TC-C-I04: 自前 `as_array() ==` 等を書かない)
+//! - 中間 `buf` は `Zeroizing<Vec<u8>>` で囲む (TC-C-I02)
+//! - AEAD タグ検証成功時のみ `verify_aead_decrypt_to_plaintext` 経由で
+//!   `Verified<Plaintext>` を構築 (CC-3 / C-14)
+
+use aes_gcm::aead::generic_array::GenericArray;
+use aes_gcm::{AeadInPlace, Aes256Gcm, Key, KeyInit};
+use shikomi_core::crypto::AeadKey;
+use shikomi_core::error::CryptoError;
+use shikomi_core::{
+    verify_aead_decrypt_to_plaintext, Aad, AuthTag, NonceBytes, Plaintext, Vek, Verified,
+    WrappedVek,
+};
+use zeroize::Zeroizing;
+
+/// AES-256-GCM AEAD アダプタ。無状態 unit struct (`Default` 経由で構築)。
+///
+/// `aes-gcm` crate の `Aes256Gcm::new(key)` は鍵ごとに毎回構築される軽量操作で、
+/// adapter 自体に state を持つ必要はない。Sub-D / Sub-E の複数呼出経路から
+/// 並列に使用しても thread-safe。
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AesGcmAeadAdapter;
+
+impl AesGcmAeadAdapter {
+    /// per-record 暗号化。`(ciphertext: Vec<u8>, tag: AuthTag)` を返す。
+    ///
+    /// AAD は `Aad::to_canonical_bytes()` の **26B 固定** (record_id 16B + version 2B BE
+    /// + created_at_micros 8B BE)。
+    ///
+    /// **`NonceCounter::increment` は本関数で呼ばない** (Sub-D vault repository 層責務、
+    /// `nonce-and-aead.md` §nonce_counter 統合契約)。
+    ///
+    /// # Errors
+    ///
+    /// `aes-gcm` 内部エラー (plaintext 過大 / AAD 過大) 時に
+    /// `CryptoError::AeadTagMismatch` を返す (内部詳細秘匿、1 variant に収束)。
+    pub fn encrypt_record(
+        &self,
+        key: &impl AeadKey,
+        nonce: &NonceBytes,
+        aad: &Aad,
+        plaintext: &[u8],
+    ) -> Result<(Vec<u8>, AuthTag), CryptoError> {
+        let aad_bytes = aad.to_canonical_bytes();
+        let nonce_ga = GenericArray::clone_from_slice(nonce.as_array());
+        // 中間バッファ。`Zeroizing<Vec<u8>>` で囲み、関数スコープ抜けで Drop → zeroize
+        // (TC-C-I02 / CC-5 / C-16)。
+        let mut buf: Zeroizing<Vec<u8>> = Zeroizing::new(plaintext.to_vec());
+
+        let tag_ga = key
+            .with_secret_bytes(|bytes| {
+                let cipher_key: &Key<Aes256Gcm> = Key::<Aes256Gcm>::from_slice(bytes);
+                let cipher = Aes256Gcm::new(cipher_key);
+                cipher.encrypt_in_place_detached(&nonce_ga, &aad_bytes, buf.as_mut_slice())
+            })
+            .map_err(|_| CryptoError::AeadTagMismatch)?;
+
+        let tag_array: [u8; 16] = tag_ga.into();
+        Ok((buf.to_vec(), AuthTag::from_array(tag_array)))
+    }
+
+    /// per-record 復号 + AEAD タグ検証。タグ検証成功時のみ `Verified<Plaintext>` を返す。
+    ///
+    /// AAD は `encrypt_record` と同一値 (`Aad::to_canonical_bytes()` 26B)。
+    /// AAD / nonce / ciphertext / tag のいずれかが不一致なら
+    /// `Err(CryptoError::AeadTagMismatch)`。
+    ///
+    /// # Errors
+    ///
+    /// AEAD タグ検証失敗時に `CryptoError::AeadTagMismatch`。
+    pub fn decrypt_record(
+        &self,
+        key: &impl AeadKey,
+        nonce: &NonceBytes,
+        aad: &Aad,
+        ciphertext: &[u8],
+        tag: &AuthTag,
+    ) -> Result<Verified<Plaintext>, CryptoError> {
+        let aad_bytes = aad.to_canonical_bytes();
+        let nonce_ga = GenericArray::clone_from_slice(nonce.as_array());
+        let tag_ga = GenericArray::clone_from_slice(tag.as_array());
+
+        verify_aead_decrypt_to_plaintext(|| {
+            let mut buf: Zeroizing<Vec<u8>> = Zeroizing::new(ciphertext.to_vec());
+            key.with_secret_bytes(|bytes| {
+                let cipher_key: &Key<Aes256Gcm> = Key::<Aes256Gcm>::from_slice(bytes);
+                let cipher = Aes256Gcm::new(cipher_key);
+                cipher.decrypt_in_place_detached(&nonce_ga, &aad_bytes, buf.as_mut_slice(), &tag_ga)
+            })
+            .map_err(|_| CryptoError::AeadTagMismatch)?;
+            // タグ検証成功直後に平文 bytes を取り出す。`buf` は本クロージャ抜けで Drop。
+            Ok(buf.to_vec())
+        })
+    }
+
+    /// VEK の wrap (KEK で AES-256-GCM 暗号化、AAD は空)。
+    ///
+    /// `wrap_vek` / `unwrap_vek` は AAD を持たない (vault ヘッダ独立 AEAD タグで別途
+    /// 保護される設計、`nonce-and-aead.md` §`AesGcmAeadAdapter`)。
+    ///
+    /// # Errors
+    ///
+    /// `aes-gcm` 内部エラー時に `CryptoError::AeadTagMismatch` (内部詳細秘匿)。
+    /// 構造的に到達しない `WrappedVek::new` の長さ検証エラーも同 variant に収束。
+    pub fn wrap_vek(
+        &self,
+        kek: &impl AeadKey,
+        nonce: &NonceBytes,
+        vek: &Vek,
+    ) -> Result<WrappedVek, CryptoError> {
+        let nonce_ga = GenericArray::clone_from_slice(nonce.as_array());
+        // VEK 平文 32B を中間バッファにコピー。`Zeroizing<Vec<u8>>` で囲む。
+        let mut buf: Zeroizing<Vec<u8>> =
+            vek.with_secret_bytes(|vek_bytes| Zeroizing::new(vek_bytes.to_vec()));
+
+        let tag_ga = kek
+            .with_secret_bytes(|kek_bytes| {
+                let cipher_key: &Key<Aes256Gcm> = Key::<Aes256Gcm>::from_slice(kek_bytes);
+                let cipher = Aes256Gcm::new(cipher_key);
+                // AAD は空 `&[]` (`wrap_vek` / `unwrap_vek` 規約)。
+                cipher.encrypt_in_place_detached(&nonce_ga, &[], buf.as_mut_slice())
+            })
+            .map_err(|_| CryptoError::AeadTagMismatch)?;
+
+        let tag_array: [u8; 16] = tag_ga.into();
+        let auth_tag = AuthTag::from_array(tag_array);
+        // VEK は型レベルで 32B 固定 → ciphertext も 32B → `WrappedVek::new` の
+        // `WrappedVekTooShort` / `WrappedVekEmpty` は構造的に到達しない。
+        // `map_err(|_| AeadTagMismatch)` は防御的 fallback (CC-10: unwrap/expect 禁止)。
+        WrappedVek::new(buf.to_vec(), nonce.clone(), auth_tag)
+            .map_err(|_| CryptoError::AeadTagMismatch)
+    }
+
+    /// VEK の unwrap (KEK で AEAD タグ検証付き復号)。AAD は空。
+    ///
+    /// 戻り値の `Verified<Plaintext>` 内の bytes を `Vek::from_array` の入力に
+    /// 復元する経路は **Sub-D 責務** (本 adapter は AEAD 検証付き復号までを保証、
+    /// 復号後の長さ検証は呼出側が実施)。
+    ///
+    /// # Errors
+    ///
+    /// AEAD タグ検証失敗時に `CryptoError::AeadTagMismatch`。
+    pub fn unwrap_vek(
+        &self,
+        kek: &impl AeadKey,
+        wrapped: &WrappedVek,
+    ) -> Result<Verified<Plaintext>, CryptoError> {
+        let nonce_ga = GenericArray::clone_from_slice(wrapped.nonce().as_array());
+        let tag_ga = GenericArray::clone_from_slice(wrapped.tag().as_array());
+
+        verify_aead_decrypt_to_plaintext(|| {
+            let mut buf: Zeroizing<Vec<u8>> = Zeroizing::new(wrapped.ciphertext().to_vec());
+            kek.with_secret_bytes(|kek_bytes| {
+                let cipher_key: &Key<Aes256Gcm> = Key::<Aes256Gcm>::from_slice(kek_bytes);
+                let cipher = Aes256Gcm::new(cipher_key);
+                cipher.decrypt_in_place_detached(&nonce_ga, &[], buf.as_mut_slice(), &tag_ga)
+            })
+            .map_err(|_| CryptoError::AeadTagMismatch)?;
+            Ok(buf.to_vec())
+        })
+    }
+}
+
+// `aes_gcm::Error` → `CryptoError::AeadTagMismatch` の変換は `From` impl を
+// **書かない** (orphan rule 違反: `aes_gcm::Error` も `CryptoError` も shikomi-infra
+// に対して foreign)。各呼出地点で `.map_err(|_| CryptoError::AeadTagMismatch)`
+// を inline する形に統一 (内部詳細秘匿、全 AEAD 経路で 1 variant に収束)。
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::crypto::{Kek, KekKindPw};
+    use shikomi_core::{RecordId, VaultVersion};
+    use time::OffsetDateTime;
+    use uuid::Uuid;
+
+    // -----------------------------------------------------------------
+    // テスト用 helper
+    // -----------------------------------------------------------------
+
+    fn make_aad() -> Aad {
+        let id = RecordId::new(Uuid::now_v7()).expect("v7 uuid");
+        Aad::new(id, VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).expect("aad")
+    }
+
+    fn another_aad() -> Aad {
+        let id = RecordId::new(Uuid::now_v7()).expect("v7 uuid");
+        Aad::new(id, VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).expect("aad")
+    }
+
+    fn make_vek(byte: u8) -> Vek {
+        Vek::from_array([byte; 32])
+    }
+
+    fn make_kek(byte: u8) -> Kek<KekKindPw> {
+        Kek::<KekKindPw>::from_array([byte; 32])
+    }
+
+    fn make_nonce(byte: u8) -> NonceBytes {
+        NonceBytes::from_random([byte; 12])
+    }
+
+    // -----------------------------------------------------------------
+    // encrypt_record / decrypt_record roundtrip
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn encrypt_then_decrypt_roundtrip_bit_exact() {
+        let adapter = AesGcmAeadAdapter;
+        let vek = make_vek(0x11);
+        let nonce = make_nonce(0x22);
+        let aad = make_aad();
+        let plaintext = b"the quick brown fox jumps over the lazy dog";
+
+        let (ciphertext, tag) = adapter
+            .encrypt_record(&vek, &nonce, &aad, plaintext)
+            .expect("encrypt ok");
+
+        // ciphertext は plaintext と同じ長さ (detached tag 方式)
+        assert_eq!(ciphertext.len(), plaintext.len());
+        // ciphertext は plaintext と一致してはならない
+        assert_ne!(ciphertext.as_slice(), plaintext.as_slice());
+
+        let verified = adapter
+            .decrypt_record(&vek, &nonce, &aad, &ciphertext, &tag)
+            .expect("decrypt ok");
+
+        assert_eq!(verified.as_inner().expose_secret(), plaintext);
+    }
+
+    #[test]
+    fn decrypt_with_wrong_key_returns_aead_tag_mismatch() {
+        let adapter = AesGcmAeadAdapter;
+        let vek1 = make_vek(0x11);
+        let vek2 = make_vek(0x22);
+        let nonce = make_nonce(0x33);
+        let aad = make_aad();
+        let plaintext = b"secret data";
+
+        let (ciphertext, tag) = adapter
+            .encrypt_record(&vek1, &nonce, &aad, plaintext)
+            .expect("encrypt ok");
+
+        let err = adapter
+            .decrypt_record(&vek2, &nonce, &aad, &ciphertext, &tag)
+            .expect_err("wrong key must fail");
+        assert!(matches!(err, CryptoError::AeadTagMismatch));
+    }
+
+    #[test]
+    fn decrypt_with_swapped_aad_returns_aead_tag_mismatch() {
+        let adapter = AesGcmAeadAdapter;
+        let vek = make_vek(0x55);
+        let nonce = make_nonce(0x66);
+        let aad_a = make_aad();
+        let aad_b = another_aad();
+        let plaintext = b"L1 protected payload";
+
+        let (ciphertext, tag) = adapter
+            .encrypt_record(&vek, &nonce, &aad_a, plaintext)
+            .expect("encrypt ok");
+
+        let err = adapter
+            .decrypt_record(&vek, &nonce, &aad_b, &ciphertext, &tag)
+            .expect_err("swapped aad must fail");
+        assert!(matches!(err, CryptoError::AeadTagMismatch));
+    }
+
+    #[test]
+    fn decrypt_with_swapped_nonce_returns_aead_tag_mismatch() {
+        let adapter = AesGcmAeadAdapter;
+        let vek = make_vek(0x77);
+        let nonce_a = make_nonce(0x10);
+        let nonce_b = make_nonce(0x20);
+        let aad = make_aad();
+        let plaintext = b"hello world";
+
+        let (ciphertext, tag) = adapter
+            .encrypt_record(&vek, &nonce_a, &aad, plaintext)
+            .expect("encrypt ok");
+
+        let err = adapter
+            .decrypt_record(&vek, &nonce_b, &aad, &ciphertext, &tag)
+            .expect_err("swapped nonce must fail");
+        assert!(matches!(err, CryptoError::AeadTagMismatch));
+    }
+
+    #[test]
+    fn decrypt_with_tampered_ciphertext_returns_aead_tag_mismatch() {
+        let adapter = AesGcmAeadAdapter;
+        let vek = make_vek(0x88);
+        let nonce = make_nonce(0x99);
+        let aad = make_aad();
+        let plaintext = b"original data";
+
+        let (mut ciphertext, tag) = adapter
+            .encrypt_record(&vek, &nonce, &aad, plaintext)
+            .expect("encrypt ok");
+        // 1 bit 反転で AEAD 失敗を観測
+        ciphertext[0] ^= 0x01;
+
+        let err = adapter
+            .decrypt_record(&vek, &nonce, &aad, &ciphertext, &tag)
+            .expect_err("tampered ciphertext must fail");
+        assert!(matches!(err, CryptoError::AeadTagMismatch));
+    }
+
+    // -----------------------------------------------------------------
+    // wrap_vek / unwrap_vek roundtrip
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn wrap_then_unwrap_vek_roundtrip() {
+        let adapter = AesGcmAeadAdapter;
+        let kek = make_kek(0xAB);
+        let nonce = make_nonce(0xCD);
+        let original_bytes = [0x42u8; 32];
+        let vek = Vek::from_array(original_bytes);
+
+        let wrapped = adapter.wrap_vek(&kek, &nonce, &vek).expect("wrap ok");
+        // ciphertext は VEK 32B と同じ長さ (detached tag 方式)
+        assert_eq!(wrapped.ciphertext().len(), 32);
+        assert_eq!(wrapped.nonce().as_array(), nonce.as_array());
+
+        let verified = adapter.unwrap_vek(&kek, &wrapped).expect("unwrap ok");
+        assert_eq!(verified.as_inner().expose_secret(), &original_bytes);
+    }
+
+    #[test]
+    fn unwrap_vek_with_wrong_kek_returns_aead_tag_mismatch() {
+        let adapter = AesGcmAeadAdapter;
+        let kek1 = make_kek(0x01);
+        let kek2 = make_kek(0x02);
+        let nonce = make_nonce(0x03);
+        let vek = make_vek(0x04);
+
+        let wrapped = adapter.wrap_vek(&kek1, &nonce, &vek).expect("wrap ok");
+        let err = adapter
+            .unwrap_vek(&kek2, &wrapped)
+            .expect_err("wrong kek must fail");
+        assert!(matches!(err, CryptoError::AeadTagMismatch));
+    }
+
+    // -----------------------------------------------------------------
+    // 構造性: ciphertext は plaintext と長さが等しい (detached tag)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn encrypt_record_ciphertext_matches_plaintext_length() {
+        let adapter = AesGcmAeadAdapter;
+        let vek = make_vek(0x10);
+        let nonce = make_nonce(0x20);
+        let aad = make_aad();
+
+        for &len in &[0usize, 1, 13, 16, 47, 64, 128] {
+            let pt = vec![0x55u8; len];
+            let (ct, _tag) = adapter
+                .encrypt_record(&vek, &nonce, &aad, &pt)
+                .expect("encrypt ok");
+            assert_eq!(ct.len(), len, "ciphertext length mismatch for len={len}");
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // KEK<KekKindRecovery> でも AeadKey impl 経由で動く (型一般化検証)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn wrap_unwrap_vek_works_with_kek_recovery() {
+        use shikomi_core::crypto::KekKindRecovery;
+        let adapter = AesGcmAeadAdapter;
+        let kek_recovery = Kek::<KekKindRecovery>::from_array([0x99u8; 32]);
+        let nonce = make_nonce(0xAA);
+        let vek_bytes = [0x33u8; 32];
+        let vek = Vek::from_array(vek_bytes);
+
+        let wrapped = adapter
+            .wrap_vek(&kek_recovery, &nonce, &vek)
+            .expect("wrap ok");
+        let verified = adapter
+            .unwrap_vek(&kek_recovery, &wrapped)
+            .expect("unwrap ok");
+        assert_eq!(verified.as_inner().expose_secret(), &vek_bytes);
+    }
+}

--- a/crates/shikomi-infra/src/crypto/aead/kat.rs
+++ b/crates/shikomi-infra/src/crypto/aead/kat.rs
@@ -1,0 +1,172 @@
+//! Known Answer Tests (KAT) — AES-256-GCM 三軸 (key bias × plaintext 長 × AAD 長) 網羅。
+//!
+//! `#[cfg(test)]` 専用。本 KAT は **自己整合 KAT** に責務を絞る:
+//! RustCrypto `aes-gcm` crate (`Aes256Gcm`) で encrypt → 同 key/nonce/aad で
+//! decrypt して bit-exact match を確認する。実装パスが「encrypt_in_place_detached
+//! / decrypt_in_place_detached の roundtrip 成立」「三軸の分散条件全てで動作」を
+//! 検証することが目的。
+//!
+//! 本物の NIST CAVP `gcmEncryptExtIV256.rsp` 公式 expected ciphertext との
+//! bit-exact 比較は **Sub-D の repository 結合テスト** で実施 (本 KAT は
+//! AES-256-GCM が動く + 三軸網羅の動作証明に限定)。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/nonce-and-aead.md`
+//!         §`AesGcmAeadAdapter` §`aes-gcm` crate 呼出契約 KAT 行
+//!         + Bug-C-003 凍結の三軸分散条件
+//!
+//! TC-C-I02 静的検査の `mod tests` ブロック判定経路に乗せるため、全 KAT
+//! 関数を本ファイル内 `mod tests { ... }` に格納する
+//! (`tests/docs/sub-c-static-checks.sh` の awk フィルタ仕様、Sub-B kat.rs と同型)。
+
+#![cfg(test)]
+
+#[cfg(test)]
+mod tests {
+    use aes_gcm::aead::generic_array::GenericArray;
+    use aes_gcm::{AeadInPlace, Aes256Gcm, Key, KeyInit};
+
+    /// AES-256-GCM の `encrypt_in_place_detached` → `decrypt_in_place_detached`
+    /// roundtrip + non-trivial 出力検証 (中身を直接担保するヘルパ)。
+    ///
+    /// 三軸の各 KAT 関数から呼び出され、**本ヘルパ内で AES-256-GCM が動く** sanity
+    /// (= ciphertext != plaintext かつ tag != 全 0) を確認する。
+    fn run_kat(key_bytes: &[u8; 32], nonce_bytes: &[u8; 12], aad: &[u8], plaintext: &[u8]) {
+        let key: &Key<Aes256Gcm> = Key::<Aes256Gcm>::from_slice(key_bytes);
+        let cipher = Aes256Gcm::new(key);
+        let nonce = GenericArray::clone_from_slice(nonce_bytes);
+
+        // encrypt
+        let mut buf = plaintext.to_vec();
+        let tag = cipher
+            .encrypt_in_place_detached(&nonce, aad, buf.as_mut_slice())
+            .expect("encrypt_in_place_detached must succeed within P_MAX/A_MAX");
+
+        // sanity: ciphertext != plaintext (空 plaintext を除く)
+        if !plaintext.is_empty() {
+            assert_ne!(
+                buf.as_slice(),
+                plaintext,
+                "ciphertext must not equal plaintext (KAT sanity)"
+            );
+        }
+        // sanity: tag は全 0 ではない (非自明 GMAC 出力)
+        assert!(
+            tag.iter().any(|&b| b != 0),
+            "auth tag must not be all zeros (GMAC running?)"
+        );
+        let ciphertext = buf.clone();
+
+        // decrypt (bit-exact match)
+        let mut decrypt_buf = ciphertext.clone();
+        cipher
+            .decrypt_in_place_detached(&nonce, aad, decrypt_buf.as_mut_slice(), &tag)
+            .expect("decrypt_in_place_detached must succeed for matching key/nonce/aad/tag");
+        assert_eq!(
+            decrypt_buf.as_slice(),
+            plaintext,
+            "roundtrip must be bit-exact"
+        );
+
+        // tampered tag → decrypt 失敗 (AEAD 検証経路の sanity)
+        let mut tampered_tag = tag;
+        tampered_tag[0] ^= 0x01;
+        let mut buf_for_bad = ciphertext.clone();
+        let bad = cipher.decrypt_in_place_detached(
+            &nonce,
+            aad,
+            buf_for_bad.as_mut_slice(),
+            &tampered_tag,
+        );
+        assert!(bad.is_err(), "tampered tag must cause AEAD failure");
+    }
+
+    // -------------------------------------------------------------------
+    // Bug-C-003 凍結の三軸分散条件: key bias × plaintext 長 × AAD 長
+    //   key bias 軸: 全 0 / 全 0xFF / random / "test" 字列 padded
+    //   plaintext 長 軸: 0 / 16 / 64 / 任意非整数倍 (13, 47)
+    //   AAD 長 軸: 0 / 16 / 64
+    // -------------------------------------------------------------------
+
+    /// KAT-1: key bias 軸 = 全 0、plaintext 長 = 0 (空)、AAD 長 = 0 (空)。
+    /// AES-GCM は plaintext 長 0 でも有効 (ciphertext は空、tag のみ生成される)。
+    #[test]
+    fn kat_1_key_all_zero_pt_empty_aad_empty() {
+        run_kat(&[0u8; 32], &[0u8; 12], &[], &[]);
+    }
+
+    /// KAT-2: key bias 軸 = 全 0xFF、plaintext 長 = 16 (1 ブロック)、AAD 長 = 16。
+    #[test]
+    fn kat_2_key_all_ff_pt_16_aad_16() {
+        run_kat(&[0xFFu8; 32], &[0x01u8; 12], &[0xAAu8; 16], &[0x55u8; 16]);
+    }
+
+    /// KAT-3: key bias 軸 = "random"-ish (UUID-like パターン)、plaintext 長 = 64
+    /// (4 ブロック)、AAD 長 = 64。
+    #[test]
+    fn kat_3_key_random_pt_64_aad_64() {
+        let key = [
+            0x01u8, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54,
+            0x32, 0x10, 0x0f, 0x1e, 0x2d, 0x3c, 0x4b, 0x5a, 0x69, 0x78, 0x87, 0x96, 0xa5, 0xb4,
+            0xc3, 0xd2, 0xe1, 0xf0,
+        ];
+        let nonce = [
+            0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0x12, 0x34, 0x56, 0x78,
+        ];
+        let aad: Vec<u8> = (0u8..64).collect();
+        let pt: Vec<u8> = (0u8..64).map(|b| b.wrapping_mul(3)).collect();
+        run_kat(&key, &nonce, &aad, &pt);
+    }
+
+    /// KAT-4: key bias 軸 = ASCII "test" 字列 padded、plaintext 長 = 13
+    /// (任意非整数倍)、AAD 長 = 0。
+    #[test]
+    fn kat_4_key_ascii_test_pt_13_aad_empty() {
+        let mut key = [0u8; 32];
+        key[..4].copy_from_slice(b"test");
+        let pt = b"hello, world!"; // 13 byte
+        run_kat(&key, &[0x42u8; 12], &[], pt);
+    }
+
+    /// KAT-5: key bias 軸 = 全 0、plaintext 長 = 47 (任意非整数倍 = 2 ブロック + 15B)、
+    /// AAD 長 = 16。
+    #[test]
+    fn kat_5_key_all_zero_pt_47_aad_16() {
+        run_kat(&[0u8; 32], &[0xCCu8; 12], &[0x99u8; 16], &[0x33u8; 47]);
+    }
+
+    /// KAT-6: key bias 軸 = 全 0xFF、plaintext 長 = 0、AAD 長 = 64。
+    /// AAD のみで GMAC が走る経路の sanity。
+    #[test]
+    fn kat_6_key_all_ff_pt_empty_aad_64() {
+        run_kat(&[0xFFu8; 32], &[0xEEu8; 12], &[0x11u8; 64], &[]);
+    }
+
+    /// KAT-7: key bias 軸 = random-ish、plaintext 長 = 16 (1 ブロック)、AAD 長 = 0。
+    #[test]
+    fn kat_7_key_random_pt_16_aad_empty() {
+        let key = [
+            0xa3u8, 0xb1, 0xc5, 0xd7, 0xe9, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+            0xff, 0x00, 0x12, 0x34,
+        ];
+        run_kat(&key, &[0x77u8; 12], &[], &[0x88u8; 16]);
+    }
+
+    /// KAT-8: key bias 軸 = ASCII "test" padded、plaintext 長 = 64、AAD 長 = 64。
+    /// 三軸の組合せ網羅を補強。
+    #[test]
+    fn kat_8_key_ascii_test_pt_64_aad_64() {
+        let mut key = [0u8; 32];
+        key[..4].copy_from_slice(b"test");
+        let aad: Vec<u8> = (0u8..64).map(|b| b.wrapping_add(0x10)).collect();
+        let pt: Vec<u8> = (0u8..64).map(|b| b.wrapping_mul(7)).collect();
+        run_kat(&key, &[0xABu8; 12], &aad, &pt);
+    }
+
+    /// KAT-9 (補): plaintext 長 = 16 (一括ブロック境界)、key 全 0、AAD 長 = 64。
+    /// AAD と plaintext の長さ非対称な経路を補強。
+    #[test]
+    fn kat_9_key_all_zero_pt_16_aad_64() {
+        run_kat(&[0u8; 32], &[0xBBu8; 12], &[0x77u8; 64], &[0x44u8; 16]);
+    }
+}

--- a/crates/shikomi-infra/src/crypto/aead/mod.rs
+++ b/crates/shikomi-infra/src/crypto/aead/mod.rs
@@ -1,0 +1,18 @@
+//! AEAD アダプタ層 (AES-256-GCM)。
+//!
+//! Sub-C (#41) で新規追加。`shikomi-core::AeadKey` クロージャインジェクション
+//! 経由で `Vek` / `Kek<_>` / `HeaderAeadKey` の鍵バイトを借り受け、
+//! `aes-gcm` crate (RustCrypto) の `Aes256Gcm` で `encrypt_in_place_detached` /
+//! `decrypt_in_place_detached` の **tag 分離 API** を呼び出す。
+//!
+//! AEAD タグ検証成功時のみ `verify_aead_decrypt_to_plaintext` 経由で
+//! `Verified<Plaintext>` を構築し、`Plaintext::new_within_module` の
+//! `pub(in crate::crypto::verified)` 限定可視性を破らない。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/nonce-and-aead.md`
+//!         §`AesGcmAeadAdapter`
+
+pub mod aes_gcm;
+mod kat;
+
+pub use aes_gcm::AesGcmAeadAdapter;

--- a/crates/shikomi-infra/src/crypto/mod.rs
+++ b/crates/shikomi-infra/src/crypto/mod.rs
@@ -10,11 +10,14 @@
 //! - [`rng`]: `rand_core::OsRng` を用いた CSPRNG 単一エントリ点 (Sub-B、`rng.md`)
 //! - [`kdf`]: Argon2id / BIP-39+PBKDF2+HKDF KDF アダプタ (Sub-B、`kdf.md`)
 //! - [`password`]: zxcvbn ベース `PasswordStrengthGate` 実装 (Sub-B、`password.md`)
+//! - [`aead`]: AES-256-GCM AEAD アダプタ (Sub-C、`nonce-and-aead.md`)
 
+pub mod aead;
 pub mod kdf;
 pub mod password;
 pub mod rng;
 
+pub use aead::AesGcmAeadAdapter;
 pub use kdf::{Argon2idAdapter, Argon2idParams, Bip39Pbkdf2Hkdf, HKDF_INFO};
 pub use password::ZxcvbnGate;
 pub use rng::Rng;

--- a/crates/shikomi-infra/tests/aead_property.rs
+++ b/crates/shikomi-infra/tests/aead_property.rs
@@ -1,0 +1,170 @@
+//! Sub-C (#41) test-design TC-C-P01 / TC-C-P02 — proptest 1000 ケース.
+//!
+//! Bug-C-001 顛末: 銀ちゃん impl PR #55 (`0507705`) は AES-GCM の roundtrip /
+//! AAD swap / wrong-key 等を**単発 fixture テスト**で確認していた。
+//! test-design.md §12.4 / §12.7 が要求するのは **proptest 1000 ケース**で、
+//! 「単発 1 件」と「ランダム入力空間 1000 ケース」は意味論が異なる:
+//! - 単発: 設計者が想定したケース 1 件で invariant が成立することを確認
+//! - proptest: ランダム入力空間で**設計者が想定していない歪み**まで覆う
+//!
+//! テスト工程でマユリが Boy Scout として補強。`proptest` crate を workspace
+//! dev-deps に追加し、本ファイルで以下 2 件を実装:
+//!
+//! - **TC-C-P01 (CC-7 / L1)**: 任意の 2 record (A/B) を組合せて encrypt し、
+//!   AAD を A/B 入れ替えて decrypt → **同一組合せのみ復号成功**、入れ替え時は
+//!   `Err(AeadTagMismatch)`。1000 ケース。
+//! - **TC-C-P02 (CC-1 / CC-6)**: 任意の plaintext (0..=4096B) + 任意 `Vek` +
+//!   任意 `Aad` + 任意 nonce で `encrypt_record → decrypt_record` 往復し、
+//!   復元 plaintext が**元 plaintext と bit-exact 一致**。1000 ケース。
+
+#![allow(clippy::unwrap_used, clippy::expect_used)] // proptest harness 内部、shrink 出力で許容
+
+use proptest::prelude::*;
+use shikomi_core::crypto::{Plaintext, Vek, Verified};
+use shikomi_core::error::CryptoError;
+use shikomi_core::vault::crypto_data::Aad;
+use shikomi_core::{NonceBytes, RecordId, VaultVersion};
+use shikomi_infra::crypto::aead::AesGcmAeadAdapter;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+/// 任意 32B 配列 → `Vek` の strategy.
+fn vek_strategy() -> impl Strategy<Value = Vek> {
+    prop::array::uniform32(any::<u8>()).prop_map(Vek::from_array)
+}
+
+/// 任意 12B 配列 → `NonceBytes` の strategy.
+fn nonce_strategy() -> impl Strategy<Value = NonceBytes> {
+    prop::array::uniform12(any::<u8>()).prop_map(NonceBytes::from_random)
+}
+
+/// 任意の `Aad` の strategy.
+/// `RecordId` は `Uuid::now_v7()` で生成（UUIDv7 必須、`RecordId::new` 検証通過）、
+/// `vault_version` は 1..=5（現実的な範囲）、`created_at` は 2020〜2030 年範囲。
+/// proptest が `RecordId` のランダムバリエーションを欲しがる場合は `now_v7` の
+/// 連続呼出が timestamp + counter で異なる値を返すため、Strategy 内では
+/// 1 ケース 1 UUID で十分。
+fn aad_strategy() -> impl Strategy<Value = Aad> {
+    // 2020-01-01T00:00:00Z = 1577836800 秒、2030-01-01T00:00:00Z = 1893456000 秒
+    // VaultVersion::CURRENT == VaultVersion::MIN_SUPPORTED == 1 (本実装時点)。
+    // 範囲外を proptest に渡すと UnsupportedVaultVersion でパニックするため、
+    // 採用範囲のみに絞る。バージョン拡張時は VaultVersion::CURRENT を辿って自動拡張可。
+    let secs_range = 1_577_836_800_i64..=1_893_456_000_i64;
+    (
+        secs_range,                          // unix epoch seconds
+        0_i64..1_000_000_i64,                // microseconds within the second
+    )
+        .prop_map(|(secs, micros)| {
+            let record_id = RecordId::new(Uuid::now_v7()).expect("UUIDv7 valid");
+            let nanos = i128::from(secs) * 1_000_000_000 + i128::from(micros) * 1_000;
+            let created_at = OffsetDateTime::from_unix_timestamp_nanos(nanos)
+                .expect("nanos within OffsetDateTime range");
+            // 本実装の有効範囲は 1 のみ (MIN_SUPPORTED..=CURRENT)、Version 値そのもののバリエーションは Sub-D 以降で拡張
+            let version = VaultVersion::try_new(VaultVersion::CURRENT.value())
+                .expect("CURRENT vault_version always valid");
+            Aad::new(record_id, version, created_at).expect("Aad::new in-range")
+        })
+}
+
+/// 任意 plaintext バイト列 (0..=4096B) の strategy.
+fn plaintext_strategy() -> impl Strategy<Value = Vec<u8>> {
+    prop::collection::vec(any::<u8>(), 0..=4096)
+}
+
+proptest! {
+    // test-design.md §12.4 / §12.7 が要求する **1000 ケース** を明示。
+    // proptest デフォルトは 256 ケースのため、ProptestConfig で上書きしないと
+    // 設計と実態が乖離する (Bug-C-001 と同型の歪み再発を防ぐ)。
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    /// TC-C-P02 (CC-1 / CC-6 / property): encrypt → decrypt 往復不変条件.
+    ///
+    /// 任意の (plaintext, vek, aad, nonce) 組合せで:
+    ///   adapter.encrypt_record → adapter.decrypt_record →
+    ///   verified.expose_secret() == plaintext (bit-exact)
+    ///
+    /// テスト件数: ProptestConfig::cases = 1000 (1000 ケース)
+    /// shrinking: 失敗時、proptest が minimal failing case を提示
+    #[test]
+    fn tc_c_p02_encrypt_decrypt_roundtrip_property(
+        plaintext in plaintext_strategy(),
+        vek in vek_strategy(),
+        aad in aad_strategy(),
+        nonce in nonce_strategy(),
+    ) {
+        let adapter = AesGcmAeadAdapter;
+
+        let (ciphertext, tag) = adapter
+            .encrypt_record(&vek, &nonce, &aad, &plaintext)
+            .expect("encrypt should succeed for any valid input");
+
+        let verified: Verified<Plaintext> = adapter
+            .decrypt_record(&vek, &nonce, &aad, &ciphertext, &tag)
+            .expect("decrypt with same (vek, nonce, aad) must succeed");
+
+        // Verified<Plaintext> から元 plaintext を取り出し bit-exact 一致を確認
+        let restored = verified.into_inner();
+        prop_assert_eq!(restored.expose_secret(), plaintext.as_slice());
+    }
+
+    /// TC-C-P01 (CC-7 / L1 / property): AAD 入れ替え攻撃検出.
+    ///
+    /// 2 つの異なる (record_id, version, created_at) を持つ record A/B を
+    /// 同一 VEK で encrypt。decrypt 時に AAD を入れ替えると `AeadTagMismatch`。
+    /// 同一組合せでは復号成功。
+    ///
+    /// テスト件数: 1000 ケース
+    #[test]
+    fn tc_c_p01_aad_swap_attack_detected(
+        plaintext_a in plaintext_strategy(),
+        plaintext_b in plaintext_strategy(),
+        vek in vek_strategy(),
+        aad_a in aad_strategy(),
+        aad_b in aad_strategy(),
+        nonce_a in nonce_strategy(),
+        nonce_b in nonce_strategy(),
+    ) {
+        // record A / B が異なる AAD を持つことを保証 (同一 AAD は本 TC の対象外)
+        prop_assume!(aad_a.to_canonical_bytes() != aad_b.to_canonical_bytes());
+        // 同一 nonce 衝突を避ける (AES-GCM は同一 (key, nonce) で 2 回 encrypt 禁止)
+        prop_assume!(nonce_a.as_array() != nonce_b.as_array());
+
+        let adapter = AesGcmAeadAdapter;
+
+        let (ct_a, tag_a) = adapter
+            .encrypt_record(&vek, &nonce_a, &aad_a, &plaintext_a)
+            .expect("encrypt A");
+        let (ct_b, tag_b) = adapter
+            .encrypt_record(&vek, &nonce_b, &aad_b, &plaintext_b)
+            .expect("encrypt B");
+
+        // 1) 同一組合せ: A の (ct, tag, nonce, aad) で復号 → 成功
+        let verified_a = adapter
+            .decrypt_record(&vek, &nonce_a, &aad_a, &ct_a, &tag_a)
+            .expect("same (nonce_a, aad_a) must succeed");
+        let restored_a = verified_a.into_inner();
+        prop_assert_eq!(restored_a.expose_secret(), plaintext_a.as_slice());
+
+        let verified_b = adapter
+            .decrypt_record(&vek, &nonce_b, &aad_b, &ct_b, &tag_b)
+            .expect("same (nonce_b, aad_b) must succeed");
+        let restored_b = verified_b.into_inner();
+        prop_assert_eq!(restored_b.expose_secret(), plaintext_b.as_slice());
+
+        // 2) AAD 入れ替え攻撃: A の ciphertext + tag に B の AAD を組合せ → AeadTagMismatch
+        let result_swap_aad = adapter.decrypt_record(&vek, &nonce_a, &aad_b, &ct_a, &tag_a);
+        prop_assert!(
+            matches!(result_swap_aad, Err(CryptoError::AeadTagMismatch)),
+            "AAD swap (A ciphertext + B aad) must return AeadTagMismatch, got: {:?}",
+            result_swap_aad
+        );
+
+        // 3) nonce 入れ替え攻撃: A の ciphertext + tag に B の nonce を組合せ → AeadTagMismatch
+        let result_swap_nonce = adapter.decrypt_record(&vek, &nonce_b, &aad_a, &ct_a, &tag_a);
+        prop_assert!(
+            matches!(result_swap_nonce, Err(CryptoError::AeadTagMismatch)),
+            "nonce swap (A ciphertext + B nonce) must return AeadTagMismatch, got: {:?}",
+            result_swap_nonce
+        );
+    }
+}

--- a/docs/features/vault-encryption/test-design.md
+++ b/docs/features/vault-encryption/test-design.md
@@ -767,6 +767,43 @@ bash tests/docs/sub-0-cross-ref.sh
 | Sub-E (#43) | VEK キャッシュ（`tokio::sync::RwLock<Option<Vek>>`）と `AeadKey` impl の Drop 連鎖統合、IPC V2 でのエラー variant マッピング |
 | Sub-F (#44) | `vault rekey` フロー TC（`NonceLimitExceeded` 検知 → 新 VEK 生成 → 全レコード再暗号化）、MSG-S10 / MSG-S11 文言確定の E2E |
 
-### 12.12 Sub-C 工程4 実施実績
+### 12.12 Sub-C 工程4 実施実績（2026-04-26、PR #55 / `0507705`）
 
-工程4 完了後、Sub-C 実装担当（坂田銀時想定）+ テスト担当（涅マユリ想定）が本ファイルを READ → EDIT で実績を追記する。雛形は Sub-A §10.11 / Sub-B §11.11 に従う。
+| 区分 | TC 数 | pass | 検証手段 |
+|---|---|---|---|
+| ユニット（runtime + KAT） | 18 | 18 | CI `cargo test -p shikomi-infra` で 67 unit pass、Sub-C 関連 22 件確認（aes_gcm 9 + kat 9 + aead_key 4） |
+| 結合（grep + cargo check） | 5 | 5 | `tests/docs/sub-c-static-checks.sh` 4/4 PASS（SKIP→PASS 切替成功） + CI cargo check |
+| property（proptest 1000 ケース）| **2** | **2 PASS** | **Bug-C-001 顛末**: 銀ちゃん impl は単発 fixture のみ、テスト工程で `crates/shikomi-infra/tests/aead_property.rs` を新規実装、Docker `rust:1.95-slim` aarch64 release で 1000 ケース 0.12 秒完走 |
+| E2E | 1 | 1 | CI 8 ジョブ全 SUCCESS、bench-kdf 3 OS 全 PASS（Sub-B 既存契約も維持）|
+| **合計** | **26** | **26 PASS** | CI + Docker proptest + 静的 grep の三系で交叉確認 |
+
+**Bug-C-001 顛末（テスト工程発見）**:
+
+設計書 §12.4 / §12.7 が要求した **proptest 1000 ケース**（TC-C-P01 AAD swap + TC-C-P02 encrypt/decrypt 往復）に対し、銀ちゃん impl PR #55 では：
+
+- **単発 fixture 1 件**で AAD 入れ替え検証 (`decrypt_with_swapped_aad_returns_aead_tag_mismatch`)
+- **単発 fixture 1 件**で encrypt/decrypt 往復検証 (`encrypt_then_decrypt_roundtrip_bit_exact`)
+
+を実装。これは「設計者が想定したケース 1 件で invariant が成立する確認」であり、「ランダム入力空間 1000 ケースで invariant が成立する確率的検証」とは**意味論が異なる**。proptest crate 不在で、shrinking で minimal failing case を提示する経路もゼロ。
+
+**マユリ Boy Scout で補強**:
+
+1. workspace + shikomi-infra dev-dependencies に `proptest = "1"` 追加
+2. `crates/shikomi-infra/tests/aead_property.rs` 新規作成（160 行）
+   - `vek_strategy` / `nonce_strategy` / `aad_strategy` / `plaintext_strategy` で入力空間定義
+   - `ProptestConfig::with_cases(1000)` で**1000 ケース明示**（proptest デフォルト 256 ケースとの乖離を構造防衛）
+3. Docker `rust:1.95-slim` aarch64 release で実行 → **2/2 PASS、所要 0.12 秒**
+
+**proptest 経路で発見した実装の堅牢性**:
+
+- TC-C-P02 (1000 ケース): 任意 plaintext (0..=4096B) + 任意 Vek + 任意 Aad + 任意 nonce で encrypt → decrypt 往復が**全件 bit-exact**。AES-GCM 実装の入力空間網羅性を確認
+- TC-C-P01 (1000 ケース): AAD 入れ替え攻撃 + nonce 入れ替え攻撃を**全件 `Err(AeadTagMismatch)`** で検出
+
+**重大度更新**:
+- Bug-C-001 (proptest 1000 ケース不在): Medium → **Resolved**（テスト工程で proptest 実装を追加、設計と実装の意味論的整合確保）
+
+**新規補助スクリプト・テスト**:
+- `crates/shikomi-infra/tests/aead_property.rs`: TC-C-P01 / P02 実装、1000 ケース proptest
+- `tests/docs/sub-c-static-checks.sh`: TC-C-I01〜I04 grep 検証（4/4 PASS、Sub-A/B 同型）
+
+**全 regression 維持**: lint 20/20 + cross-ref 9/9 + sub-a 3/3 + sub-b 3/3 + sub-c 4/4 = **39/39 PASS**


### PR DESCRIPTION
## Summary

Test execution phase for Sub-C (#41) impl PR #55 (`0507705`). 26/26 TC pass.

| Channel | Result |
|---|---|
| GitHub Actions CI | 67 unit tests pass (22 Sub-C crypto), 8 jobs all green incl bench-kdf 3 OS |
| Docker `rust:1.95-slim` aarch64 release | proptest 2 tests @ 1000 cases each = 0.12s all PASS |
| `tests/docs/sub-c-static-checks.sh` | 4/4 PASS (SKIP→PASS on impl arrival) |

## Bug-C-001 (Medium → Resolved)

impl PR #55 implemented TC-C-P01 / P02 as **single-fixture unit tests**, but design §12.4 / §12.7 explicitly required **proptest 1000 cases**. `proptest` crate was absent from the workspace.

Boy-Scout fix in this PR:
- Added `proptest = "1"` to workspace + shikomi-infra dev-dependencies.
- New `crates/shikomi-infra/tests/aead_property.rs` (170 lines) with `ProptestConfig::with_cases(1000)` explicit and full input-space strategies (Vek / NonceBytes / Aad / plaintext 0..=4096B).
- Two property tests:
  - `tc_c_p02_encrypt_decrypt_roundtrip_property`: 1000 cases roundtrip bit-exact.
  - `tc_c_p01_aad_swap_attack_detected`: 1000 cases AAD-swap + nonce-swap → `AeadTagMismatch`.

## Test plan

- [x] CI all SUCCESS for `0507705`
- [x] Docker proptest: 2 tests × 1000 cases all PASS in 0.12s
- [x] sub-c-static-checks.sh 4/4 PASS
- [x] Sub-A/B regression suites green (3/3, 3/3)
- [x] Sub-0 lint/cross-ref green (20/20, 9/9)

Closes test execution phase of #41.