### PR TITLE
feat(vault-encryption): implement Sub-D encrypted vault repository service (Issue #42)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,13 +752,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1189,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1228,6 +1240,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
@@ -1279,6 +1300,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "ptyprocess"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,9 +1334,35 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand_core"
@@ -1309,6 +1371,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1666,7 +1746,8 @@ dependencies = [
  "fs4",
  "getrandom 0.2.17",
  "hkdf",
- "rand_core",
+ "proptest",
+ "rand_core 0.6.4",
  "rusqlite",
  "secrecy",
  "serial_test",
@@ -2005,6 +2086,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/shikomi-infra/src/crypto/aead/aes_gcm.rs
+++ b/crates/shikomi-infra/src/crypto/aead/aes_gcm.rs
@@ -178,6 +178,70 @@ impl AesGcmAeadAdapter {
             Ok(buf.to_vec())
         })
     }
+
+    /// 任意長 AAD で AEAD encrypt (ヘッダ封筒用、plaintext は通常空 byte)。
+    ///
+    /// `encrypt_record` は `Aad` 型 (26B 固定) を要求するが、ヘッダ AEAD は
+    /// `canonical_bytes_for_aad` (任意長) を AAD に取る必要がある (C-17/C-18)。
+    /// 本メソッドは raw byte slice を AAD に取り、空 plaintext + tag のみで
+    /// MAC として動作させる用途を含む (AES-256-GCM は空 plaintext + AAD でも
+    /// 16B authentic tag を返す)。
+    ///
+    /// # Errors
+    ///
+    /// AEAD 暗号化失敗時 `CryptoError::AeadTagMismatch` (内部詳細秘匿)。
+    pub fn encrypt_with_raw_aad(
+        &self,
+        key: &impl AeadKey,
+        nonce: &NonceBytes,
+        aad: &[u8],
+        plaintext: &[u8],
+    ) -> Result<(Vec<u8>, AuthTag), CryptoError> {
+        let nonce_ga = GenericArray::clone_from_slice(nonce.as_array());
+        let mut buf: Zeroizing<Vec<u8>> = Zeroizing::new(plaintext.to_vec());
+
+        let tag_ga = key
+            .with_secret_bytes(|bytes| {
+                let cipher_key: &Key<Aes256Gcm> = Key::<Aes256Gcm>::from_slice(bytes);
+                let cipher = Aes256Gcm::new(cipher_key);
+                cipher.encrypt_in_place_detached(&nonce_ga, aad, buf.as_mut_slice())
+            })
+            .map_err(|_| CryptoError::AeadTagMismatch)?;
+
+        let tag_array: [u8; 16] = tag_ga.into();
+        Ok((buf.to_vec(), AuthTag::from_array(tag_array)))
+    }
+
+    /// 任意長 AAD で AEAD decrypt (ヘッダ封筒検証用)。
+    ///
+    /// タグ検証成功時のみ `Verified<Plaintext>` を返す。失敗時は内部詳細秘匿で
+    /// `Err(CryptoError::AeadTagMismatch)`。
+    ///
+    /// # Errors
+    ///
+    /// AEAD 検証失敗時 `CryptoError::AeadTagMismatch` (内部詳細秘匿)。
+    pub fn decrypt_with_raw_aad(
+        &self,
+        key: &impl AeadKey,
+        nonce: &NonceBytes,
+        aad: &[u8],
+        ciphertext: &[u8],
+        tag: &AuthTag,
+    ) -> Result<Verified<Plaintext>, CryptoError> {
+        let nonce_ga = GenericArray::clone_from_slice(nonce.as_array());
+        let tag_ga = GenericArray::clone_from_slice(tag.as_array());
+
+        verify_aead_decrypt_to_plaintext(|| {
+            let mut buf: Zeroizing<Vec<u8>> = Zeroizing::new(ciphertext.to_vec());
+            key.with_secret_bytes(|bytes| {
+                let cipher_key: &Key<Aes256Gcm> = Key::<Aes256Gcm>::from_slice(bytes);
+                let cipher = Aes256Gcm::new(cipher_key);
+                cipher.decrypt_in_place_detached(&nonce_ga, aad, buf.as_mut_slice(), &tag_ga)
+            })
+            .map_err(|_| CryptoError::AeadTagMismatch)?;
+            Ok(buf.to_vec())
+        })
+    }
 }
 
 // `aes_gcm::Error` → `CryptoError::AeadTagMismatch` の変換は `From` impl を
@@ -400,5 +464,60 @@ mod tests {
             .unwrap_vek(&kek_recovery, &wrapped)
             .expect("unwrap ok");
         assert_eq!(verified.as_inner().expose_secret(), &vek_bytes);
+    }
+
+    // -----------------------------------------------------------------
+    // encrypt_with_raw_aad / decrypt_with_raw_aad (任意長 AAD、ヘッダ封筒用)
+    // -----------------------------------------------------------------
+
+    /// 任意長 AAD + 空 plaintext で MAC として動作させ、同 AAD で検証成功 +
+    /// 別 AAD で `AeadTagMismatch` を確認する (C-17/C-18 ヘッダ AEAD 用)。
+    #[test]
+    fn raw_aad_encrypt_then_decrypt_roundtrip_and_swap_fails() {
+        let adapter = AesGcmAeadAdapter;
+        let kek = make_kek(0x5A);
+        let nonce = make_nonce(0xC3);
+        let aad = b"canonical-header-bytes-arbitrary-length-payload-1234567890";
+        let aad_other = b"canonical-header-bytes-DIFFERENT-payload-0987654321!!!!!!!";
+
+        // 空 plaintext (header AEAD envelope の標準ケース)
+        let (ct, tag) = adapter
+            .encrypt_with_raw_aad(&kek, &nonce, aad, &[])
+            .expect("encrypt ok");
+        // 空 plaintext → ciphertext も 0 byte (detached tag)
+        assert_eq!(ct.len(), 0);
+
+        // 同 AAD で decrypt → bit-exact 一致 (空)
+        let verified = adapter
+            .decrypt_with_raw_aad(&kek, &nonce, aad, &ct, &tag)
+            .expect("decrypt ok");
+        assert_eq!(verified.as_inner().expose_secret(), b"");
+
+        // 別 AAD で decrypt → AeadTagMismatch
+        let err = adapter
+            .decrypt_with_raw_aad(&kek, &nonce, aad_other, &ct, &tag)
+            .expect_err("swapped raw AAD must fail");
+        assert!(matches!(err, CryptoError::AeadTagMismatch));
+    }
+
+    /// 非空 plaintext + 任意長 AAD でも roundtrip が動くことを確認 (一般化)。
+    #[test]
+    fn raw_aad_roundtrip_with_nonempty_plaintext_bit_exact() {
+        let adapter = AesGcmAeadAdapter;
+        let kek = make_kek(0x77);
+        let nonce = make_nonce(0x88);
+        let aad = b"AAD-of-arbitrary-length";
+        let pt = b"the quick brown fox jumps over the lazy dog";
+
+        let (ct, tag) = adapter
+            .encrypt_with_raw_aad(&kek, &nonce, aad, pt)
+            .expect("encrypt ok");
+        assert_eq!(ct.len(), pt.len());
+        assert_ne!(ct.as_slice(), pt.as_slice());
+
+        let verified = adapter
+            .decrypt_with_raw_aad(&kek, &nonce, aad, &ct, &tag)
+            .expect("decrypt ok");
+        assert_eq!(verified.as_inner().expose_secret(), pt);
     }
 }

--- a/crates/shikomi-infra/src/persistence/mod.rs
+++ b/crates/shikomi-infra/src/persistence/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod paths;
 pub(crate) mod permission;
 pub(crate) mod repository;
 pub(crate) mod sqlite;
+pub mod vault_migration;
 
 // -------------------------------------------------------------------
 // 公開 re-export
@@ -24,11 +25,19 @@ pub use error::{AtomicWriteStage, CorruptedReason, PersistenceError, VaultDirRea
 pub use paths::VaultPaths;
 pub use repository::SqliteVaultRepository;
 
+// Sub-D (#42) vault migration service と新規型 (8 種)。
+pub use vault_migration::{
+    DecryptConfirmation, EncryptedRecord, HeaderAeadEnvelope, KdfParams, MigrationError,
+    RecoveryDisclosure, RecoveryWords, VaultEncryptedHeader, VaultMigration,
+};
+
 // -------------------------------------------------------------------
 // 定数
 // -------------------------------------------------------------------
 
-/// 暗号化 vault 永続化の追跡 Issue 番号。未登録のため `None`。
+/// 暗号化 vault 永続化の追跡 Issue 番号。Sub-D (#42) で実装解禁済のため `None` を維持。
+/// 旧 `TRACKING_ISSUE_ENCRYPTED_VAULT` は repository.rs から参照されない (Sub-D 解禁)。
+#[allow(dead_code)]
 pub(crate) const TRACKING_ISSUE_ENCRYPTED_VAULT: Option<u32> = None;
 
 // -------------------------------------------------------------------

--- a/crates/shikomi-infra/src/persistence/repository.rs
+++ b/crates/shikomi-infra/src/persistence/repository.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::time::Instant;
 
 use rusqlite::{Connection, OpenFlags};
-use shikomi_core::{ProtectionMode, Record, Vault};
+use shikomi_core::{Record, Vault};
 
 use super::{
     audit::Audit,
@@ -13,7 +13,7 @@ use super::{
     paths::{self, VaultPaths},
     permission::PermissionGuard,
     sqlite::{atomic::AtomicWriter, mapping::Mapping, schema::SchemaSql},
-    VaultRepository, TRACKING_ISSUE_ENCRYPTED_VAULT,
+    VaultRepository,
 };
 
 // -------------------------------------------------------------------
@@ -197,13 +197,8 @@ impl SqliteVaultRepository {
         // Step 10: vault_header を SELECT
         let header = Self::select_vault_header(&conn)?;
 
-        // Step 12: 暗号化モードは未実装
-        if header.protection_mode() == ProtectionMode::Encrypted {
-            return Err(PersistenceError::UnsupportedYet {
-                feature: "encrypted vault persistence",
-                tracking_issue: TRACKING_ISSUE_ENCRYPTED_VAULT,
-            });
-        }
+        // Step 12: Sub-D (#42) で暗号化モードを解禁。protection_mode による拒否経路は削除。
+        // 暗号化処理 (AEAD 検証 / wrap_VEK 復号) は呼出側 (`VaultMigration` / Sub-E daemon) 責務。
 
         // Step 13: Vault 集約を構築
         let mut vault = Vault::new(header);
@@ -290,13 +285,8 @@ impl SqliteVaultRepository {
 
     /// `save` の実装本体。audit ログなしで vault を書き込む。書き込みバイト数を返す。
     fn save_inner(&self, vault: &Vault) -> Result<u64, PersistenceError> {
-        // Step 2: 暗号化モードは未実装（Fail Fast）
-        if vault.protection_mode() == ProtectionMode::Encrypted {
-            return Err(PersistenceError::UnsupportedYet {
-                feature: "encrypted vault persistence",
-                tracking_issue: TRACKING_ISSUE_ENCRYPTED_VAULT,
-            });
-        }
+        // Step 2: Sub-D (#42) で暗号化モード save を解禁。Fail Fast 拒否経路は削除。
+        // BLOB は composite container として `Mapping::vault_header_to_params` で詰める。
 
         // Step 3: ディレクトリを作成し、適切なパーミッションを設定
         PermissionGuard::ensure_dir(self.paths.dir())?;

--- a/crates/shikomi-infra/src/persistence/sqlite/mapping/header.rs
+++ b/crates/shikomi-infra/src/persistence/sqlite/mapping/header.rs
@@ -1,23 +1,22 @@
 //! `VaultHeader` ↔ `SQLite` 行のマッピング。
 //!
-//! Sub-A 改訂: `WrappedVek` の内部構造分離型化に伴い、暗号化ヘッダの BLOB シリアライズ
-//! 形式は **Sub-D で `bincode` 等の正式フォーマットに確定する**。
-//! Sub-A 〜 Sub-C 期間中、暗号化ヘッダの永続化は型レベルで未実装とし、本マッピング層は
-//! `UnsupportedYet { feature: "encrypted vault header (Sub-D)" }` を即返す。
-//! `repository::save_inner` / `repository::load` も Encrypted モードを Fail Fast で
-//! 弾いており、本層は二重防御として動作する。
+//! Sub-D (#42) 改訂: 暗号化モード分岐を解禁。
+//! `wrapped_vek_by_pw` 列は composite container BLOB として詰められ
+//! (`vault_migration::storage` で構築)、`nonce_counter` / `kdf_params` /
+//! `header_aead_envelope` を内包する。本層は BLOB を **不透明な `Vec<u8>` として**
+//! SQLite に保存・復元するだけで、暗号化アルゴリズムには無知 (REQ-P11 改訂、
+//! 設計書 §責務境界: SqliteVaultRepository は暗号化に「無知」のまま据え置き)。
 
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
-use shikomi_core::{ProtectionMode, VaultHeader, VaultVersion};
+use shikomi_core::{
+    AuthTag, KdfSalt, NonceBytes, ProtectionMode, VaultHeader, VaultVersion, WrappedVek,
+};
 
 use crate::persistence::error::{CorruptedReason, PersistenceError};
 
 use super::{params::HeaderParams, Mapping};
-
-/// Sub-D で実装予定の暗号化ヘッダ永続化の追跡 Issue 番号 (Epic #37 / Sub-D #42)。
-const TRACKING_ISSUE_ENCRYPTED_HEADER: Option<u32> = Some(42);
 
 impl Mapping {
     /// `VaultHeader` → `HeaderParams` に変換する。
@@ -25,8 +24,6 @@ impl Mapping {
     /// # Errors
     ///
     /// - `created_at` の RFC3339 フォーマット失敗: `PersistenceError::Corrupted`
-    /// - 暗号化モードヘッダ: `PersistenceError::UnsupportedYet`
-    ///   (Sub-D で `WrappedVek` の正式 BLOB シリアライザを実装するまで未対応)
     pub(crate) fn vault_header_to_params(
         header: &VaultHeader,
     ) -> Result<HeaderParams, PersistenceError> {
@@ -45,8 +42,8 @@ impl Mapping {
                     source: None,
                 })?;
 
-        match header.protection_mode() {
-            ProtectionMode::Plaintext => Ok(HeaderParams {
+        match header {
+            VaultHeader::Plaintext(_) => Ok(HeaderParams {
                 protection_mode,
                 vault_version,
                 created_at_rfc3339,
@@ -54,10 +51,46 @@ impl Mapping {
                 wrapped_vek_by_pw: None,
                 wrapped_vek_by_recovery: None,
             }),
-            ProtectionMode::Encrypted => Err(PersistenceError::UnsupportedYet {
-                feature: "encrypted vault header (Sub-D)",
-                tracking_issue: TRACKING_ISSUE_ENCRYPTED_HEADER,
-            }),
+            VaultHeader::Encrypted(_) => {
+                let kdf_salt = header.kdf_salt().map(|s| s.as_array().to_vec()).ok_or(
+                    PersistenceError::Corrupted {
+                        table: "vault_header",
+                        row_key: None,
+                        reason: CorruptedReason::NullViolation { column: "kdf_salt" },
+                        source: None,
+                    },
+                )?;
+                let wrapped_vek_by_pw = header
+                    .wrapped_vek_by_pw()
+                    .map(serialize_wrapped_vek)
+                    .ok_or(PersistenceError::Corrupted {
+                        table: "vault_header",
+                        row_key: None,
+                        reason: CorruptedReason::NullViolation {
+                            column: "wrapped_vek_by_pw",
+                        },
+                        source: None,
+                    })?;
+                let wrapped_vek_by_recovery = header
+                    .wrapped_vek_by_recovery()
+                    .map(serialize_wrapped_vek)
+                    .ok_or(PersistenceError::Corrupted {
+                        table: "vault_header",
+                        row_key: None,
+                        reason: CorruptedReason::NullViolation {
+                            column: "wrapped_vek_by_recovery",
+                        },
+                        source: None,
+                    })?;
+                Ok(HeaderParams {
+                    protection_mode,
+                    vault_version,
+                    created_at_rfc3339,
+                    kdf_salt: Some(kdf_salt),
+                    wrapped_vek_by_pw: Some(wrapped_vek_by_pw),
+                    wrapped_vek_by_recovery: Some(wrapped_vek_by_recovery),
+                })
+            }
         }
     }
 
@@ -68,8 +101,7 @@ impl Mapping {
     /// - 保護モード不明: `PersistenceError::Corrupted`
     /// - vault バージョン範囲外: `PersistenceError::Corrupted`
     /// - RFC3339 パース失敗: `PersistenceError::Corrupted`
-    /// - 暗号化モード行: `PersistenceError::UnsupportedYet`
-    ///   (Sub-D で `WrappedVek` の正式 BLOB デシリアライザを実装するまで未対応)
+    /// - 暗号化モードで NULL 必須カラム欠落: `PersistenceError::Corrupted`
     pub(crate) fn row_to_vault_header(
         row: &rusqlite::Row<'_>,
     ) -> Result<VaultHeader, PersistenceError> {
@@ -136,10 +168,188 @@ impl Mapping {
                     },
                     source: Some(e),
                 }),
-            ProtectionMode::Encrypted => Err(PersistenceError::UnsupportedYet {
-                feature: "encrypted vault header (Sub-D)",
-                tracking_issue: TRACKING_ISSUE_ENCRYPTED_HEADER,
-            }),
+            ProtectionMode::Encrypted => {
+                // Col 3: kdf_salt (BLOB 16B)
+                let kdf_salt_raw: Option<Vec<u8>> = row
+                    .get(3)
+                    .map_err(|e| PersistenceError::Sqlite { source: e })?;
+                let kdf_salt_bytes = kdf_salt_raw.ok_or_else(|| PersistenceError::Corrupted {
+                    table: "vault_header",
+                    row_key: Some("1".to_string()),
+                    reason: CorruptedReason::NullViolation { column: "kdf_salt" },
+                    source: None,
+                })?;
+                let kdf_salt =
+                    KdfSalt::try_new(&kdf_salt_bytes).map_err(|e| PersistenceError::Corrupted {
+                        table: "vault_header",
+                        row_key: Some("1".to_string()),
+                        reason: CorruptedReason::InvalidRowCombination {
+                            detail: format!("invalid kdf_salt: {e}"),
+                        },
+                        source: Some(e),
+                    })?;
+
+                // Col 4: wrapped_vek_by_pw (BLOB, composite container >= 32B)
+                let pw_raw: Option<Vec<u8>> = row
+                    .get(4)
+                    .map_err(|e| PersistenceError::Sqlite { source: e })?;
+                let pw_bytes = pw_raw.ok_or_else(|| PersistenceError::Corrupted {
+                    table: "vault_header",
+                    row_key: Some("1".to_string()),
+                    reason: CorruptedReason::NullViolation {
+                        column: "wrapped_vek_by_pw",
+                    },
+                    source: None,
+                })?;
+                let wrapped_vek_by_pw = deserialize_wrapped_vek(&pw_bytes).map_err(|e| {
+                    PersistenceError::Corrupted {
+                        table: "vault_header",
+                        row_key: Some("1".to_string()),
+                        reason: CorruptedReason::InvalidRowCombination {
+                            detail: format!("invalid wrapped_vek_by_pw: {e}"),
+                        },
+                        source: Some(e),
+                    }
+                })?;
+
+                // Col 5: wrapped_vek_by_recovery (BLOB)
+                let recovery_raw: Option<Vec<u8>> = row
+                    .get(5)
+                    .map_err(|e| PersistenceError::Sqlite { source: e })?;
+                let recovery_bytes = recovery_raw.ok_or_else(|| PersistenceError::Corrupted {
+                    table: "vault_header",
+                    row_key: Some("1".to_string()),
+                    reason: CorruptedReason::NullViolation {
+                        column: "wrapped_vek_by_recovery",
+                    },
+                    source: None,
+                })?;
+                let wrapped_vek_by_recovery =
+                    deserialize_wrapped_vek(&recovery_bytes).map_err(|e| {
+                        PersistenceError::Corrupted {
+                            table: "vault_header",
+                            row_key: Some("1".to_string()),
+                            reason: CorruptedReason::InvalidRowCombination {
+                                detail: format!("invalid wrapped_vek_by_recovery: {e}"),
+                            },
+                            source: Some(e),
+                        }
+                    })?;
+
+                VaultHeader::new_encrypted(
+                    vault_version,
+                    created_at,
+                    kdf_salt,
+                    wrapped_vek_by_pw,
+                    wrapped_vek_by_recovery,
+                )
+                .map_err(|e| PersistenceError::Corrupted {
+                    table: "vault_header",
+                    row_key: Some("1".to_string()),
+                    reason: CorruptedReason::InvalidRowCombination {
+                        detail: e.to_string(),
+                    },
+                    source: Some(e),
+                })
+            }
         }
+    }
+}
+
+/// `WrappedVek` を `nonce(12) ‖ tag(16) ‖ ciphertext(N)` 形式に直列化する
+/// (vault_header 列保存用、N は composite container 含み可変)。
+fn serialize_wrapped_vek(w: &WrappedVek) -> Vec<u8> {
+    let mut out = Vec::with_capacity(12 + 16 + w.ciphertext().len());
+    out.extend_from_slice(w.nonce().as_array());
+    out.extend_from_slice(w.tag().as_array());
+    out.extend_from_slice(w.ciphertext());
+    out
+}
+
+/// `nonce(12) ‖ tag(16) ‖ ciphertext(N)` BLOB を `WrappedVek` に復元する。
+fn deserialize_wrapped_vek(bytes: &[u8]) -> Result<WrappedVek, shikomi_core::DomainError> {
+    if bytes.len() < 12 + 16 + 32 {
+        // 構造的最小サイズ: nonce 12 + tag 16 + ciphertext (>=32 = WrappedVek 最小)
+        return Err(shikomi_core::DomainError::InvalidVaultHeader(
+            shikomi_core::InvalidVaultHeaderReason::WrappedVekTooShort,
+        ));
+    }
+    let mut nonce_arr = [0u8; 12];
+    nonce_arr.copy_from_slice(&bytes[0..12]);
+    let mut tag_arr = [0u8; 16];
+    tag_arr.copy_from_slice(&bytes[12..28]);
+    let ciphertext = bytes[28..].to_vec();
+    WrappedVek::new(
+        ciphertext,
+        NonceBytes::from_random(nonce_arr),
+        AuthTag::from_array(tag_arr),
+    )
+}
+
+// 不使用の型のみエクスポート - `DomainError` 構築に必要な場合に備えて
+#[allow(unused_imports)]
+use shikomi_core::InvalidVaultHeaderReason as _;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::{KdfSalt, NonceBytes};
+
+    fn dummy_wrapped_vek() -> WrappedVek {
+        WrappedVek::new(
+            vec![0xAAu8; 48], // composite container 模倣 (>= 32B)
+            NonceBytes::from_random([0xBBu8; 12]),
+            AuthTag::from_array([0xCCu8; 16]),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn serialize_deserialize_wrapped_vek_round_trip() {
+        let original = dummy_wrapped_vek();
+        let bytes = serialize_wrapped_vek(&original);
+        let restored = deserialize_wrapped_vek(&bytes).unwrap();
+        assert_eq!(restored.ciphertext(), original.ciphertext());
+        assert_eq!(restored.nonce().as_array(), original.nonce().as_array());
+        assert_eq!(restored.tag().as_array(), original.tag().as_array());
+    }
+
+    #[test]
+    fn deserialize_wrapped_vek_too_short_returns_err() {
+        let err = deserialize_wrapped_vek(&[0u8; 30]).unwrap_err();
+        assert!(matches!(
+            err,
+            shikomi_core::DomainError::InvalidVaultHeader(_)
+        ));
+    }
+
+    #[test]
+    fn vault_header_to_params_for_encrypted_returns_some_blobs() {
+        let kdf_salt = KdfSalt::from_array([0u8; 16]);
+        let wrapped = dummy_wrapped_vek();
+        let header = VaultHeader::new_encrypted(
+            VaultVersion::CURRENT,
+            OffsetDateTime::UNIX_EPOCH,
+            kdf_salt,
+            wrapped.clone(),
+            wrapped.clone(),
+        )
+        .unwrap();
+        let params = Mapping::vault_header_to_params(&header).unwrap();
+        assert_eq!(params.protection_mode, "encrypted");
+        assert!(params.kdf_salt.is_some());
+        assert!(params.wrapped_vek_by_pw.is_some());
+        assert!(params.wrapped_vek_by_recovery.is_some());
+    }
+
+    #[test]
+    fn vault_header_to_params_for_plaintext_returns_none_blobs() {
+        let header =
+            VaultHeader::new_plaintext(VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).unwrap();
+        let params = Mapping::vault_header_to_params(&header).unwrap();
+        assert_eq!(params.protection_mode, "plaintext");
+        assert!(params.kdf_salt.is_none());
+        assert!(params.wrapped_vek_by_pw.is_none());
+        assert!(params.wrapped_vek_by_recovery.is_none());
     }
 }

--- a/crates/shikomi-infra/src/persistence/vault_migration/confirmation.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/confirmation.rs
@@ -1,0 +1,83 @@
+//! `DecryptConfirmation` — `vault decrypt` 二段確認の型レベル証跡 (Sub-D 新規)。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/repository-and-migration.md`
+//! §`DecryptConfirmation` (C-20)
+//!
+//! ## C-20 型レベル強制契約
+//!
+//! - `_private: ()` フィールドが非 `pub` のため**外部 crate から直接構築禁止**。
+//! - `DecryptConfirmation::confirm()` のみが `Self` を返す pub API。
+//! - `VaultMigration::decrypt_vault(.., _confirm: DecryptConfirmation)` の引数で
+//!   存在を強制 → `--force` フラグでも省略不可 (Sub-F CLI 経路で型シグネチャに支配される)。
+
+use core::fmt;
+
+/// `vault decrypt` 二段確認の型レベル証跡。
+///
+/// 設計書 §`DecryptConfirmation`:
+/// - 外部 crate からの直接構築禁止 (`_private: ()` 非可視性)。
+/// - `confirm()` のみが pub コンストラクタ (Sub-F CLI が「DECRYPT」キーワード入力 +
+///   パスワード再入力の二段確認通過後に呼ぶ)。
+/// - `VaultMigration::decrypt_vault` の引数として要求される。
+pub struct DecryptConfirmation {
+    /// 非 `pub` フィールド。外部 crate からの直接構築禁止 (C-20 構造的封鎖)。
+    _private: (),
+}
+
+impl DecryptConfirmation {
+    /// 二段確認通過後に Sub-F CLI / GUI が呼ぶコンストラクタ。
+    ///
+    /// ## 呼出側責務 (Sub-F CLI / GUI)
+    ///
+    /// 1. ユーザに「DECRYPT」大文字英字を**手入力**させる (UI で paste 抑制)。
+    /// 2. パスワード再入力させる (`subtle::ConstantTimeEq` で比較)。
+    /// 3. 両方通過後に本関数を呼んで `DecryptConfirmation` を取得。
+    /// 4. `VaultMigration::decrypt_vault(_, confirm)` の引数として渡す。
+    ///
+    /// 本関数自体は引数を取らない。確認ロジックは Sub-F CLI/GUI 層が担当し、
+    /// 通過した事実だけを型レベル証跡として `DecryptConfirmation` に閉じ込める。
+    /// (二段確認の具体ロジックを shikomi-infra に持ち込まない、Clean Arch 維持)
+    #[must_use]
+    pub fn confirm() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl fmt::Debug for DecryptConfirmation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("DecryptConfirmation(confirmed)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// TC-D-U08 simplified: `confirm()` で `DecryptConfirmation` を構築できる。
+    /// 二段確認の具体ロジック (yes_keyword / password_reentry) は Sub-F CLI 層実装、
+    /// shikomi-infra 側は通過証跡型のみ提供する責務分離。
+    #[test]
+    fn confirm_constructs_decrypt_confirmation() {
+        let _ = DecryptConfirmation::confirm();
+    }
+
+    #[test]
+    fn debug_returns_fixed_marker() {
+        let c = DecryptConfirmation::confirm();
+        assert_eq!(format!("{c:?}"), "DecryptConfirmation(confirmed)");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 型レベル強制 compile_fail doctest (C-20 / TC-D-U11)
+// ---------------------------------------------------------------------------
+
+/// TC-D-U11: 外部 crate から `DecryptConfirmation { _private: () }` 直接構築は compile_fail。
+///
+/// ```compile_fail
+/// use shikomi_infra::persistence::vault_migration::DecryptConfirmation;
+/// // _private フィールドは非 pub のため外部から構築できない (E0451)。
+/// let _ = DecryptConfirmation { _private: () };
+/// ```
+#[cfg(doctest)]
+struct _CompileFailGuard;

--- a/crates/shikomi-infra/src/persistence/vault_migration/error.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/error.rs
@@ -67,7 +67,9 @@ pub enum MigrationError {
     },
 
     /// リカバリ経路 unlock が必要 (パスワード経路で `MasterPassword::new` 失敗等)。
-    /// MSG-S12 リカバリ経路へ誘導。
+    /// MSG-S09 (a) パスワード違いカテゴリの「リカバリ経路 (`vault unlock --recovery`) も可能」
+    /// 案内へ変換 (Sub-E IPC V2 / Sub-F CLI 文言確定責務)。
+    /// MSG-S12 はリカバリ入力検証失敗 (`CryptoError::InvalidMnemonic` 等) 専用で本 variant とは別経路。
     #[error("recovery path required")]
     RecoveryRequired,
 }
@@ -123,6 +125,12 @@ mod tests {
     }
 
     /// DC-7: `match` 網羅で warning 0 件 (variant 増減検出)。
+    ///
+    /// `#[non_exhaustive]` は **defining crate (本 crate) 内では無効** であり、
+    /// 9 variant を全列挙した時点で exhaustive。ワイルドカード `_` は付けない
+    /// (TC-D-U12 設計書指示 + TC-D-S07 grep gate で機械検証)。
+    /// variant 追加時は本テストが **実際に** 先に壊れ (E0004 non-exhaustive patterns)、
+    /// 設計書 / テスト設計 / 実装の四層同期漏れを早期検出する。
     #[test]
     fn all_variants_match_exhaustively() {
         let e = MigrationError::AlreadyEncrypted;
@@ -136,9 +144,6 @@ mod tests {
             MigrationError::RecoveryAlreadyConsumed => "recovery-consumed",
             MigrationError::AtomicWriteFailed { .. } => "atomic-write-failed",
             MigrationError::RecoveryRequired => "recovery-required",
-            // `#[non_exhaustive]` で外部 crate には wildcard が必須だが
-            // crate 内 match では網羅すれば exhaustive。将来 variant 追加時は本テストが先に壊れる。
-            _ => "unknown",
         };
     }
 }

--- a/crates/shikomi-infra/src/persistence/vault_migration/error.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/error.rs
@@ -120,7 +120,9 @@ mod tests {
     fn atomic_write_failed_displays_stage() {
         let e = MigrationError::AtomicWriteFailed {
             stage: AtomicWriteStage::Rename,
-            source: std::io::Error::new(std::io::ErrorKind::Other, "boom"),
+            // clippy::io_other_error (clippy::all level deny): `Error::new(Other, ...)` の代わりに
+            // `Error::other(...)` を使う (std 1.74+ の short-cut API)。
+            source: std::io::Error::other("boom"),
         };
         let msg = format!("{e}");
         assert!(msg.contains("rename"));

--- a/crates/shikomi-infra/src/persistence/vault_migration/error.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/error.rs
@@ -43,12 +43,6 @@ pub enum MigrationError {
     #[error("vault is not encrypted")]
     NotEncrypted,
 
-    /// `decrypt_vault` で `DecryptConfirmation` 引数が必要だが
-    /// 構築前経路で呼出された (本来は型シグネチャで防がれるが防衛的に variant 化)。
-    /// MSG-S14 経路で UI 確認モーダル再表示。
-    #[error("decrypt confirmation required")]
-    ConfirmationRequired,
-
     /// 復号に成功した平文 record が UTF-8 不正だった。
     /// AEAD 検証通過後の追加検証層、ありえない経路の防衛的 variant。
     #[error("decrypted plaintext is not valid UTF-8")]
@@ -138,7 +132,6 @@ mod tests {
             MigrationError::Domain(_) => "domain",
             MigrationError::AlreadyEncrypted => "already-encrypted",
             MigrationError::NotEncrypted => "not-encrypted",
-            MigrationError::ConfirmationRequired => "confirmation-required",
             MigrationError::PlaintextNotUtf8 => "plaintext-not-utf8",
             MigrationError::RecoveryAlreadyConsumed => "recovery-consumed",
             MigrationError::AtomicWriteFailed { .. } => "atomic-write-failed",

--- a/crates/shikomi-infra/src/persistence/vault_migration/error.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/error.rs
@@ -1,0 +1,149 @@
+//! `MigrationError` — Sub-D vault マイグレーション失敗の統一エラー型。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/repository-and-migration.md`
+//! §`MigrationError`
+//!
+//! `#[non_exhaustive]` で外部 crate からの破壊的変更耐性を確保 (DC-7)。
+//! `Crypto(CryptoError)` / `Persistence(PersistenceError)` / `DomainError` を
+//! `#[from]` で内包し、各レイヤエラーを透過する。
+
+use shikomi_core::error::{CryptoError, DomainError};
+use thiserror::Error;
+
+use crate::persistence::error::{AtomicWriteStage, PersistenceError};
+
+/// vault マイグレーション失敗の統一エラー型 (Sub-D)。
+///
+/// 設計書 §`MigrationError` (DC-7): 5+ variants、`#[non_exhaustive]`。
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MigrationError {
+    /// 暗号操作 (KDF / AEAD / 強度ゲート) の失敗を透過する。
+    /// `CryptoError::AeadTagMismatch` (MSG-S10) / `CryptoError::WeakPassword` (MSG-S08) /
+    /// `CryptoError::NonceLimitExceeded` (MSG-S11) 等を運ぶ。
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
+
+    /// 永続化レイヤエラーを透過する。
+    #[error(transparent)]
+    Persistence(#[from] PersistenceError),
+
+    /// shikomi-core ドメインエラーを透過する。
+    /// `DomainError::Crypto(_)` を直接受け取った場合の経路。
+    #[error(transparent)]
+    Domain(#[from] DomainError),
+
+    /// 平文 vault に対し `encrypt_vault` 以外の暗号化前提メソッドを呼んだ。
+    /// 既に暗号化済み vault に対し `encrypt_vault` を再実行した場合も同様。
+    #[error("vault is already encrypted")]
+    AlreadyEncrypted,
+
+    /// 暗号化 vault に対し `decrypt_vault` 以外の平文前提メソッドを呼んだ。
+    /// あるいは平文 vault に対し `decrypt_vault` を呼んだ場合。
+    #[error("vault is not encrypted")]
+    NotEncrypted,
+
+    /// `decrypt_vault` で `DecryptConfirmation` 引数が必要だが
+    /// 構築前経路で呼出された (本来は型シグネチャで防がれるが防衛的に variant 化)。
+    /// MSG-S14 経路で UI 確認モーダル再表示。
+    #[error("decrypt confirmation required")]
+    ConfirmationRequired,
+
+    /// 復号に成功した平文 record が UTF-8 不正だった。
+    /// AEAD 検証通過後の追加検証層、ありえない経路の防衛的 variant。
+    #[error("decrypted plaintext is not valid UTF-8")]
+    PlaintextNotUtf8,
+
+    /// `RecoveryDisclosure::disclose` を 2 度呼び出そうとした (runtime 検出)。
+    /// 通常は所有権消費でコンパイルエラーになるが、`drop_without_disclose` 後の
+    /// 観測可能な経路防衛のための variant。
+    #[error("recovery disclosure already consumed")]
+    RecoveryAlreadyConsumed,
+
+    /// マイグレーション中の atomic write 失敗で原状復帰 (C-21)。
+    /// `vault-persistence` の `.new` cleanup 経路に委譲済みで、本 variant 受理時点で
+    /// vault.db バイト列は変更前状態。MSG-S13 経路。
+    #[error("vault migration atomic write failed at stage {stage}")]
+    AtomicWriteFailed {
+        /// 失敗ステージ (`PrepareNew` / `WriteTemp` / `FsyncTemp` / `FsyncDir` / `Rename` / `CleanupOrphan`)。
+        stage: AtomicWriteStage,
+        /// 元 IO エラー。
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// リカバリ経路 unlock が必要 (パスワード経路で `MasterPassword::new` 失敗等)。
+    /// MSG-S12 リカバリ経路へ誘導。
+    #[error("recovery path required")]
+    RecoveryRequired,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::crypto::WeakPasswordFeedback;
+
+    #[test]
+    fn from_crypto_error_wraps_aead_tag_mismatch() {
+        let e: MigrationError = CryptoError::AeadTagMismatch.into();
+        assert!(matches!(
+            e,
+            MigrationError::Crypto(CryptoError::AeadTagMismatch)
+        ));
+    }
+
+    #[test]
+    fn from_crypto_error_wraps_weak_password() {
+        let fb = WeakPasswordFeedback::new(Some("too short".to_string()), vec![]);
+        let e: MigrationError = CryptoError::WeakPassword(Box::new(fb)).into();
+        assert!(matches!(
+            e,
+            MigrationError::Crypto(CryptoError::WeakPassword(_))
+        ));
+    }
+
+    #[test]
+    fn already_encrypted_displays_known_phrase() {
+        let e = MigrationError::AlreadyEncrypted;
+        let msg = format!("{e}");
+        assert!(msg.contains("already encrypted"));
+    }
+
+    #[test]
+    fn not_encrypted_displays_known_phrase() {
+        let e = MigrationError::NotEncrypted;
+        let msg = format!("{e}");
+        assert!(msg.contains("not encrypted"));
+    }
+
+    #[test]
+    fn atomic_write_failed_displays_stage() {
+        let e = MigrationError::AtomicWriteFailed {
+            stage: AtomicWriteStage::Rename,
+            source: std::io::Error::new(std::io::ErrorKind::Other, "boom"),
+        };
+        let msg = format!("{e}");
+        assert!(msg.contains("rename"));
+    }
+
+    /// DC-7: `match` 網羅で warning 0 件 (variant 増減検出)。
+    #[test]
+    fn all_variants_match_exhaustively() {
+        let e = MigrationError::AlreadyEncrypted;
+        let _: &str = match e {
+            MigrationError::Crypto(_) => "crypto",
+            MigrationError::Persistence(_) => "persistence",
+            MigrationError::Domain(_) => "domain",
+            MigrationError::AlreadyEncrypted => "already-encrypted",
+            MigrationError::NotEncrypted => "not-encrypted",
+            MigrationError::ConfirmationRequired => "confirmation-required",
+            MigrationError::PlaintextNotUtf8 => "plaintext-not-utf8",
+            MigrationError::RecoveryAlreadyConsumed => "recovery-consumed",
+            MigrationError::AtomicWriteFailed { .. } => "atomic-write-failed",
+            MigrationError::RecoveryRequired => "recovery-required",
+            // `#[non_exhaustive]` で外部 crate には wildcard が必須だが
+            // crate 内 match では網羅すれば exhaustive。将来 variant 追加時は本テストが先に壊れる。
+            _ => "unknown",
+        };
+    }
+}

--- a/crates/shikomi-infra/src/persistence/vault_migration/header.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/header.rs
@@ -219,30 +219,15 @@ impl VaultEncryptedHeader {
     /// - kdf_params (12B = m||t||p)
     #[must_use]
     pub fn canonical_bytes_for_aad(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(64);
-        out.extend_from_slice(&self.version.value().to_be_bytes());
-
-        // created_at の i64 マイクロ秒変換 (Aad と同じ規約)。
-        // 範囲外時はゼロ埋めで防衛的フォールバック (構造的に到達しない、time crate 限界外)。
-        // unix_timestamp_nanos() は既に i128 を返すため i128::from() は冗長 (clippy::useless_conversion)。
-        let micros = self.created_at.unix_timestamp_nanos() / 1_000;
-        let micros_i64 = i64::try_from(micros).unwrap_or(0);
-        out.extend_from_slice(&micros_i64.to_be_bytes());
-
-        out.extend_from_slice(self.kdf_salt.as_array());
-        Self::serialize_wrapped_vek_into(&mut out, &self.wrapped_vek_by_pw);
-        Self::serialize_wrapped_vek_into(&mut out, &self.wrapped_vek_by_recovery);
-        out.extend_from_slice(&self.nonce_counter.current().to_be_bytes());
-        out.extend_from_slice(&self.kdf_params.to_canonical_bytes());
-        out
-    }
-
-    /// `WrappedVek` を canonical bytes として `out` に追記する (AAD 用、envelope 用)。
-    /// レイアウト: `nonce 12B ‖ tag 16B ‖ ciphertext ?B`。
-    fn serialize_wrapped_vek_into(out: &mut Vec<u8>, w: &WrappedVek) {
-        out.extend_from_slice(w.nonce().as_array());
-        out.extend_from_slice(w.tag().as_array());
-        out.extend_from_slice(w.ciphertext());
+        canonical_aad_bytes(
+            self.version,
+            self.created_at,
+            &self.kdf_salt,
+            &self.wrapped_vek_by_pw,
+            &self.wrapped_vek_by_recovery,
+            &self.nonce_counter,
+            self.kdf_params,
+        )
     }
 
     /// `nonce_counter.increment()` のみ呼ぶ (Sub-D Rev1: `Rng` 依存ゼロ)。
@@ -318,6 +303,55 @@ impl VaultEncryptedHeader {
             header_aead_envelope,
         }
     }
+}
+
+/// AAD 正規化バイト列を **生フィールドから** 直接構築するスタンドアロン関数。
+///
+/// `VaultEncryptedHeader::canonical_bytes_for_aad` の構築ロジックを切り出した
+/// 同型実装。`build_header_envelope` (service.rs) は `VaultEncryptedHeader::new`
+/// **前** にヘッダ AEAD タグを計算する必要があるため、本関数を経由する。
+///
+/// ## レイアウト凍結 (Sub-D Rev1)
+/// - version (2B BE u16)
+/// - created_at_micros (8B BE i64)
+/// - kdf_salt (16B)
+/// - wrapped_vek_by_pw_serialized (`nonce 12B ‖ tag 16B ‖ ct ?`)
+/// - wrapped_vek_by_recovery_serialized (同)
+/// - nonce_counter (8B BE u64) — L1 巻戻し改竄を構造防衛
+/// - kdf_params (12B = m||t||p)
+#[must_use]
+pub(crate) fn canonical_aad_bytes(
+    version: VaultVersion,
+    created_at: OffsetDateTime,
+    kdf_salt: &KdfSalt,
+    wrapped_vek_by_pw: &WrappedVek,
+    wrapped_vek_by_recovery: &WrappedVek,
+    nonce_counter: &NonceCounter,
+    kdf_params: KdfParams,
+) -> Vec<u8> {
+    let mut out = Vec::with_capacity(64);
+    out.extend_from_slice(&version.value().to_be_bytes());
+
+    // created_at の i64 マイクロ秒変換 (Aad と同じ規約)。
+    // 範囲外時はゼロ埋めで防衛的フォールバック (構造的に到達しない、time crate 限界外)。
+    let micros = created_at.unix_timestamp_nanos() / 1_000;
+    let micros_i64 = i64::try_from(micros).unwrap_or(0);
+    out.extend_from_slice(&micros_i64.to_be_bytes());
+
+    out.extend_from_slice(kdf_salt.as_array());
+    serialize_wrapped_vek_into_buf(&mut out, wrapped_vek_by_pw);
+    serialize_wrapped_vek_into_buf(&mut out, wrapped_vek_by_recovery);
+    out.extend_from_slice(&nonce_counter.current().to_be_bytes());
+    out.extend_from_slice(&kdf_params.to_canonical_bytes());
+    out
+}
+
+/// `WrappedVek` を canonical bytes として `out` に追記する (関数版、`VaultEncryptedHeader`
+/// の inherent helper と完全同型)。
+fn serialize_wrapped_vek_into_buf(out: &mut Vec<u8>, w: &WrappedVek) {
+    out.extend_from_slice(w.nonce().as_array());
+    out.extend_from_slice(w.tag().as_array());
+    out.extend_from_slice(w.ciphertext());
 }
 
 /// `from_core_with_extras` の防衛的 fallback 用の dummy `WrappedVek`。

--- a/crates/shikomi-infra/src/persistence/vault_migration/header.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/header.rs
@@ -1,0 +1,486 @@
+//! `VaultEncryptedHeader` / `HeaderAeadEnvelope` / `KdfParams` —
+//! shikomi-infra 側暗号化ヘッダ・ラッパ型 (Sub-D 新規)。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/repository-and-migration.md`
+//! §`VaultEncryptedHeader` / §`HeaderAeadEnvelope` / §`KdfParams`
+//!
+//! ## 責務分離
+//!
+//! - shikomi-core 側 `VaultHeaderEncrypted` (既存) は version / created_at / kdf_salt /
+//!   wrapped_vek_by_pw / wrapped_vek_by_recovery の 5 フィールドで凍結。
+//! - shikomi-infra 側 `VaultEncryptedHeader` はこれをラップし、Sub-D 完成形の
+//!   `nonce_counter` / `kdf_params` / `header_aead_envelope` を追加保持する。
+//! - SQLite 永続化形式の決定はこのモジュールで集約する (Mapping への入出力境界)。
+
+use shikomi_core::error::CryptoError;
+use shikomi_core::vault::header::VaultHeaderEncrypted;
+use shikomi_core::{
+    AuthTag, KdfSalt, NonceBytes, NonceCounter, VaultHeader, VaultVersion, WrappedVek,
+};
+use time::OffsetDateTime;
+
+// -------------------------------------------------------------------
+// KdfParams
+// -------------------------------------------------------------------
+
+/// Argon2id KDF パラメータの永続化形 (12B = `m||t||p` の big-endian)。
+///
+/// `Argon2idParams::FROZEN_OWASP_2024_05` (`m=19_456, t=2, p=1`) と意味論的に同じだが
+/// 永続化序列を凍結する独立型。`Argon2idParams::output_len` は 32B 固定のため永続化しない。
+///
+/// 設計書 §`KdfParams`。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KdfParams {
+    /// memory cost (KiB)。
+    pub m: u32,
+    /// time cost (iterations)。
+    pub t: u32,
+    /// parallelism (lanes)。
+    pub p: u32,
+}
+
+impl KdfParams {
+    /// 凍結値 (`Argon2idParams::FROZEN_OWASP_2024_05` と意味論的に等価)。
+    pub const FROZEN: Self = Self {
+        m: 19_456,
+        t: 2,
+        p: 1,
+    };
+
+    /// AAD 用 12 byte 正規化バイト列を返す (`m||t||p` 各 4B BE)。
+    #[must_use]
+    pub fn to_canonical_bytes(&self) -> [u8; 12] {
+        let mut out = [0u8; 12];
+        out[0..4].copy_from_slice(&self.m.to_be_bytes());
+        out[4..8].copy_from_slice(&self.t.to_be_bytes());
+        out[8..12].copy_from_slice(&self.p.to_be_bytes());
+        out
+    }
+
+    /// 12 byte 配列から `KdfParams` を復元する (永続化からの復元用)。
+    #[must_use]
+    pub fn from_canonical_bytes(bytes: [u8; 12]) -> Self {
+        let m = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        let t = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+        let p = u32::from_be_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+        Self { m, t, p }
+    }
+}
+
+impl Default for KdfParams {
+    fn default() -> Self {
+        Self::FROZEN
+    }
+}
+
+// -------------------------------------------------------------------
+// HeaderAeadEnvelope
+// -------------------------------------------------------------------
+
+/// vault ヘッダ独立 AEAD タグの 3 フィールド封筒 (`Sub-A WrappedVek` と同型構造)。
+///
+/// 設計書 §`HeaderAeadEnvelope`:
+/// - `ciphertext` は **空 `Vec::new()`** が標準 (改竄検出専用、鍵を運ばない)。
+/// - `nonce` 12B + `tag` 16B + `ciphertext` 0B が標準形。
+/// - AAD = `VaultEncryptedHeader::canonical_bytes_for_aad()` の正規化バイト列。
+///
+/// `Debug, Clone` 派生 (ciphertext / nonce / tag は秘密でない、改竄検出マーカーのみ)。
+#[derive(Debug, Clone)]
+pub struct HeaderAeadEnvelope {
+    /// AEAD ciphertext (通常 0 byte、改竄検出専用)。
+    pub ciphertext: Vec<u8>,
+    /// AEAD nonce 12B。
+    pub nonce: NonceBytes,
+    /// AEAD authentication tag 16B。
+    pub tag: AuthTag,
+}
+
+impl HeaderAeadEnvelope {
+    /// 3 要素から `HeaderAeadEnvelope` を構築する。
+    #[must_use]
+    pub fn new(ciphertext: Vec<u8>, nonce: NonceBytes, tag: AuthTag) -> Self {
+        Self {
+            ciphertext,
+            nonce,
+            tag,
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// VaultEncryptedHeader
+// -------------------------------------------------------------------
+
+/// shikomi-infra 側の暗号化ヘッダ完成形 (Sub-D 新規ラッパ)。
+///
+/// shikomi-core `VaultHeaderEncrypted` (5 フィールド) + `nonce_counter` +
+/// `kdf_params` + `header_aead_envelope` を保持。永続化境界 (`Mapping`) と
+/// `VaultMigration` service との架橋型。
+///
+/// 設計書 §`VaultEncryptedHeader` / §AAD 構築フロー (`canonical_bytes_for_aad`)。
+#[derive(Debug)]
+pub struct VaultEncryptedHeader {
+    version: VaultVersion,
+    created_at: OffsetDateTime,
+    kdf_salt: KdfSalt,
+    wrapped_vek_by_pw: WrappedVek,
+    wrapped_vek_by_recovery: WrappedVek,
+    nonce_counter: NonceCounter,
+    kdf_params: KdfParams,
+    header_aead_envelope: HeaderAeadEnvelope,
+}
+
+impl VaultEncryptedHeader {
+    /// 全フィールドを受け取って `VaultEncryptedHeader` を構築する。
+    ///
+    /// 各フィールドは構築済型 (`KdfSalt::try_new` / `WrappedVek::new` /
+    /// `NonceCounter::resume` 等) を渡すこと。本コンストラクタは追加検証を行わない。
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub fn new(
+        version: VaultVersion,
+        created_at: OffsetDateTime,
+        kdf_salt: KdfSalt,
+        wrapped_vek_by_pw: WrappedVek,
+        wrapped_vek_by_recovery: WrappedVek,
+        nonce_counter: NonceCounter,
+        kdf_params: KdfParams,
+        header_aead_envelope: HeaderAeadEnvelope,
+    ) -> Self {
+        Self {
+            version,
+            created_at,
+            kdf_salt,
+            wrapped_vek_by_pw,
+            wrapped_vek_by_recovery,
+            nonce_counter,
+            kdf_params,
+            header_aead_envelope,
+        }
+    }
+
+    /// vault フォーマットバージョンを返す。
+    #[must_use]
+    pub fn version(&self) -> VaultVersion {
+        self.version
+    }
+
+    /// 作成時刻を返す。
+    #[must_use]
+    pub fn created_at(&self) -> OffsetDateTime {
+        self.created_at
+    }
+
+    /// KDF salt への参照。
+    #[must_use]
+    pub fn kdf_salt(&self) -> &KdfSalt {
+        &self.kdf_salt
+    }
+
+    /// パスワード経路 wrapped VEK への参照。
+    #[must_use]
+    pub fn wrapped_vek_by_pw(&self) -> &WrappedVek {
+        &self.wrapped_vek_by_pw
+    }
+
+    /// リカバリ経路 wrapped VEK への参照。
+    #[must_use]
+    pub fn wrapped_vek_by_recovery(&self) -> &WrappedVek {
+        &self.wrapped_vek_by_recovery
+    }
+
+    /// nonce counter への参照。
+    #[must_use]
+    pub fn nonce_counter(&self) -> &NonceCounter {
+        &self.nonce_counter
+    }
+
+    /// KDF params への参照。
+    #[must_use]
+    pub fn kdf_params(&self) -> KdfParams {
+        self.kdf_params
+    }
+
+    /// ヘッダ AEAD envelope への参照。
+    #[must_use]
+    pub fn header_aead_envelope(&self) -> &HeaderAeadEnvelope {
+        &self.header_aead_envelope
+    }
+
+    /// AAD 用ヘッダ全フィールド正規化バイト列 (envelope 自体は含まない)。
+    ///
+    /// レイアウト (Sub-D Rev1 凍結):
+    /// - version (2B BE u16)
+    /// - created_at_micros (8B BE i64)
+    /// - kdf_salt (16B)
+    /// - wrapped_vek_by_pw_serialized (`nonce 12B ‖ tag 16B ‖ ct ?`)
+    /// - wrapped_vek_by_recovery_serialized (同)
+    /// - nonce_counter (8B BE u64) — L1 巻戻し改竄を構造防衛
+    /// - kdf_params (12B = m||t||p)
+    #[must_use]
+    pub fn canonical_bytes_for_aad(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(64);
+        out.extend_from_slice(&self.version.value().to_be_bytes());
+
+        // created_at の i64 マイクロ秒変換 (Aad と同じ規約)。
+        // 範囲外時はゼロ埋めで防衛的フォールバック (構造的に到達しない、time crate 限界外)。
+        let micros = i128::from(self.created_at.unix_timestamp_nanos()) / 1_000;
+        let micros_i64 = i64::try_from(micros).unwrap_or(0);
+        out.extend_from_slice(&micros_i64.to_be_bytes());
+
+        out.extend_from_slice(self.kdf_salt.as_array());
+        Self::serialize_wrapped_vek_into(&mut out, &self.wrapped_vek_by_pw);
+        Self::serialize_wrapped_vek_into(&mut out, &self.wrapped_vek_by_recovery);
+        out.extend_from_slice(&self.nonce_counter.current().to_be_bytes());
+        out.extend_from_slice(&self.kdf_params.to_canonical_bytes());
+        out
+    }
+
+    /// `WrappedVek` を canonical bytes として `out` に追記する (AAD 用、envelope 用)。
+    /// レイアウト: `nonce 12B ‖ tag 16B ‖ ciphertext ?B`。
+    fn serialize_wrapped_vek_into(out: &mut Vec<u8>, w: &WrappedVek) {
+        out.extend_from_slice(w.nonce().as_array());
+        out.extend_from_slice(w.tag().as_array());
+        out.extend_from_slice(w.ciphertext());
+    }
+
+    /// `nonce_counter.increment()` のみ呼ぶ (Sub-D Rev1: `Rng` 依存ゼロ)。
+    ///
+    /// per-record AEAD nonce の生成は呼出側 `VaultMigration` の責務。
+    /// 上限到達時 `Err(CryptoError::NonceLimitExceeded { limit })` を透過。
+    ///
+    /// # Errors
+    ///
+    /// `NonceCounter::increment` の `DomainError::NonceLimitExceeded` を
+    /// `CryptoError::NonceLimitExceeded { limit: NonceCounter::LIMIT }` に変換して返す。
+    pub fn increment_nonce_counter(&mut self) -> Result<(), CryptoError> {
+        self.nonce_counter
+            .increment()
+            .map_err(|_| CryptoError::NonceLimitExceeded {
+                limit: NonceCounter::LIMIT,
+            })
+    }
+
+    /// shikomi-core 側 `VaultHeader::Encrypted` への変換 (永続化境界の素通し)。
+    ///
+    /// shikomi-core 側の `VaultHeader` 集約は version / created_at / kdf_salt /
+    /// wrapped_vek_by_pw / wrapped_vek_by_recovery のみを保持する (Sub-A 凍結)。
+    /// 追加メタデータ (nonce_counter / kdf_params / header_aead_envelope) は
+    /// 永続化レイヤ (Mapping::vault_header_to_params) で個別 BLOB に詰める。
+    ///
+    /// # Errors
+    ///
+    /// `VaultHeader::new_encrypted` のエラー (version 範囲外等) を透過。
+    pub fn to_core_header(&self) -> Result<VaultHeader, shikomi_core::DomainError> {
+        VaultHeader::new_encrypted(
+            self.version,
+            self.created_at,
+            self.kdf_salt.clone(),
+            self.wrapped_vek_by_pw.clone(),
+            self.wrapped_vek_by_recovery.clone(),
+        )
+    }
+
+    /// shikomi-core 側 `VaultHeaderEncrypted` から逆変換 (Sub-D 永続化復元用)。
+    /// 追加メタデータは引数で受ける。
+    #[must_use]
+    pub fn from_core_with_extras(
+        core: &VaultHeaderEncrypted,
+        nonce_counter: NonceCounter,
+        kdf_params: KdfParams,
+        header_aead_envelope: HeaderAeadEnvelope,
+    ) -> Self {
+        // shikomi-core 側 `VaultHeaderEncrypted` は pub フィールドではないため
+        // 標準 accessor 経由で個別に取得する。`VaultHeader::wrapped_vek_by_pw()` 等は
+        // `&WrappedVek` を返すため `clone()` が必要。
+        let header_wrapper = VaultHeader::Encrypted(core.clone());
+        Self {
+            version: header_wrapper.version(),
+            created_at: header_wrapper.created_at(),
+            // accessor は `Option<&KdfSalt>` を返すが `Encrypted` variant 確定下では `Some`。
+            // 防衛的に unwrap を避け、accessor が `None` の場合は dummy 値で構築する経路を作るが、
+            // ここでは Encrypted ヘッダが既に渡されているため `Some` 確定。
+            kdf_salt: header_wrapper
+                .kdf_salt()
+                .cloned()
+                .unwrap_or_else(|| KdfSalt::from_array([0u8; 16])),
+            wrapped_vek_by_pw: header_wrapper
+                .wrapped_vek_by_pw()
+                .cloned()
+                .unwrap_or_else(dummy_wrapped_vek),
+            wrapped_vek_by_recovery: header_wrapper
+                .wrapped_vek_by_recovery()
+                .cloned()
+                .unwrap_or_else(dummy_wrapped_vek),
+            nonce_counter,
+            kdf_params,
+            header_aead_envelope,
+        }
+    }
+}
+
+/// `from_core_with_extras` の防衛的 fallback 用の dummy `WrappedVek`。
+///
+/// 構造的にはこの fallback には到達しない (`Encrypted` variant の `VaultHeader` を
+/// 引数に取った時点で `wrapped_vek_by_pw()` / `wrapped_vek_by_recovery()` は `Some` 確定)。
+/// CC-10 (unwrap/expect 禁止) を遵守しつつ、`WrappedVek::new` の構造的成功を
+/// `match` で受ける。Err 経路に到達した場合は不変条件破壊のため最低限の値を返す。
+fn dummy_wrapped_vek() -> WrappedVek {
+    // 32B (最小) ciphertext + 12B nonce + 16B tag。`WrappedVek::new` の検証を満たす。
+    match WrappedVek::new(
+        vec![0u8; 32],
+        NonceBytes::from_random([0u8; 12]),
+        AuthTag::from_array([0u8; 16]),
+    ) {
+        Ok(w) => w,
+        // 構造的到達不能。`WrappedVek::new` は 32B + 非空 で必ず Ok を返す。
+        // unwrap/expect を回避しつつ Err を握り潰す形にする (defensive infallible)。
+        Err(_) => match WrappedVek::new(
+            vec![1u8; 32],
+            NonceBytes::from_random([0u8; 12]),
+            AuthTag::from_array([0u8; 16]),
+        ) {
+            Ok(w) => w,
+            Err(_) => dummy_wrapped_vek(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::{NonceBytes, VaultVersion};
+    use time::OffsetDateTime;
+
+    fn dummy_kdf_salt() -> KdfSalt {
+        KdfSalt::from_array([0xABu8; 16])
+    }
+
+    fn dummy_wrapped_vek_test() -> WrappedVek {
+        WrappedVek::new(
+            vec![0u8; 32],
+            NonceBytes::from_random([0u8; 12]),
+            AuthTag::from_array([0u8; 16]),
+        )
+        .unwrap()
+    }
+
+    fn dummy_envelope() -> HeaderAeadEnvelope {
+        HeaderAeadEnvelope::new(
+            Vec::new(),
+            NonceBytes::from_random([0xCDu8; 12]),
+            AuthTag::from_array([0xEFu8; 16]),
+        )
+    }
+
+    fn make_header() -> VaultEncryptedHeader {
+        VaultEncryptedHeader::new(
+            VaultVersion::CURRENT,
+            OffsetDateTime::UNIX_EPOCH,
+            dummy_kdf_salt(),
+            dummy_wrapped_vek_test(),
+            dummy_wrapped_vek_test(),
+            NonceCounter::new(),
+            KdfParams::FROZEN,
+            dummy_envelope(),
+        )
+    }
+
+    #[test]
+    fn kdf_params_frozen_matches_argon2id_owasp_2024_05() {
+        assert_eq!(KdfParams::FROZEN.m, 19_456);
+        assert_eq!(KdfParams::FROZEN.t, 2);
+        assert_eq!(KdfParams::FROZEN.p, 1);
+    }
+
+    #[test]
+    fn kdf_params_to_from_canonical_bytes_round_trip() {
+        let params = KdfParams {
+            m: 19_456,
+            t: 2,
+            p: 1,
+        };
+        let bytes = params.to_canonical_bytes();
+        assert_eq!(bytes.len(), 12);
+        let restored = KdfParams::from_canonical_bytes(bytes);
+        assert_eq!(restored, params);
+    }
+
+    #[test]
+    fn kdf_params_to_canonical_bytes_uses_big_endian() {
+        let params = KdfParams { m: 1, t: 2, p: 3 };
+        let bytes = params.to_canonical_bytes();
+        assert_eq!(&bytes[0..4], &[0, 0, 0, 1]);
+        assert_eq!(&bytes[4..8], &[0, 0, 0, 2]);
+        assert_eq!(&bytes[8..12], &[0, 0, 0, 3]);
+    }
+
+    /// TC-D-U01 / C-17 / C-18: canonical_bytes_for_aad は決定論的でフィールド順序固定。
+    #[test]
+    fn canonical_bytes_for_aad_is_deterministic_for_same_header() {
+        let h = make_header();
+        let a = h.canonical_bytes_for_aad();
+        let b = h.canonical_bytes_for_aad();
+        assert_eq!(a, b);
+    }
+
+    /// C-17: nonce_counter を含むことの確認 (L1 巻戻し攻撃防衛)。
+    #[test]
+    fn canonical_bytes_includes_nonce_counter() {
+        let h = make_header();
+        let baseline = h.canonical_bytes_for_aad();
+
+        // nonce_counter を 1 つ進めると AAD バイト列が変わる。
+        let mut h2 = make_header();
+        h2.nonce_counter = NonceCounter::resume(1);
+        let after = h2.canonical_bytes_for_aad();
+        assert_ne!(baseline, after, "nonce_counter must affect AAD bytes");
+    }
+
+    /// C-18: kdf_params を含むことの確認 (KDF 弱パラメータ改竄防衛)。
+    #[test]
+    fn canonical_bytes_includes_kdf_params() {
+        let h = make_header();
+        let baseline = h.canonical_bytes_for_aad();
+
+        let mut h2 = make_header();
+        h2.kdf_params = KdfParams { m: 1, t: 1, p: 1 };
+        let after = h2.canonical_bytes_for_aad();
+        assert_ne!(baseline, after, "kdf_params must affect AAD bytes");
+    }
+
+    #[test]
+    fn increment_nonce_counter_advances_by_one() {
+        let mut h = make_header();
+        assert_eq!(h.nonce_counter.current(), 0);
+        h.increment_nonce_counter().unwrap();
+        assert_eq!(h.nonce_counter.current(), 1);
+    }
+
+    #[test]
+    fn increment_nonce_counter_at_limit_returns_nonce_limit_exceeded() {
+        let mut h = VaultEncryptedHeader::new(
+            VaultVersion::CURRENT,
+            OffsetDateTime::UNIX_EPOCH,
+            dummy_kdf_salt(),
+            dummy_wrapped_vek_test(),
+            dummy_wrapped_vek_test(),
+            NonceCounter::resume(NonceCounter::LIMIT),
+            KdfParams::FROZEN,
+            dummy_envelope(),
+        );
+        let err = h.increment_nonce_counter().unwrap_err();
+        assert!(matches!(err, CryptoError::NonceLimitExceeded { .. }));
+    }
+
+    #[test]
+    fn to_core_header_preserves_5_basic_fields() {
+        let h = make_header();
+        let core = h.to_core_header().unwrap();
+        assert_eq!(core.version(), VaultVersion::CURRENT);
+        assert_eq!(core.created_at(), OffsetDateTime::UNIX_EPOCH);
+        assert!(core.kdf_salt().is_some());
+        assert!(core.wrapped_vek_by_pw().is_some());
+        assert!(core.wrapped_vek_by_recovery().is_some());
+    }
+}

--- a/crates/shikomi-infra/src/persistence/vault_migration/header.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/header.rs
@@ -224,7 +224,8 @@ impl VaultEncryptedHeader {
 
         // created_at の i64 マイクロ秒変換 (Aad と同じ規約)。
         // 範囲外時はゼロ埋めで防衛的フォールバック (構造的に到達しない、time crate 限界外)。
-        let micros = i128::from(self.created_at.unix_timestamp_nanos()) / 1_000;
+        // unix_timestamp_nanos() は既に i128 を返すため i128::from() は冗長 (clippy::useless_conversion)。
+        let micros = self.created_at.unix_timestamp_nanos() / 1_000;
         let micros_i64 = i64::try_from(micros).unwrap_or(0);
         out.extend_from_slice(&micros_i64.to_be_bytes());
 

--- a/crates/shikomi-infra/src/persistence/vault_migration/mod.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/mod.rs
@@ -4,13 +4,13 @@
 //!
 //! ## モジュール構成
 //!
-//! - [`error`]: `MigrationError` (Sub-D 新規、`#[non_exhaustive]`)
-//! - [`header`]: `VaultEncryptedHeader` / `HeaderAeadEnvelope` / `KdfParams`
-//! - [`record`]: `EncryptedRecord` (永続化形)
-//! - [`recovery`]: `RecoveryDisclosure` / `RecoveryWords` (REQ-S13 型レベル強制)
-//! - [`confirmation`]: `DecryptConfirmation` (C-20 二段確認証跡)
-//! - [`service`]: `VaultMigration` 6 メソッド (encrypt/decrypt/unlock x2/rekey/change_password)
-//! - [`storage`]: SQLite 永続化形式 ↔ `VaultEncryptedHeader` のエンコード / デコード
+//! - `error`: `MigrationError` (Sub-D 新規、`#[non_exhaustive]`)
+//! - `header`: `VaultEncryptedHeader` / `HeaderAeadEnvelope` / `KdfParams`
+//! - `record`: `EncryptedRecord` (永続化形)
+//! - `recovery`: `RecoveryDisclosure` / `RecoveryWords` (REQ-S13 型レベル強制)
+//! - `confirmation`: `DecryptConfirmation` (C-20 二段確認証跡)
+//! - `service`: `VaultMigration` 6 メソッド (encrypt/decrypt/unlock x2/rekey/change_password)
+//! - `storage`: SQLite 永続化形式 ↔ `VaultEncryptedHeader` のエンコード / デコード
 //!
 //! ## Clean Architecture
 //!

--- a/crates/shikomi-infra/src/persistence/vault_migration/mod.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/mod.rs
@@ -1,0 +1,37 @@
+//! `vault_migration` — 平文 ⇄ 暗号化 vault マイグレーション service (Sub-D 新規)。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/repository-and-migration.md`
+//!
+//! ## モジュール構成
+//!
+//! - [`error`]: `MigrationError` (Sub-D 新規、`#[non_exhaustive]`)
+//! - [`header`]: `VaultEncryptedHeader` / `HeaderAeadEnvelope` / `KdfParams`
+//! - [`record`]: `EncryptedRecord` (永続化形)
+//! - [`recovery`]: `RecoveryDisclosure` / `RecoveryWords` (REQ-S13 型レベル強制)
+//! - [`confirmation`]: `DecryptConfirmation` (C-20 二段確認証跡)
+//! - [`service`]: `VaultMigration` 6 メソッド (encrypt/decrypt/unlock x2/rekey/change_password)
+//! - [`storage`]: SQLite 永続化形式 ↔ `VaultEncryptedHeader` のエンコード / デコード
+//!
+//! ## Clean Architecture
+//!
+//! - shikomi-core 側型のみ消費 (`Vek` / `MasterPassword` / `RecoveryMnemonic` /
+//!   `Aad` / `WrappedVek` / `Record` / `Vault`)。
+//! - shikomi-core への新規依存追加なし (`aes-gcm` / `argon2` / `bip39` は
+//!   shikomi-infra::crypto::{aead, kdf} アダプタ経由のみ)。
+//! - TC-D-S01 / TC-D-S04 sub-d-static-checks.sh で grep 検証。
+
+pub mod confirmation;
+pub mod error;
+pub mod header;
+pub mod record;
+pub mod recovery;
+pub mod service;
+pub mod storage;
+
+// 公開 re-export (shikomi-infra crate ルートから利用するエントリ)。
+pub use confirmation::DecryptConfirmation;
+pub use error::MigrationError;
+pub use header::{HeaderAeadEnvelope, KdfParams, VaultEncryptedHeader};
+pub use record::EncryptedRecord;
+pub use recovery::{RecoveryDisclosure, RecoveryWords};
+pub use service::VaultMigration;

--- a/crates/shikomi-infra/src/persistence/vault_migration/record.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/record.rs
@@ -1,0 +1,100 @@
+//! `EncryptedRecord` — shikomi-infra 側の暗号化レコード型 (Sub-D 新規)。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/repository-and-migration.md`
+//! §`EncryptedRecord`
+//!
+//! shikomi-core 既存 `RecordPayloadEncrypted` (nonce + ciphertext + aad) と並列。
+//! shikomi-infra 側では label / kind / created_at / updated_at まで含めた完全な
+//! per-record 永続化形を保持し、`VaultMigration` の AEAD 経路で利用する。
+
+use shikomi_core::{AuthTag, NonceBytes, RecordId, RecordKind, RecordLabel};
+use time::OffsetDateTime;
+
+/// AEAD 暗号化済みレコード (shikomi-infra 永続化形)。
+///
+/// 設計書 §`EncryptedRecord`:
+/// - 派生: `Debug, Clone` (ciphertext / nonce / tag は秘密でない)。
+/// - `Drop` 不要 (秘密保持なし)。
+/// - AAD は `Aad::Record { id, version, created_at }` で 26B 正規化 (Sub-A `Aad`)。
+#[derive(Debug, Clone)]
+pub struct EncryptedRecord {
+    /// レコード ID (UUIDv7)。
+    pub id: RecordId,
+    /// レコード種別 (`Text` / `Secret`)。
+    pub kind: RecordKind,
+    /// レコードラベル (1..=255 graphemes)。
+    pub label: RecordLabel,
+    /// AEAD 暗号文 (plaintext と同じ長さ、detached tag 方式)。
+    pub payload_ciphertext: Vec<u8>,
+    /// per-record AEAD nonce 12B。
+    pub nonce: NonceBytes,
+    /// per-record AEAD authentication tag 16B。
+    pub tag: AuthTag,
+    /// 作成時刻 (マイクロ秒精度)。
+    pub created_at: OffsetDateTime,
+    /// 最終更新時刻 (マイクロ秒精度)。
+    pub updated_at: OffsetDateTime,
+}
+
+impl EncryptedRecord {
+    /// 全フィールドを受け取って `EncryptedRecord` を構築する。
+    /// 各フィールドは構築済型を渡すこと (検証は呼出側責務)。
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub fn new(
+        id: RecordId,
+        kind: RecordKind,
+        label: RecordLabel,
+        payload_ciphertext: Vec<u8>,
+        nonce: NonceBytes,
+        tag: AuthTag,
+        created_at: OffsetDateTime,
+        updated_at: OffsetDateTime,
+    ) -> Self {
+        Self {
+            id,
+            kind,
+            label,
+            payload_ciphertext,
+            nonce,
+            tag,
+            created_at,
+            updated_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::{NonceBytes, RecordId, RecordKind, RecordLabel};
+    use time::OffsetDateTime;
+    use uuid::Uuid;
+
+    fn make_record() -> EncryptedRecord {
+        EncryptedRecord::new(
+            RecordId::new(Uuid::now_v7()).unwrap(),
+            RecordKind::Secret,
+            RecordLabel::try_new("test".to_string()).unwrap(),
+            vec![0u8; 16],
+            NonceBytes::from_random([0u8; 12]),
+            AuthTag::from_array([0u8; 16]),
+            OffsetDateTime::UNIX_EPOCH,
+            OffsetDateTime::UNIX_EPOCH,
+        )
+    }
+
+    #[test]
+    fn new_constructs_without_panic() {
+        let _ = make_record();
+    }
+
+    #[test]
+    fn clone_preserves_all_fields() {
+        let r = make_record();
+        let r2 = r.clone();
+        assert_eq!(r.payload_ciphertext, r2.payload_ciphertext);
+        assert_eq!(r.nonce.as_array(), r2.nonce.as_array());
+        assert_eq!(r.tag.as_array(), r2.tag.as_array());
+    }
+}

--- a/crates/shikomi-infra/src/persistence/vault_migration/recovery.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/recovery.rs
@@ -1,0 +1,244 @@
+//! `RecoveryDisclosure` / `RecoveryWords` — 24 語初回 1 度表示の型レベル強制 (Sub-D 新規)。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/repository-and-migration.md`
+//! §`RecoveryDisclosure`
+//!
+//! ## REQ-S13 型レベル強制契約
+//!
+//! 1. `disclose(self)` は `self` を消費 → 2 度呼出は compile_fail (C-19)。
+//! 2. `RecoveryWords` は `Display` / `Serialize` 未実装 → 永続化禁止 (DC-6)。
+//! 3. `Drop` 連鎖で内包 `RecoveryMnemonic` の `SecretBox<Zeroizing<...>>` が zeroize。
+//! 4. `drop_without_disclose(self)` でクラッシュ・キャンセル経路の Fail Secure 提供。
+
+use core::fmt;
+use shikomi_core::crypto::RecoveryMnemonic;
+use time::OffsetDateTime;
+
+// -------------------------------------------------------------------
+// RecoveryWords (24 語表示用 newtype)
+// -------------------------------------------------------------------
+
+/// 24 語リカバリ・ワード (CLI/GUI 表示専用)。
+///
+/// `RecoveryDisclosure::disclose` の戻り値として **1 度だけ**取得され、表示後即 Drop で
+/// `String` の zeroize が連鎖発火する (`zeroize::Zeroizing` 相当)。
+///
+/// # Forbidden traits (DC-6)
+///
+/// - `Display` 未実装: 誤 `println!("{}", words)` を構造禁止。
+/// - `serde::Serialize` 未実装: 誤永続化を構造禁止。
+/// - `Clone` 未実装: 表示後の複製による滞留時間延長を構造禁止。
+/// - `Debug` は `[REDACTED RECOVERY WORDS (24)]` 固定 (秘匿)。
+///
+/// ## 表示ルール
+///
+/// `iter()` で `(index, &str)` の番号付きイテレータを取得し、CLI/GUI が
+/// 「1: word1, 2: word2, ...」形式で表示する。表示完了後即 Drop。
+pub struct RecoveryWords {
+    words: [String; 24],
+}
+
+impl RecoveryWords {
+    /// `RecoveryDisclosure::disclose` 専用 `pub(super)` コンストラクタ。
+    ///
+    /// 同一モジュール (`vault_migration`) 内の `RecoveryDisclosure::disclose` のみが呼出可能。
+    pub(super) fn new(words: [String; 24]) -> Self {
+        Self { words }
+    }
+
+    /// 番号付きイテレータ `(1..=24, &str)` を返す (CLI/GUI 表示用)。
+    pub fn iter(&self) -> impl Iterator<Item = (usize, &str)> {
+        self.words
+            .iter()
+            .enumerate()
+            .map(|(i, w)| (i + 1, w.as_str()))
+    }
+
+    /// 24 語の生スライスへの参照 (テスト・ユニット検証用)。
+    /// 本番 CLI/GUI からは `iter()` 経由で利用すること。
+    #[must_use]
+    pub fn as_slice(&self) -> &[String; 24] {
+        &self.words
+    }
+}
+
+impl fmt::Debug for RecoveryWords {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED RECOVERY WORDS (24)]")
+    }
+}
+
+impl Drop for RecoveryWords {
+    fn drop(&mut self) {
+        // 各 String の中身を zeroize (zeroize crate 経由)。
+        // String 自体は Drop で free されるが、ヒープ内容を 0 上書きするため
+        // 一旦 mem::take して空文字列に置換 → 元の中身を zeroize する。
+        use zeroize::Zeroize;
+        for w in &mut self.words {
+            w.zeroize();
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// RecoveryDisclosure (24 語初回 1 度表示の型レベル強制)
+// -------------------------------------------------------------------
+
+/// 24 語初回 1 度表示の型レベル強制ラッパ (REQ-S13 / C-19)。
+///
+/// `disclose(self)` は `self` を消費するため Rust の所有権ルールで 2 度呼出が compile_fail。
+/// `Drop` 連鎖で内包する `RecoveryMnemonic` の zeroize が発火する (Sub-A C-1 維持)。
+///
+/// `Serialize` / `Display` 未実装で永続化・表示経路を型レベル封鎖。
+pub struct RecoveryDisclosure {
+    /// 内包する 24 語ニーモニック。
+    mnemonic: RecoveryMnemonic,
+    /// 監査ログ用構築時刻 (秘密でない)。
+    displayed_at: OffsetDateTime,
+}
+
+impl RecoveryDisclosure {
+    /// `vault_migration` モジュール内部からのみ構築可能。
+    /// `VaultMigration::encrypt_vault` の戻り値として 1 回だけ生成される。
+    pub(super) fn new(mnemonic: RecoveryMnemonic, displayed_at: OffsetDateTime) -> Self {
+        Self {
+            mnemonic,
+            displayed_at,
+        }
+    }
+
+    /// 24 語を `RecoveryWords` として取り出す (所有権消費)。
+    ///
+    /// `self` を move するため、本メソッドは型レベルで 2 度呼べない (C-19)。
+    /// `RecoveryMnemonic::expose_words()` で `&[String; 24]` を取得 → コピーして
+    /// `RecoveryWords` を構築 → 元の `RecoveryMnemonic` は scope 抜けで Drop & zeroize。
+    #[must_use]
+    pub fn disclose(self) -> RecoveryWords {
+        let words_ref = self.mnemonic.expose_words();
+        // `[String; 24]` を `clone` してコピーを `RecoveryWords` に渡す。
+        // 元 `RecoveryMnemonic` は `self` の Drop で zeroize される。
+        let words: [String; 24] = std::array::from_fn(|i| words_ref[i].clone());
+        RecoveryWords::new(words)
+    }
+
+    /// クラッシュ・キャンセル経路で「ユーザに見せずに即破棄」する Fail Secure 経路。
+    ///
+    /// `self` を消費するため `disclose` と同様 2 度呼べない。
+    /// `RecoveryMnemonic` の Drop 連鎖で zeroize が発火する。
+    pub fn drop_without_disclose(self) {
+        // self の所有権を取り、本関数の scope 抜けで Drop が発火する。
+        drop(self);
+    }
+
+    /// 監査ログ用構築時刻 (秘密でない、CLI/GUI が表示メッセージに使う場合あり)。
+    #[must_use]
+    pub fn displayed_at(&self) -> OffsetDateTime {
+        self.displayed_at
+    }
+}
+
+impl fmt::Debug for RecoveryDisclosure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED RECOVERY DISCLOSURE]")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::crypto::RecoveryMnemonic;
+
+    fn dummy_mnemonic() -> RecoveryMnemonic {
+        let words: [String; 24] = std::array::from_fn(|i| format!("word{i:02}"));
+        RecoveryMnemonic::from_words(words)
+    }
+
+    #[test]
+    fn disclose_yields_recovery_words_with_24_entries() {
+        let m = dummy_mnemonic();
+        let d = RecoveryDisclosure::new(m, OffsetDateTime::UNIX_EPOCH);
+        let words = d.disclose();
+        assert_eq!(words.as_slice().len(), 24);
+        assert_eq!(words.as_slice()[0], "word00");
+        assert_eq!(words.as_slice()[23], "word23");
+    }
+
+    #[test]
+    fn disclose_iter_returns_numbered_entries() {
+        let m = dummy_mnemonic();
+        let d = RecoveryDisclosure::new(m, OffsetDateTime::UNIX_EPOCH);
+        let words = d.disclose();
+        let collected: Vec<(usize, String)> =
+            words.iter().map(|(i, w)| (i, w.to_string())).collect();
+        assert_eq!(collected.len(), 24);
+        assert_eq!(collected[0].0, 1);
+        assert_eq!(collected[0].1, "word00");
+        assert_eq!(collected[23].0, 24);
+    }
+
+    #[test]
+    fn recovery_words_debug_returns_redacted_marker() {
+        let m = dummy_mnemonic();
+        let d = RecoveryDisclosure::new(m, OffsetDateTime::UNIX_EPOCH);
+        let words = d.disclose();
+        let s = format!("{words:?}");
+        assert_eq!(s, "[REDACTED RECOVERY WORDS (24)]");
+        assert!(!s.contains("word00"));
+    }
+
+    #[test]
+    fn recovery_disclosure_debug_returns_redacted_marker() {
+        let m = dummy_mnemonic();
+        let d = RecoveryDisclosure::new(m, OffsetDateTime::UNIX_EPOCH);
+        let s = format!("{d:?}");
+        assert_eq!(s, "[REDACTED RECOVERY DISCLOSURE]");
+    }
+
+    /// TC-D-U05: drop_without_disclose で内部 RecoveryMnemonic の Drop 連鎖発火。
+    /// メモリパターン直接観測は OS/Allocator 依存のため、API として呼び出せて
+    /// panic しないこと + `self` 消費で 2 度呼べないことを確認する。
+    #[test]
+    fn drop_without_disclose_consumes_self_without_panic() {
+        let m = dummy_mnemonic();
+        let d = RecoveryDisclosure::new(m, OffsetDateTime::UNIX_EPOCH);
+        d.drop_without_disclose();
+        // d はここで使えない (move 後)。compile_fail を期待する経路は doctest で別途。
+    }
+
+    #[test]
+    fn displayed_at_returns_construction_time() {
+        let m = dummy_mnemonic();
+        let now = OffsetDateTime::UNIX_EPOCH;
+        let d = RecoveryDisclosure::new(m, now);
+        assert_eq!(d.displayed_at(), now);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 型レベル強制 compile_fail doctests (C-19 / DC-6)
+// ---------------------------------------------------------------------------
+
+/// C-19: `disclose(self)` 所有権消費後、move 後再使用は compile_fail。
+///
+/// ```compile_fail
+/// use shikomi_infra::persistence::vault_migration::RecoveryDisclosure;
+/// // RecoveryDisclosure::new は pub(super) のため外部 crate から構築不可だが、
+/// // 仮に構築できたとしても disclose 後の再利用は compile_fail。
+/// // ここでは型シグネチャの所有権消費を示す疑似コードとして記述。
+/// fn _check(d: RecoveryDisclosure) {
+///     let _ = d.disclose();
+///     let _ = d.disclose(); // E0382 use of moved value
+/// }
+/// ```
+///
+/// DC-6: `RecoveryWords` への `Display` 実装は compile_fail (型外部からは impl 不能)。
+///
+/// ```compile_fail
+/// use shikomi_infra::persistence::vault_migration::RecoveryWords;
+/// // 外部 crate から impl すると orphan rule 違反 (E0117)。
+/// impl std::fmt::Display for RecoveryWords {
+///     fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) }
+/// }
+/// ```
+#[cfg(doctest)]
+struct _CompileFailGuard;

--- a/crates/shikomi-infra/src/persistence/vault_migration/service.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/service.rs
@@ -312,18 +312,27 @@ impl<'a> VaultMigration<'a> {
     // F-D4: rekey_vault
     // ---------------------------------------------------------------
 
-    /// VEK 入替 + 全レコード再暗号化 (NonceCounter LIMIT 到達時の必須経路)。
+    /// VEK 入替 + 全レコード再暗号化 (NonceCounter LIMIT 到達時の必須経路、F-D4)。
     ///
-    /// **本 Sub-D 簡略実装**: `current_password` のみを引数に取り、wrapped_vek_by_pw /
-    /// wrapped_vek_by_recovery は **更新しない** (旧 wrap は新 VEK に対応しなくなる)。
-    /// 厳密な「新 wrapped_vek 構築」は Sub-E IPC 統合時に master_password を unlock
-    /// 経路で保持し続ける設計で対応する。本 Sub-D は record 層のみ更新 +
-    /// nonce_counter リセットの責務に閉じる。
+    /// 設計書 §F-D4 step 4-5 通り、新 VEK を **旧 KEK_pw で再 wrap** して
+    /// 新 wrapped_vek_by_pw を構築する (records だけ新 VEK で再暗号化して
+    /// wrapped_vek を旧のまま維持すると post-rekey unlock で旧 VEK が復元され
+    /// records 復号が全件 `AeadTagMismatch` になる、Bug-D-002 対応)。
+    ///
+    /// **recovery 経路 (`wrapped_vek_by_recovery`) は本 Sub-D 範囲では更新しない**:
+    /// recovery rekey は Sub-E IPC 統合で `change_recovery` メソッド追加予定
+    /// (新 mnemonic を呼出側に開示するフローが追加で必要なため、本メソッドの
+    /// `current_password: String` 1 引数 API では責務が混ざる)。
+    /// rekey 後の **recovery 経路 unlock は本実装範囲外** (旧 mnemonic の
+    /// wrapped_vek_by_recovery は旧 VEK を unwrap するため、records 復号で失敗する)。
     ///
     /// # Errors
     ///
     /// 各段階のエラーを `MigrationError` に変換して返す。
     pub fn rekey_vault(&self, current_password: String) -> Result<(), MigrationError> {
+        // 0. password を rewrap 用にも使うため clone (KEK_pw 再導出に使う)
+        let password_for_rewrap = current_password.clone();
+
         // 1. unlock で旧 VEK と現在の暗号化 vault を取得
         let (loaded_vault, old_header, old_vek) =
             self.unlock_internal_with_password(current_password)?;
@@ -351,27 +360,57 @@ impl<'a> VaultMigration<'a> {
         // 4. nonce_counter リセット
         let new_nonce_counter = NonceCounter::resume(0);
 
-        // 5. ヘッダは旧 wrapped_vek を維持し、nonce_counter のみ更新
+        // 5. 旧 KEK_pw を再導出 (kdf_salt 不変、password 同一なので KEK は同じだが、
+        //    rewrap には key 値が必要なため改めて導出する)。
+        let master_pw_rewrap = MasterPassword::new(password_for_rewrap, self.gate)?;
+        let kek_pw_rewrap = self
+            .kdf_pw
+            .derive_kek_pw(&master_pw_rewrap, old_header.kdf_salt())?;
+
+        // 6. 新 VEK を旧 KEK_pw で wrap (新 wrapped_vek_by_pw)
+        let new_wrapped_pw =
+            self.aead
+                .wrap_vek(&kek_pw_rewrap, &self.rng.generate_nonce_bytes(), &new_vek)?;
+
+        // 7. ヘッダ AEAD envelope を新 wrapped_pw + 新 nonce_counter + 旧 kdf_salt +
+        //    旧 wrapped_recovery で再構築 (AAD は新フィールドで再計算、改竄検出に必要)。
+        let header_envelope = build_header_envelope(
+            self.aead,
+            self.rng,
+            &kek_pw_rewrap,
+            old_header.version(),
+            old_header.created_at(),
+            old_header.kdf_salt(),
+            &new_wrapped_pw,
+            old_header.wrapped_vek_by_recovery(),
+            &new_nonce_counter,
+            old_header.kdf_params(),
+        )?;
+
+        // 8. ヘッダ更新: 新 wrapped_vek_by_pw + 旧 wrapped_vek_by_recovery + 新 nonce_counter
+        //    + 新 envelope。NOTE: wrapped_vek_by_recovery は本 Sub-D 範囲では更新しない
+        //    (recovery rekey は Sub-E `change_recovery` で対応、メソッド doc 参照)。
         let new_header = VaultEncryptedHeader::new(
             old_header.version(),
             old_header.created_at(),
             old_header.kdf_salt().clone(),
-            old_header.wrapped_vek_by_pw().clone(),
+            new_wrapped_pw,
             old_header.wrapped_vek_by_recovery().clone(),
             new_nonce_counter,
             old_header.kdf_params(),
-            old_header.header_aead_envelope().clone(),
+            header_envelope,
         );
 
-        // 6. 新 vault 集約構築 + save
+        // 9. 新 vault 集約構築 + save
         let vault_to_save = build_encrypted_vault(&new_header, new_records)?;
         self.repository
             .save(&vault_to_save)
             .map_err(map_persistence_error)?;
 
-        // 旧 VEK / 新 VEK は scope 抜けで Drop & zeroize
+        // 旧 VEK / 新 VEK / 再導出 KEK_pw は scope 抜けで Drop & zeroize
         drop(old_vek);
         drop(new_vek);
+        drop(kek_pw_rewrap);
 
         Ok(())
     }

--- a/crates/shikomi-infra/src/persistence/vault_migration/service.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/service.rs
@@ -1,0 +1,661 @@
+//! `VaultMigration` — vault 平文⇄暗号化マイグレーション service (Sub-D 新規)。
+//!
+//! 設計書: `docs/features/vault-encryption/detailed-design/repository-and-migration.md`
+//! §`VaultMigration` (6 メソッド)
+//!
+//! ## 6 メソッド
+//!
+//! - `encrypt_vault`: 平文 vault → 暗号化 vault 初回マイグレーション (F-D1)
+//! - `decrypt_vault`: 暗号化 vault → 平文 vault 戻し (F-D3、`DecryptConfirmation` 強制)
+//! - `unlock_with_password`: 暗号化 vault パスワード経路 unlock → `Vek` 復元 (F-D2)
+//! - `unlock_with_recovery`: 暗号化 vault リカバリ経路 unlock → `Vek` 復元 (F-D2)
+//! - `rekey_vault`: VEK 入替 + 全レコード再暗号化 (F-D4、NonceCounter LIMIT 到達時)
+//! - `change_password`: マスターパスワード変更 (F-D5、O(1)、VEK 不変)
+//!
+//! ## DI 構造
+//!
+//! 設計書 §`VaultMigration::DI`: 6 依存を `&'a` で受ける (`SqliteVaultRepository` /
+//! `Argon2idAdapter` / `Bip39Pbkdf2Hkdf` / `AesGcmAeadAdapter` / `Rng` / `ZxcvbnGate`)。
+//! 後続 Sub-E でテスト容易性のため trait 境界化を検討する余地を残す (現段階は具体型固定)。
+//!
+//! ## Clean Architecture
+//!
+//! - shikomi-core 側型のみを消費 (`Vek` / `MasterPassword` / `RecoveryMnemonic` /
+//!   `Verified<Plaintext>` / `Aad` / `WrappedVek` / `Record` / `Vault` / `VaultHeader`)。
+//! - shikomi-core への新規依存追加なし。
+//! - `aes-gcm` / `argon2` / `bip39` の直接 import なし
+//!   (Sub-B/C アダプタ経由のみ、TC-D-S04 sub-d-static-checks.sh で grep 検証)。
+
+use shikomi_core::crypto::{
+    HeaderAeadKey, MasterPassword, Plaintext, RecoveryMnemonic, Vek, Verified,
+};
+use shikomi_core::error::CryptoError;
+use shikomi_core::{
+    Aad, AuthTag, CipherText, NonceBytes, NonceCounter, ProtectionMode, Record, RecordPayload,
+    RecordPayloadEncrypted, SecretString, Vault, VaultHeader, VaultVersion,
+};
+use time::OffsetDateTime;
+
+use crate::crypto::aead::AesGcmAeadAdapter;
+use crate::crypto::kdf::{Argon2idAdapter, Bip39Pbkdf2Hkdf};
+use crate::crypto::password::ZxcvbnGate;
+use crate::crypto::rng::Rng;
+use crate::persistence::error::PersistenceError;
+use crate::persistence::repository::SqliteVaultRepository;
+use crate::persistence::VaultRepository;
+
+use super::confirmation::DecryptConfirmation;
+use super::error::MigrationError;
+use super::header::{HeaderAeadEnvelope, KdfParams, VaultEncryptedHeader};
+use super::recovery::RecoveryDisclosure;
+use super::storage::{decode_vault_to_encrypted_header, encode_encrypted_header_for_storage};
+
+/// vault マイグレーション service。
+///
+/// 設計書 §DI 構造: 全依存を `&'a` で受ける無状態集約。
+/// 後続 Sub-E (#43) でテスト容易性のため trait 境界化を検討するが、Sub-D 段階では
+/// 具体型固定で開始する (Sub-D 完了優先、trait 化は Sub-E でのリファクタ余地)。
+pub struct VaultMigration<'a> {
+    /// vault 永続化リポジトリ。
+    pub repository: &'a SqliteVaultRepository,
+    /// パスワード経路 KDF (Argon2id)。
+    pub kdf_pw: &'a Argon2idAdapter,
+    /// リカバリ経路 KDF (BIP-39 + PBKDF2 + HKDF)。
+    pub kdf_recovery: &'a Bip39Pbkdf2Hkdf,
+    /// AEAD アダプタ (AES-256-GCM)。
+    pub aead: &'a AesGcmAeadAdapter,
+    /// CSPRNG エントリ点。
+    pub rng: &'a Rng,
+    /// パスワード強度ゲート (zxcvbn)。
+    pub gate: &'a ZxcvbnGate,
+}
+
+impl<'a> VaultMigration<'a> {
+    /// `VaultMigration` を構築する。
+    #[must_use]
+    pub fn new(
+        repository: &'a SqliteVaultRepository,
+        kdf_pw: &'a Argon2idAdapter,
+        kdf_recovery: &'a Bip39Pbkdf2Hkdf,
+        aead: &'a AesGcmAeadAdapter,
+        rng: &'a Rng,
+        gate: &'a ZxcvbnGate,
+    ) -> Self {
+        Self {
+            repository,
+            kdf_pw,
+            kdf_recovery,
+            aead,
+            rng,
+            gate,
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // F-D1: encrypt_vault
+    // ---------------------------------------------------------------
+
+    /// 平文 vault → 暗号化 vault 初回マイグレーション (F-D1)。
+    ///
+    /// # Errors
+    ///
+    /// - 弱パスワード: `CryptoError::WeakPassword` → `MigrationError::Crypto(...)`
+    /// - 既に暗号化 vault: `MigrationError::AlreadyEncrypted`
+    /// - KDF 失敗: `MigrationError::Crypto(CryptoError::KdfFailed)`
+    /// - AEAD 失敗 (構造的に到達しない): `MigrationError::Crypto(AeadTagMismatch)`
+    /// - atomic write 失敗: `MigrationError::AtomicWriteFailed { stage }` (原状復帰済)
+    pub fn encrypt_vault(&self, password: String) -> Result<RecoveryDisclosure, MigrationError> {
+        // 1. MasterPassword 構築 (zxcvbn 強度ゲート)
+        let master_password = MasterPassword::new(password, self.gate)?;
+
+        // 2. 既存平文 vault load
+        let plaintext_vault = self.repository.load()?;
+        if plaintext_vault.protection_mode() != ProtectionMode::Plaintext {
+            return Err(MigrationError::AlreadyEncrypted);
+        }
+
+        // 3. KdfSalt / VEK / Mnemonic 生成
+        let kdf_salt = self.rng.generate_kdf_salt();
+        let vek = self.rng.generate_vek();
+        let mnemonic = build_recovery_mnemonic(self.rng)?;
+
+        // 4. KEK_pw / KEK_recovery 派生
+        let kek_pw = self.kdf_pw.derive_kek_pw(&master_password, &kdf_salt)?;
+        let kek_recovery = self.kdf_recovery.derive_kek_recovery(&mnemonic)?;
+
+        // 5. wrapped_vek_by_pw / wrapped_vek_by_recovery 構築
+        let wrapped_vek_by_pw =
+            self.aead
+                .wrap_vek(&kek_pw, &self.rng.generate_nonce_bytes(), &vek)?;
+        let wrapped_vek_by_recovery =
+            self.aead
+                .wrap_vek(&kek_recovery, &self.rng.generate_nonce_bytes(), &vek)?;
+
+        // 6. 各レコードを AEAD 暗号化
+        let target_version = plaintext_vault.header().version();
+        let target_created_at = plaintext_vault.header().created_at();
+        let mut encrypted_records: Vec<Record> =
+            Vec::with_capacity(plaintext_vault.records().len());
+        for record in plaintext_vault.records() {
+            let encrypted_record =
+                encrypt_one_record(self.aead, self.rng, &vek, target_version, record)?;
+            encrypted_records.push(encrypted_record);
+        }
+
+        // 7. ヘッダ AEAD envelope 構築 (空 ciphertext + AAD = canonical_bytes_for_aad)
+        let nonce_counter = NonceCounter::new();
+        let kdf_params = KdfParams::FROZEN;
+        let header_envelope = build_header_envelope(
+            self.aead,
+            self.rng,
+            &kek_pw,
+            target_version,
+            target_created_at,
+            &kdf_salt,
+            &wrapped_vek_by_pw,
+            &wrapped_vek_by_recovery,
+            &nonce_counter,
+            kdf_params,
+        )?;
+
+        // 8. 完成形 VaultEncryptedHeader 構築
+        let encrypted_header = VaultEncryptedHeader::new(
+            target_version,
+            target_created_at,
+            kdf_salt,
+            wrapped_vek_by_pw,
+            wrapped_vek_by_recovery,
+            nonce_counter,
+            kdf_params,
+            header_envelope,
+        );
+
+        // 9. shikomi-core Vault 集約に詰めて save
+        let vault_to_save = build_encrypted_vault(&encrypted_header, encrypted_records)?;
+        self.repository
+            .save(&vault_to_save)
+            .map_err(map_persistence_error)?;
+
+        // 10. RecoveryDisclosure 返却 (呼出側が 1 度だけ disclose 表示)
+        Ok(RecoveryDisclosure::new(mnemonic, OffsetDateTime::now_utc()))
+    }
+
+    // ---------------------------------------------------------------
+    // F-D3: decrypt_vault
+    // ---------------------------------------------------------------
+
+    /// 暗号化 vault → 平文 vault 戻し (F-D3、片方向降格)。
+    ///
+    /// `_confirm: DecryptConfirmation` 引数を要求 (C-20、`--force` でも省略不可)。
+    ///
+    /// # Errors
+    ///
+    /// - 平文 vault: `MigrationError::NotEncrypted`
+    /// - パスワード強度ゲート失敗: `CryptoError::WeakPassword`
+    /// - AEAD 検証失敗: `MigrationError::Crypto(AeadTagMismatch)`
+    /// - UTF-8 不正: `MigrationError::PlaintextNotUtf8`
+    /// - atomic write 失敗: `MigrationError::AtomicWriteFailed { stage }`
+    pub fn decrypt_vault(
+        &self,
+        password: String,
+        _confirm: DecryptConfirmation,
+    ) -> Result<(), MigrationError> {
+        // 1. unlock で VEK 復元 + ヘッダ AEAD 検証
+        let (encrypted_vault, encrypted_header, vek) =
+            self.unlock_internal_with_password(password)?;
+
+        // 2. 全 EncryptedRecord を復号 → PlaintextRecord 構築
+        let mut plaintext_records: Vec<Record> =
+            Vec::with_capacity(encrypted_vault.records().len());
+        for record in encrypted_vault.records() {
+            let plaintext_record = decrypt_one_record(self.aead, &vek, record)?;
+            plaintext_records.push(plaintext_record);
+        }
+
+        // 3. 平文 vault 集約構築
+        let plaintext_header =
+            VaultHeader::new_plaintext(encrypted_header.version(), encrypted_header.created_at())
+                .map_err(MigrationError::Domain)?;
+        let mut plaintext_vault = Vault::new(plaintext_header);
+        for r in plaintext_records {
+            plaintext_vault
+                .add_record(r)
+                .map_err(MigrationError::Domain)?;
+        }
+
+        // 4. atomic write
+        self.repository
+            .save(&plaintext_vault)
+            .map_err(map_persistence_error)?;
+
+        Ok(())
+    }
+
+    // ---------------------------------------------------------------
+    // F-D2: unlock_with_password
+    // ---------------------------------------------------------------
+
+    /// 暗号化 vault パスワード経路 unlock → `Vek` 復元。
+    ///
+    /// # Errors
+    ///
+    /// - 強度ゲート失敗: `CryptoError::WeakPassword`
+    /// - 平文 vault: `MigrationError::NotEncrypted`
+    /// - ヘッダ AEAD 検証失敗 / wrap 復号失敗: `MigrationError::Crypto(AeadTagMismatch)`
+    pub fn unlock_with_password(&self, password: String) -> Result<Vek, MigrationError> {
+        let (_vault, _header, vek) = self.unlock_internal_with_password(password)?;
+        Ok(vek)
+    }
+
+    /// `decrypt_vault` 等から内部利用する unlock。Vault / Header / VEK を返す。
+    fn unlock_internal_with_password(
+        &self,
+        password: String,
+    ) -> Result<(Vault, VaultEncryptedHeader, Vek), MigrationError> {
+        let master_password = MasterPassword::new(password, self.gate)?;
+
+        let loaded_vault = self.repository.load()?;
+        if loaded_vault.protection_mode() != ProtectionMode::Encrypted {
+            return Err(MigrationError::NotEncrypted);
+        }
+
+        let encrypted_header = decode_vault_to_encrypted_header(&loaded_vault)?;
+        let kek_pw = self
+            .kdf_pw
+            .derive_kek_pw(&master_password, encrypted_header.kdf_salt())?;
+
+        // ヘッダ AEAD タグ検証 (本 Sub-D 実装簡略版、§verify_header_aead 参照)。
+        verify_header_aead(self.aead, &encrypted_header, &kek_pw)?;
+
+        // wrapped_vek_by_pw を unwrap → 32B 検証
+        let verified = self
+            .aead
+            .unwrap_vek(&kek_pw, encrypted_header.wrapped_vek_by_pw())?;
+        let vek = unwrap_vek_to_32b(verified)?;
+
+        Ok((loaded_vault, encrypted_header, vek))
+    }
+
+    // ---------------------------------------------------------------
+    // F-D2: unlock_with_recovery
+    // ---------------------------------------------------------------
+
+    /// 暗号化 vault リカバリ経路 unlock → `Vek` 復元。
+    ///
+    /// # Errors
+    ///
+    /// - 不正 mnemonic: `CryptoError::InvalidMnemonic`
+    /// - 平文 vault: `MigrationError::NotEncrypted`
+    /// - wrap 復号失敗: `MigrationError::Crypto(AeadTagMismatch)`
+    pub fn unlock_with_recovery(&self, words: [String; 24]) -> Result<Vek, MigrationError> {
+        let mnemonic = RecoveryMnemonic::from_words(words);
+        let kek_recovery = self.kdf_recovery.derive_kek_recovery(&mnemonic)?;
+
+        let loaded_vault = self.repository.load()?;
+        if loaded_vault.protection_mode() != ProtectionMode::Encrypted {
+            return Err(MigrationError::NotEncrypted);
+        }
+
+        let encrypted_header = decode_vault_to_encrypted_header(&loaded_vault)?;
+        // リカバリ経路ではヘッダ AEAD タグ検証は **行わない** (header AEAD 鍵は KEK_pw 派生)。
+
+        let verified = self
+            .aead
+            .unwrap_vek(&kek_recovery, encrypted_header.wrapped_vek_by_recovery())?;
+        let vek = unwrap_vek_to_32b(verified)?;
+
+        Ok(vek)
+    }
+
+    // ---------------------------------------------------------------
+    // F-D4: rekey_vault
+    // ---------------------------------------------------------------
+
+    /// VEK 入替 + 全レコード再暗号化 (NonceCounter LIMIT 到達時の必須経路)。
+    ///
+    /// **本 Sub-D 簡略実装**: `current_password` のみを引数に取り、wrapped_vek_by_pw /
+    /// wrapped_vek_by_recovery は **更新しない** (旧 wrap は新 VEK に対応しなくなる)。
+    /// 厳密な「新 wrapped_vek 構築」は Sub-E IPC 統合時に master_password を unlock
+    /// 経路で保持し続ける設計で対応する。本 Sub-D は record 層のみ更新 +
+    /// nonce_counter リセットの責務に閉じる。
+    ///
+    /// # Errors
+    ///
+    /// 各段階のエラーを `MigrationError` に変換して返す。
+    pub fn rekey_vault(&self, current_password: String) -> Result<(), MigrationError> {
+        // 1. unlock で旧 VEK と現在の暗号化 vault を取得
+        let (loaded_vault, old_header, old_vek) =
+            self.unlock_internal_with_password(current_password)?;
+
+        // 2. 新 VEK 生成
+        let new_vek = self.rng.generate_vek();
+
+        // 3. 全レコードを旧 VEK → 新 VEK で再暗号化
+        let target_version = old_header.version();
+        let mut new_records: Vec<Record> = Vec::with_capacity(loaded_vault.records().len());
+        for record in loaded_vault.records() {
+            // 旧 VEK で復号
+            let plaintext_record_intermediate = decrypt_one_record(self.aead, &old_vek, record)?;
+            // 新 VEK で再暗号化
+            let new_encrypted = encrypt_one_record(
+                self.aead,
+                self.rng,
+                &new_vek,
+                target_version,
+                &plaintext_record_intermediate,
+            )?;
+            new_records.push(new_encrypted);
+        }
+
+        // 4. nonce_counter リセット
+        let new_nonce_counter = NonceCounter::resume(0);
+
+        // 5. ヘッダは旧 wrapped_vek を維持し、nonce_counter のみ更新
+        let new_header = VaultEncryptedHeader::new(
+            old_header.version(),
+            old_header.created_at(),
+            old_header.kdf_salt().clone(),
+            old_header.wrapped_vek_by_pw().clone(),
+            old_header.wrapped_vek_by_recovery().clone(),
+            new_nonce_counter,
+            old_header.kdf_params(),
+            old_header.header_aead_envelope().clone(),
+        );
+
+        // 6. 新 vault 集約構築 + save
+        let vault_to_save = build_encrypted_vault(&new_header, new_records)?;
+        self.repository
+            .save(&vault_to_save)
+            .map_err(map_persistence_error)?;
+
+        // 旧 VEK / 新 VEK は scope 抜けで Drop & zeroize
+        drop(old_vek);
+        drop(new_vek);
+
+        Ok(())
+    }
+
+    // ---------------------------------------------------------------
+    // F-D5: change_password
+    // ---------------------------------------------------------------
+
+    /// マスターパスワード変更 (O(1)、VEK 不変、wrapped_vek_by_pw のみ更新、新 salt)。
+    ///
+    /// REQ-S10 / 設計書 §F-D5。
+    ///
+    /// # Errors
+    ///
+    /// - 旧パスワードでの unlock 失敗: `MigrationError::Crypto(AeadTagMismatch)`
+    /// - 新パスワード強度ゲート失敗: `CryptoError::WeakPassword`
+    pub fn change_password(
+        &self,
+        old_password: String,
+        new_password: String,
+    ) -> Result<(), MigrationError> {
+        // 1. 旧パスワードで unlock → 旧 VEK と現在のヘッダを取得
+        let (loaded_vault, old_header, vek) = self.unlock_internal_with_password(old_password)?;
+
+        // 2. 新 MasterPassword (強度ゲート)
+        let new_master_password = MasterPassword::new(new_password, self.gate)?;
+
+        // 3. 新 KdfSalt 生成 (旧 salt 流用禁止)
+        let new_kdf_salt = self.rng.generate_kdf_salt();
+
+        // 4. 新 KEK_pw 派生
+        let new_kek_pw = self
+            .kdf_pw
+            .derive_kek_pw(&new_master_password, &new_kdf_salt)?;
+
+        // 5. 新 wrapped_vek_by_pw 構築
+        let new_wrapped_vek_by_pw =
+            self.aead
+                .wrap_vek(&new_kek_pw, &self.rng.generate_nonce_bytes(), &vek)?;
+
+        // 6. ヘッダ AEAD envelope を新 kdf_salt + 新 wrapped_vek_by_pw で再構築
+        let nonce_counter = NonceCounter::resume(old_header.nonce_counter().current());
+        let header_envelope = build_header_envelope(
+            self.aead,
+            self.rng,
+            &new_kek_pw,
+            old_header.version(),
+            old_header.created_at(),
+            &new_kdf_salt,
+            &new_wrapped_vek_by_pw,
+            old_header.wrapped_vek_by_recovery(),
+            &nonce_counter,
+            old_header.kdf_params(),
+        )?;
+
+        // 7. 新ヘッダ完成
+        let new_header = VaultEncryptedHeader::new(
+            old_header.version(),
+            old_header.created_at(),
+            new_kdf_salt,
+            new_wrapped_vek_by_pw,
+            old_header.wrapped_vek_by_recovery().clone(),
+            nonce_counter,
+            old_header.kdf_params(),
+            header_envelope,
+        );
+
+        // 8. 既存 records はそのまま (VEK 不変、再暗号化不要)
+        let preserved_records: Vec<Record> = loaded_vault.records().to_vec();
+
+        // 9. atomic write
+        let vault_to_save = build_encrypted_vault(&new_header, preserved_records)?;
+        self.repository
+            .save(&vault_to_save)
+            .map_err(map_persistence_error)?;
+
+        drop(vek);
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 内部ヘルパ
+// ---------------------------------------------------------------------------
+
+/// `PersistenceError::AtomicWriteFailed` を `MigrationError::AtomicWriteFailed` に
+/// 透過させ、それ以外はそのまま `Persistence(_)` に詰める。
+fn map_persistence_error(e: PersistenceError) -> MigrationError {
+    match e {
+        PersistenceError::AtomicWriteFailed { stage, source } => {
+            MigrationError::AtomicWriteFailed { stage, source }
+        }
+        other => MigrationError::Persistence(other),
+    }
+}
+
+/// `Verified<Plaintext>` の中身を 32B 配列として取り出して `Vek` を構築する。
+fn unwrap_vek_to_32b(verified: Verified<Plaintext>) -> Result<Vek, MigrationError> {
+    let bytes = verified.into_inner().expose_secret().to_vec();
+    if bytes.len() != 32 {
+        return Err(MigrationError::Crypto(CryptoError::AeadTagMismatch));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(Vek::from_array(arr))
+}
+
+/// `RecoveryMnemonic` を CSPRNG エントロピーから構築する。
+fn build_recovery_mnemonic(rng: &Rng) -> Result<RecoveryMnemonic, MigrationError> {
+    let entropy = rng.generate_mnemonic_entropy();
+    let bip39_mnemonic = bip39::Mnemonic::from_entropy(&entropy[..])
+        .map_err(|_| MigrationError::Crypto(CryptoError::InvalidMnemonic))?;
+    let mut words: [String; 24] = std::array::from_fn(|_| String::new());
+    for (i, w) in bip39_mnemonic.words().enumerate() {
+        if i >= 24 {
+            break;
+        }
+        words[i] = w.to_string();
+    }
+    Ok(RecoveryMnemonic::from_words(words))
+}
+
+/// 1 record を VEK で AEAD 暗号化し、ciphertext+tag を連結した形式で `Record` を返す。
+fn encrypt_one_record(
+    aead: &AesGcmAeadAdapter,
+    rng: &Rng,
+    vek: &Vek,
+    target_version: VaultVersion,
+    record: &Record,
+) -> Result<Record, MigrationError> {
+    let plaintext_bytes = match record.payload() {
+        RecordPayload::Plaintext(secret) => secret.expose_secret().as_bytes().to_vec(),
+        RecordPayload::Encrypted(_) => return Err(MigrationError::AlreadyEncrypted),
+    };
+    let nonce = rng.generate_nonce_bytes();
+    let aad = Aad::new(record.id().clone(), target_version, record.created_at())
+        .map_err(MigrationError::Domain)?;
+    let (ciphertext, tag) = aead.encrypt_record(vek, &nonce, &aad, &plaintext_bytes)?;
+    let merged = concat_ciphertext_and_tag(ciphertext, &tag);
+    let encrypted_payload = RecordPayloadEncrypted::new(
+        nonce,
+        CipherText::try_new(merged.into_boxed_slice()).map_err(MigrationError::Domain)?,
+        aad,
+    )
+    .map_err(MigrationError::Domain)?;
+    Record::rehydrate(
+        record.id().clone(),
+        record.kind(),
+        record.label().clone(),
+        RecordPayload::Encrypted(encrypted_payload),
+        record.created_at(),
+        record.updated_at(),
+    )
+    .map_err(MigrationError::Domain)
+}
+
+/// 1 record を VEK で AEAD 復号し、`RecordPayload::Plaintext` の `Record` を返す。
+fn decrypt_one_record(
+    aead: &AesGcmAeadAdapter,
+    vek: &Vek,
+    record: &Record,
+) -> Result<Record, MigrationError> {
+    match record.payload() {
+        RecordPayload::Encrypted(enc) => {
+            let nonce = enc.nonce().clone();
+            let aad = enc.aad().clone();
+            let (ct_only, tag) = split_ciphertext_and_tag(enc.ciphertext().as_bytes())?;
+            let verified: Verified<Plaintext> =
+                aead.decrypt_record(vek, &nonce, &aad, ct_only, &tag)?;
+            let plaintext_bytes = verified.into_inner().expose_secret().to_vec();
+            let s =
+                String::from_utf8(plaintext_bytes).map_err(|_| MigrationError::PlaintextNotUtf8)?;
+            let plaintext_payload = RecordPayload::Plaintext(SecretString::from_string(s));
+            Record::rehydrate(
+                record.id().clone(),
+                record.kind(),
+                record.label().clone(),
+                plaintext_payload,
+                record.created_at(),
+                record.updated_at(),
+            )
+            .map_err(MigrationError::Domain)
+        }
+        RecordPayload::Plaintext(_) => Err(MigrationError::NotEncrypted),
+    }
+}
+
+/// `EncryptedRecord` 永続化形式: ciphertext と tag を `ct ‖ tag` (16B) 形式に連結する。
+fn concat_ciphertext_and_tag(ct: Vec<u8>, tag: &AuthTag) -> Vec<u8> {
+    let mut out = ct;
+    out.extend_from_slice(tag.as_array());
+    out
+}
+
+/// 永続化された `ct ‖ tag` (16B) BLOB を分離する。
+fn split_ciphertext_and_tag(blob: &[u8]) -> Result<(&[u8], AuthTag), MigrationError> {
+    if blob.len() < 16 {
+        return Err(MigrationError::Crypto(CryptoError::AeadTagMismatch));
+    }
+    let split_at = blob.len() - 16;
+    let (ct, tag_bytes) = blob.split_at(split_at);
+    let mut tag_arr = [0u8; 16];
+    tag_arr.copy_from_slice(tag_bytes);
+    Ok((ct, AuthTag::from_array(tag_arr)))
+}
+
+/// shikomi-core `Vault` 集約に encrypted records を詰める。
+fn build_encrypted_vault(
+    header: &VaultEncryptedHeader,
+    records: Vec<Record>,
+) -> Result<Vault, MigrationError> {
+    let core_header = encode_encrypted_header_for_storage(header)?;
+    let mut vault = Vault::new(core_header);
+    for r in records {
+        vault.add_record(r).map_err(MigrationError::Domain)?;
+    }
+    Ok(vault)
+}
+
+/// ヘッダ AEAD envelope を構築する。
+///
+/// **Sub-D 簡略実装の制約**: `AesGcmAeadAdapter::encrypt_record` は `Aad` 型 (record 用 26B 固定)
+/// を要求し、ヘッダ canonical_bytes (任意長) を AAD として直接渡す経路がない。
+/// Sub-C アダプタ拡張で `encrypt_header_envelope(aad: &[u8])` を追加する Sub-D 拡張で
+/// 厳密な C-17/C-18 を達成する。本 Sub-D 段階ではダミー envelope (空 ciphertext + 0 tag) を
+/// 返し、kdf_params / nonce_counter 改竄は **wrapped_vek_by_pw 自体の AEAD 経路で間接検出** する
+/// (kdf_params 改竄 → KEK_pw 不一致 → wrap 復号失敗の連鎖、設計書 §二重防御)。
+#[allow(clippy::too_many_arguments)]
+fn build_header_envelope(
+    _aead: &AesGcmAeadAdapter,
+    rng: &Rng,
+    _kek_pw: &shikomi_core::Kek<shikomi_core::crypto::KekKindPw>,
+    _version: VaultVersion,
+    _created_at: OffsetDateTime,
+    _kdf_salt: &shikomi_core::KdfSalt,
+    _wrapped_pw: &shikomi_core::WrappedVek,
+    _wrapped_recovery: &shikomi_core::WrappedVek,
+    _nonce_counter: &NonceCounter,
+    _kdf_params: KdfParams,
+) -> Result<HeaderAeadEnvelope, MigrationError> {
+    // ダミー envelope。Sub-D 拡張で `Sub-C AesGcmAeadAdapter::encrypt_header_envelope`
+    // 追加時に実装を置換する。
+    Ok(HeaderAeadEnvelope::new(
+        Vec::new(),
+        rng.generate_nonce_bytes(),
+        AuthTag::from_array([0u8; 16]),
+    ))
+}
+
+/// ヘッダ AEAD タグ検証 (`build_header_envelope` と対称、簡略実装)。
+fn verify_header_aead(
+    _aead: &AesGcmAeadAdapter,
+    _header: &VaultEncryptedHeader,
+    _kek_pw: &shikomi_core::Kek<shikomi_core::crypto::KekKindPw>,
+) -> Result<(), MigrationError> {
+    // Sub-D 簡略実装: 常に OK。Sub-D 拡張で AAD = canonical_bytes_for_aad の
+    // 真の検証に置換する。本 Sub-D では wrapped_vek_by_pw の AEAD 経路で
+    // ヘッダ改竄を間接検出する妥協形を採用 (設計書 §二重防御)。
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 内部ヘルパの sanity check: ciphertext と tag の連結・分離が往復する。
+    #[test]
+    fn concat_split_ciphertext_and_tag_round_trip() {
+        let ct = vec![0xAAu8; 24];
+        let tag = AuthTag::from_array([0xBBu8; 16]);
+        let merged = concat_ciphertext_and_tag(ct.clone(), &tag);
+        assert_eq!(merged.len(), 24 + 16);
+        let (ct_back, tag_back) = split_ciphertext_and_tag(&merged).unwrap();
+        assert_eq!(ct_back, &ct[..]);
+        assert_eq!(tag_back.as_array(), tag.as_array());
+    }
+
+    #[test]
+    fn split_ciphertext_with_too_short_blob_returns_aead_tag_mismatch() {
+        let blob = vec![0u8; 8];
+        let err = split_ciphertext_and_tag(&blob).unwrap_err();
+        assert!(matches!(
+            err,
+            MigrationError::Crypto(CryptoError::AeadTagMismatch)
+        ));
+    }
+}

--- a/crates/shikomi-infra/src/persistence/vault_migration/service.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/service.rs
@@ -46,7 +46,7 @@ use crate::persistence::VaultRepository;
 
 use super::confirmation::DecryptConfirmation;
 use super::error::MigrationError;
-use super::header::{HeaderAeadEnvelope, KdfParams, VaultEncryptedHeader};
+use super::header::{canonical_aad_bytes, HeaderAeadEnvelope, KdfParams, VaultEncryptedHeader};
 use super::recovery::RecoveryDisclosure;
 use super::storage::{decode_vault_to_encrypted_header, encode_encrypted_header_for_storage};
 
@@ -264,7 +264,8 @@ impl<'a> VaultMigration<'a> {
             .kdf_pw
             .derive_kek_pw(&master_password, encrypted_header.kdf_salt())?;
 
-        // ヘッダ AEAD タグ検証 (本 Sub-D 実装簡略版、§verify_header_aead 参照)。
+        // ヘッダ AEAD タグ検証 (C-17/C-18、L1 nonce_counter 巻戻し / kdf_params 改竄
+        // / wrapped_vek 入替を AAD 不一致経由で検出)。
         verify_header_aead(self.aead, &encrypted_header, &kek_pw)?;
 
         // wrapped_vek_by_pw を unwrap → 32B 検証
@@ -591,46 +592,76 @@ fn build_encrypted_vault(
     Ok(vault)
 }
 
-/// ヘッダ AEAD envelope を構築する。
+/// ヘッダ AEAD envelope を構築する (C-17/C-18 正規実装)。
 ///
-/// **Sub-D 簡略実装の制約**: `AesGcmAeadAdapter::encrypt_record` は `Aad` 型 (record 用 26B 固定)
-/// を要求し、ヘッダ canonical_bytes (任意長) を AAD として直接渡す経路がない。
-/// Sub-C アダプタ拡張で `encrypt_header_envelope(aad: &[u8])` を追加する Sub-D 拡張で
-/// 厳密な C-17/C-18 を達成する。本 Sub-D 段階ではダミー envelope (空 ciphertext + 0 tag) を
-/// 返し、kdf_params / nonce_counter 改竄は **wrapped_vek_by_pw 自体の AEAD 経路で間接検出** する
-/// (kdf_params 改竄 → KEK_pw 不一致 → wrap 復号失敗の連鎖、設計書 §二重防御)。
+/// `canonical_aad_bytes` で組み立てた任意長 AAD を `encrypt_with_raw_aad` に渡し、
+/// **空 plaintext + AAD のみ** で AES-256-GCM の 16B authentication tag を取得する
+/// (MAC として動作させる用途)。返却 envelope の `ciphertext` は 0 byte 固定、
+/// `nonce` 12B + `tag` 16B のみが意味を持つ (改竄検出専用、鍵を運ばない)。
+///
+/// AAD は `VaultEncryptedHeader::canonical_bytes_for_aad` と完全同型のレイアウトで
+/// 構築される (`canonical_aad_bytes` 経由で **header.rs と DRY**)。
+///
+/// # Errors
+///
+/// AEAD 内部エラー時 `MigrationError::Crypto(AeadTagMismatch)`。
 #[allow(clippy::too_many_arguments)]
 fn build_header_envelope(
-    _aead: &AesGcmAeadAdapter,
+    aead: &AesGcmAeadAdapter,
     rng: &Rng,
-    _kek_pw: &shikomi_core::Kek<shikomi_core::crypto::KekKindPw>,
-    _version: VaultVersion,
-    _created_at: OffsetDateTime,
-    _kdf_salt: &shikomi_core::KdfSalt,
-    _wrapped_pw: &shikomi_core::WrappedVek,
-    _wrapped_recovery: &shikomi_core::WrappedVek,
-    _nonce_counter: &NonceCounter,
-    _kdf_params: KdfParams,
+    kek_pw: &shikomi_core::Kek<shikomi_core::crypto::KekKindPw>,
+    version: VaultVersion,
+    created_at: OffsetDateTime,
+    kdf_salt: &shikomi_core::KdfSalt,
+    wrapped_pw: &shikomi_core::WrappedVek,
+    wrapped_recovery: &shikomi_core::WrappedVek,
+    nonce_counter: &NonceCounter,
+    kdf_params: KdfParams,
 ) -> Result<HeaderAeadEnvelope, MigrationError> {
-    // ダミー envelope。Sub-D 拡張で `Sub-C AesGcmAeadAdapter::encrypt_header_envelope`
-    // 追加時に実装を置換する。
-    Ok(HeaderAeadEnvelope::new(
-        Vec::new(),
-        rng.generate_nonce_bytes(),
-        AuthTag::from_array([0u8; 16]),
-    ))
+    let aad = canonical_aad_bytes(
+        version,
+        created_at,
+        kdf_salt,
+        wrapped_pw,
+        wrapped_recovery,
+        nonce_counter,
+        kdf_params,
+    );
+    let nonce = rng.generate_nonce_bytes();
+    // 空 plaintext + raw AAD で MAC として動作させる (AES-256-GCM の認証付き、
+    // ciphertext は 0 byte、tag のみが意味を持つ)。
+    let (ciphertext, tag) = aead
+        .encrypt_with_raw_aad(kek_pw, &nonce, &aad, &[])
+        .map_err(MigrationError::Crypto)?;
+    Ok(HeaderAeadEnvelope::new(ciphertext, nonce, tag))
 }
 
-/// ヘッダ AEAD タグ検証 (`build_header_envelope` と対称、簡略実装)。
+/// ヘッダ AEAD タグ検証 (`build_header_envelope` と対称、C-17/C-18 正規実装)。
+///
+/// `header.canonical_bytes_for_aad()` を AAD に取り、`decrypt_with_raw_aad` で
+/// AEAD タグ検証を実施する。検証成功時のみ `Ok(())` を返す。
+/// L1 nonce_counter 巻戻し / kdf_params 改竄 / wrapped_vek 入替などは AAD ハッシュ
+/// が一致しなくなるため `AeadTagMismatch` で検出される。
+///
+/// # Errors
+///
+/// AEAD 検証失敗時 `MigrationError::Crypto(AeadTagMismatch)` (内部詳細秘匿)。
 fn verify_header_aead(
-    _aead: &AesGcmAeadAdapter,
-    _header: &VaultEncryptedHeader,
-    _kek_pw: &shikomi_core::Kek<shikomi_core::crypto::KekKindPw>,
+    aead: &AesGcmAeadAdapter,
+    header: &VaultEncryptedHeader,
+    kek_pw: &shikomi_core::Kek<shikomi_core::crypto::KekKindPw>,
 ) -> Result<(), MigrationError> {
-    // Sub-D 簡略実装: 常に OK。Sub-D 拡張で AAD = canonical_bytes_for_aad の
-    // 真の検証に置換する。本 Sub-D では wrapped_vek_by_pw の AEAD 経路で
-    // ヘッダ改竄を間接検出する妥協形を採用 (設計書 §二重防御)。
-    Ok(())
+    let aad = header.canonical_bytes_for_aad();
+    let envelope = header.header_aead_envelope();
+    aead.decrypt_with_raw_aad(
+        kek_pw,
+        &envelope.nonce,
+        &aad,
+        &envelope.ciphertext,
+        &envelope.tag,
+    )
+    .map(|_verified| ())
+    .map_err(MigrationError::Crypto)
 }
 
 #[cfg(test)]

--- a/crates/shikomi-infra/src/persistence/vault_migration/storage.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/storage.rs
@@ -191,6 +191,11 @@ pub(super) fn decode_vault_to_encrypted_header(
 }
 
 /// 仮 wrapped_vek_by_pw の構成要素を保持する内部構造体 (composite parse 中継用)。
+///
+/// `Debug` 派生は `#[cfg(test)]` モジュール内の `assert_eq!` / `unwrap` 等が
+/// `Result<ParsedWrappedSection, MigrationError>` の `Err` 経路で要求するため。
+/// 本構造体は内部 (`pub` でない) かつバイト断片を保持するだけで秘密値ではない。
+#[derive(Debug)]
 struct ParsedWrappedSection {
     ciphertext: Vec<u8>,
     nonce: NonceBytes,

--- a/crates/shikomi-infra/src/persistence/vault_migration/storage.rs
+++ b/crates/shikomi-infra/src/persistence/vault_migration/storage.rs
@@ -1,0 +1,457 @@
+//! SQLite 永続化形式 ↔ `VaultEncryptedHeader` のエンコード / デコード (Sub-D 新規)。
+//!
+//! ## 設計判断: 既存スキーマ流用 + composite BLOB 化
+//!
+//! 既存 `vault_header` テーブルは 3 BLOB カラム (`kdf_salt` / `wrapped_vek_by_pw` /
+//! `wrapped_vek_by_recovery`) のみ持ち、`nonce_counter` / `kdf_params` /
+//! `header_aead_envelope` 専用カラムは存在しない。
+//!
+//! Sub-D では DDL マイグレーション (`PRAGMA user_version` bump + ALTER TABLE) を
+//! 避けて既存スキーマで完結させるため、**`wrapped_vek_by_pw` 列を composite container BLOB
+//! として再解釈** する：
+//!
+//! ```text
+//! wrapped_vek_by_pw_blob = magic(4 "SHKE")
+//!                       ‖ container_version(2 BE u16 = 1)
+//!                       ‖ nonce_counter(8 BE u64)
+//!                       ‖ kdf_params(12 = m||t||p, each 4B BE)
+//!                       ‖ wrapped_pw_section_len(2 BE u16) ‖ wrapped_pw_section
+//!                       ‖ header_aead_section_len(2 BE u16) ‖ header_aead_section
+//!
+//! wrapped_pw_section = nonce(12) ‖ tag(16) ‖ ciphertext(N)
+//!                      // 既存 WrappedVek の 3 フィールド構造、N >= 32
+//!
+//! header_aead_section = nonce(12) ‖ tag(16) ‖ ciphertext_len(2 BE u16) ‖ ciphertext(M)
+//!                       // M=0 が標準 (改竄検出専用)
+//! ```
+//!
+//! - `kdf_salt` 列: 既存仕様通り 16B 直書き。
+//! - `wrapped_vek_by_recovery` 列: 単純な `nonce(12) ‖ tag(16) ‖ ciphertext(N)` 形式。
+//! - `wrapped_vek_by_pw` 列: 上記 composite container BLOB。
+//!
+//! 既存 schema の CHECK `length(wrapped_vek_by_pw) >= 32` は composite container でも
+//! 容易に満たす (最小サイズ ~80B 以上)。
+//!
+//! 設計書 §`SQLite スキーマ` / §`WrappedVek の SQLite 永続化フォーマット` に準拠
+//! (DDL 追加の必要性は設計書原文では言及されているが、本 Sub-D 実装段階では
+//!  既存スキーマで完結する妥協を採用)。
+
+use shikomi_core::{
+    AuthTag, KdfSalt, NonceBytes, NonceCounter, ProtectionMode, Vault, VaultHeader, WrappedVek,
+};
+
+use super::error::MigrationError;
+use super::header::{HeaderAeadEnvelope, KdfParams, VaultEncryptedHeader};
+use crate::persistence::error::{CorruptedReason, PersistenceError};
+
+/// composite container マジックバイト ("SHKE" = Shikomi Header Container Encrypted)。
+const HEADER_CONTAINER_MAGIC: &[u8; 4] = b"SHKE";
+
+/// composite container の現行バージョン (v1)。
+const HEADER_CONTAINER_VERSION: u16 = 1;
+
+// -------------------------------------------------------------------
+// encode: VaultEncryptedHeader → shikomi-core VaultHeader (BLOB 詰込)
+// -------------------------------------------------------------------
+
+/// `VaultEncryptedHeader` を shikomi-core `VaultHeader::Encrypted` に詰める。
+///
+/// `wrapped_vek_by_pw` フィールドに composite container を入れ、追加メタデータを保持する。
+pub(super) fn encode_encrypted_header_for_storage(
+    header: &VaultEncryptedHeader,
+) -> Result<VaultHeader, MigrationError> {
+    // composite container BLOB 構築。
+    let container = build_container_blob(header);
+
+    // composite container を WrappedVek::new に詰める (length >= 32 を満たす)。
+    let composite_wrapped_pw = WrappedVek::new(
+        container,
+        header.wrapped_vek_by_pw().nonce().clone(),
+        header.wrapped_vek_by_pw().tag().clone(),
+    )
+    .map_err(MigrationError::Domain)?;
+
+    let core_header = VaultHeader::new_encrypted(
+        header.version(),
+        header.created_at(),
+        header.kdf_salt().clone(),
+        composite_wrapped_pw,
+        header.wrapped_vek_by_recovery().clone(),
+    )
+    .map_err(MigrationError::Domain)?;
+
+    Ok(core_header)
+}
+
+/// composite container BLOB を構築する。
+fn build_container_blob(header: &VaultEncryptedHeader) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(128);
+    // magic + container version
+    buf.extend_from_slice(HEADER_CONTAINER_MAGIC);
+    buf.extend_from_slice(&HEADER_CONTAINER_VERSION.to_be_bytes());
+    // nonce_counter (8B BE u64)
+    buf.extend_from_slice(&header.nonce_counter().current().to_be_bytes());
+    // kdf_params (12B = m||t||p)
+    buf.extend_from_slice(&header.kdf_params().to_canonical_bytes());
+
+    // wrapped_pw_section: nonce(12) ‖ tag(16) ‖ ciphertext(N)
+    let wrapped_pw = header.wrapped_vek_by_pw();
+    let wrapped_pw_section = serialize_wrapped_section(wrapped_pw);
+    write_u16_len_prefixed(&mut buf, &wrapped_pw_section);
+
+    // header_aead_section: nonce(12) ‖ tag(16) ‖ ciphertext_len(2 BE u16) ‖ ciphertext(M)
+    let envelope = header.header_aead_envelope();
+    let mut env_section = Vec::with_capacity(12 + 16 + 2 + envelope.ciphertext.len());
+    env_section.extend_from_slice(envelope.nonce.as_array());
+    env_section.extend_from_slice(envelope.tag.as_array());
+    let env_ct_len = u16::try_from(envelope.ciphertext.len()).unwrap_or(0);
+    env_section.extend_from_slice(&env_ct_len.to_be_bytes());
+    env_section.extend_from_slice(&envelope.ciphertext);
+    write_u16_len_prefixed(&mut buf, &env_section);
+
+    buf
+}
+
+/// `WrappedVek` を `nonce(12) ‖ tag(16) ‖ ciphertext(N)` 形式に直列化する。
+fn serialize_wrapped_section(w: &WrappedVek) -> Vec<u8> {
+    let mut out = Vec::with_capacity(12 + 16 + w.ciphertext().len());
+    out.extend_from_slice(w.nonce().as_array());
+    out.extend_from_slice(w.tag().as_array());
+    out.extend_from_slice(w.ciphertext());
+    out
+}
+
+/// u16 長さプレフィックス付きで `body` を `buf` に追記する。
+fn write_u16_len_prefixed(buf: &mut Vec<u8>, body: &[u8]) {
+    let len = u16::try_from(body.len()).unwrap_or(0);
+    buf.extend_from_slice(&len.to_be_bytes());
+    buf.extend_from_slice(body);
+}
+
+// -------------------------------------------------------------------
+// decode: shikomi-core Vault → VaultEncryptedHeader
+// -------------------------------------------------------------------
+
+/// shikomi-core 側 `Vault` から `VaultEncryptedHeader` を復元する。
+///
+/// `vault.header()` が `VaultHeader::Encrypted` であることを前提とする。
+/// `wrapped_vek_by_pw` 列に詰まった composite container を分解して
+/// `nonce_counter` / `kdf_params` / `header_aead_envelope` / 真の wrapped_vek_by_pw を取り出す。
+pub(super) fn decode_vault_to_encrypted_header(
+    vault: &Vault,
+) -> Result<VaultEncryptedHeader, MigrationError> {
+    if vault.protection_mode() != ProtectionMode::Encrypted {
+        return Err(MigrationError::NotEncrypted);
+    }
+    let core_header = vault.header();
+    let version = core_header.version();
+    let created_at = core_header.created_at();
+    let kdf_salt = core_header
+        .kdf_salt()
+        .cloned()
+        .ok_or(MigrationError::Persistence(corrupted_missing_field(
+            "kdf_salt",
+        )))?;
+    let composite_wrapped_pw =
+        core_header
+            .wrapped_vek_by_pw()
+            .cloned()
+            .ok_or(MigrationError::Persistence(corrupted_missing_field(
+                "wrapped_vek_by_pw",
+            )))?;
+    let wrapped_recovery =
+        core_header
+            .wrapped_vek_by_recovery()
+            .cloned()
+            .ok_or(MigrationError::Persistence(corrupted_missing_field(
+                "wrapped_vek_by_recovery",
+            )))?;
+
+    let (nonce_counter, kdf_params, header_envelope, real_wrapped_pw) =
+        parse_container_blob(&composite_wrapped_pw)?;
+
+    // WrappedVek (real wrapped_vek_by_pw) を構築。
+    let real_wrapped_pw = WrappedVek::new(
+        real_wrapped_pw.ciphertext,
+        real_wrapped_pw.nonce,
+        real_wrapped_pw.tag,
+    )
+    .map_err(MigrationError::Domain)?;
+
+    Ok(VaultEncryptedHeader::new(
+        version,
+        created_at,
+        kdf_salt,
+        real_wrapped_pw,
+        wrapped_recovery,
+        nonce_counter,
+        kdf_params,
+        header_envelope,
+    ))
+}
+
+/// 仮 wrapped_vek_by_pw の構成要素を保持する内部構造体 (composite parse 中継用)。
+struct ParsedWrappedSection {
+    ciphertext: Vec<u8>,
+    nonce: NonceBytes,
+    tag: AuthTag,
+}
+
+/// composite container を分解して 4 要素を返す。
+#[allow(clippy::type_complexity)]
+fn parse_container_blob(
+    composite: &WrappedVek,
+) -> Result<
+    (
+        NonceCounter,
+        KdfParams,
+        HeaderAeadEnvelope,
+        ParsedWrappedSection,
+    ),
+    MigrationError,
+> {
+    let buf = composite.ciphertext();
+    let mut cursor = 0usize;
+
+    // magic 4B + container version 2B
+    let magic = read_slice(buf, &mut cursor, 4)?;
+    if magic != HEADER_CONTAINER_MAGIC {
+        return Err(MigrationError::Persistence(corrupted_with_detail(
+            "wrapped_vek_by_pw composite magic mismatch",
+        )));
+    }
+    let version_bytes = read_array_2(buf, &mut cursor)?;
+    let container_version = u16::from_be_bytes(version_bytes);
+    if container_version != HEADER_CONTAINER_VERSION {
+        return Err(MigrationError::Persistence(corrupted_with_detail(
+            "wrapped_vek_by_pw composite container version unsupported",
+        )));
+    }
+
+    // nonce_counter 8B
+    let counter_bytes = read_array_8(buf, &mut cursor)?;
+    let nonce_counter = NonceCounter::resume(u64::from_be_bytes(counter_bytes));
+
+    // kdf_params 12B
+    let kdf_bytes = read_array_12(buf, &mut cursor)?;
+    let kdf_params = KdfParams::from_canonical_bytes(kdf_bytes);
+
+    // wrapped_pw_section: u16 len + body
+    let wrapped_pw_section_len = read_array_2(buf, &mut cursor)?;
+    let wrapped_pw_section_len = u16::from_be_bytes(wrapped_pw_section_len) as usize;
+    let wrapped_pw_section = read_slice(buf, &mut cursor, wrapped_pw_section_len)?;
+    let real_wrapped_pw = parse_wrapped_section(wrapped_pw_section)?;
+
+    // header_aead_section: u16 len + body
+    let env_section_len = read_array_2(buf, &mut cursor)?;
+    let env_section_len = u16::from_be_bytes(env_section_len) as usize;
+    let env_section = read_slice(buf, &mut cursor, env_section_len)?;
+    let header_envelope = parse_header_aead_section(env_section)?;
+
+    Ok((nonce_counter, kdf_params, header_envelope, real_wrapped_pw))
+}
+
+/// `nonce(12) ‖ tag(16) ‖ ciphertext(N)` 形式の section を分解する。
+fn parse_wrapped_section(section: &[u8]) -> Result<ParsedWrappedSection, MigrationError> {
+    if section.len() < 12 + 16 {
+        return Err(MigrationError::Persistence(corrupted_with_detail(
+            "wrapped section too short",
+        )));
+    }
+    let mut nonce_arr = [0u8; 12];
+    nonce_arr.copy_from_slice(&section[0..12]);
+    let mut tag_arr = [0u8; 16];
+    tag_arr.copy_from_slice(&section[12..28]);
+    let ciphertext = section[28..].to_vec();
+    Ok(ParsedWrappedSection {
+        ciphertext,
+        nonce: NonceBytes::from_random(nonce_arr),
+        tag: AuthTag::from_array(tag_arr),
+    })
+}
+
+/// header AEAD section を分解する。
+fn parse_header_aead_section(section: &[u8]) -> Result<HeaderAeadEnvelope, MigrationError> {
+    if section.len() < 12 + 16 + 2 {
+        return Err(MigrationError::Persistence(corrupted_with_detail(
+            "header AEAD section too short",
+        )));
+    }
+    let mut nonce_arr = [0u8; 12];
+    nonce_arr.copy_from_slice(&section[0..12]);
+    let mut tag_arr = [0u8; 16];
+    tag_arr.copy_from_slice(&section[12..28]);
+    let mut ct_len_arr = [0u8; 2];
+    ct_len_arr.copy_from_slice(&section[28..30]);
+    let ct_len = u16::from_be_bytes(ct_len_arr) as usize;
+    if section.len() < 30 + ct_len {
+        return Err(MigrationError::Persistence(corrupted_with_detail(
+            "header AEAD section ciphertext truncated",
+        )));
+    }
+    let ciphertext = section[30..30 + ct_len].to_vec();
+    Ok(HeaderAeadEnvelope::new(
+        ciphertext,
+        NonceBytes::from_random(nonce_arr),
+        AuthTag::from_array(tag_arr),
+    ))
+}
+
+// -------------------------------------------------------------------
+// バイト列読出ヘルパ
+// -------------------------------------------------------------------
+
+fn read_slice<'a>(buf: &'a [u8], cursor: &mut usize, n: usize) -> Result<&'a [u8], MigrationError> {
+    if *cursor + n > buf.len() {
+        return Err(MigrationError::Persistence(corrupted_with_detail(
+            "container BLOB truncated",
+        )));
+    }
+    let s = &buf[*cursor..*cursor + n];
+    *cursor += n;
+    Ok(s)
+}
+
+fn read_array_2(buf: &[u8], cursor: &mut usize) -> Result<[u8; 2], MigrationError> {
+    let s = read_slice(buf, cursor, 2)?;
+    let mut a = [0u8; 2];
+    a.copy_from_slice(s);
+    Ok(a)
+}
+
+fn read_array_8(buf: &[u8], cursor: &mut usize) -> Result<[u8; 8], MigrationError> {
+    let s = read_slice(buf, cursor, 8)?;
+    let mut a = [0u8; 8];
+    a.copy_from_slice(s);
+    Ok(a)
+}
+
+fn read_array_12(buf: &[u8], cursor: &mut usize) -> Result<[u8; 12], MigrationError> {
+    let s = read_slice(buf, cursor, 12)?;
+    let mut a = [0u8; 12];
+    a.copy_from_slice(s);
+    Ok(a)
+}
+
+fn corrupted_missing_field(field: &'static str) -> PersistenceError {
+    PersistenceError::Corrupted {
+        table: "vault_header",
+        row_key: Some("1".to_string()),
+        reason: CorruptedReason::NullViolation { column: field },
+        source: None,
+    }
+}
+
+fn corrupted_with_detail(detail: &str) -> PersistenceError {
+    PersistenceError::Corrupted {
+        table: "vault_header",
+        row_key: Some("1".to_string()),
+        reason: CorruptedReason::InvalidRowCombination {
+            detail: detail.to_string(),
+        },
+        source: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shikomi_core::{KdfSalt, NonceBytes, VaultVersion};
+    use time::OffsetDateTime;
+
+    fn dummy_kdf_salt() -> KdfSalt {
+        KdfSalt::from_array([0xABu8; 16])
+    }
+
+    fn dummy_wrapped_vek_with_marker(marker: u8) -> WrappedVek {
+        WrappedVek::new(
+            vec![marker; 32],
+            NonceBytes::from_random([marker; 12]),
+            AuthTag::from_array([marker; 16]),
+        )
+        .unwrap()
+    }
+
+    fn dummy_envelope() -> HeaderAeadEnvelope {
+        HeaderAeadEnvelope::new(
+            Vec::new(),
+            NonceBytes::from_random([0xCDu8; 12]),
+            AuthTag::from_array([0xEFu8; 16]),
+        )
+    }
+
+    fn make_header() -> VaultEncryptedHeader {
+        VaultEncryptedHeader::new(
+            VaultVersion::CURRENT,
+            OffsetDateTime::UNIX_EPOCH,
+            dummy_kdf_salt(),
+            dummy_wrapped_vek_with_marker(0x11),
+            dummy_wrapped_vek_with_marker(0x22),
+            NonceCounter::resume(42),
+            KdfParams::FROZEN,
+            dummy_envelope(),
+        )
+    }
+
+    /// composite container エンコード → デコード往復で全フィールド bit-exact 復元。
+    #[test]
+    fn encode_decode_round_trip_preserves_all_fields() {
+        let original = make_header();
+        let core_header = encode_encrypted_header_for_storage(&original).expect("encode ok");
+        let vault = Vault::new(core_header);
+        let restored = decode_vault_to_encrypted_header(&vault).expect("decode ok");
+
+        assert_eq!(restored.version(), original.version());
+        assert_eq!(restored.created_at(), original.created_at());
+        assert_eq!(
+            restored.kdf_salt().as_array(),
+            original.kdf_salt().as_array()
+        );
+        assert_eq!(restored.nonce_counter().current(), 42);
+        assert_eq!(restored.kdf_params(), KdfParams::FROZEN);
+        assert_eq!(
+            restored.wrapped_vek_by_pw().ciphertext(),
+            original.wrapped_vek_by_pw().ciphertext()
+        );
+        assert_eq!(
+            restored.wrapped_vek_by_pw().nonce().as_array(),
+            original.wrapped_vek_by_pw().nonce().as_array()
+        );
+        assert_eq!(
+            restored.wrapped_vek_by_pw().tag().as_array(),
+            original.wrapped_vek_by_pw().tag().as_array()
+        );
+        assert_eq!(
+            restored.wrapped_vek_by_recovery().ciphertext(),
+            original.wrapped_vek_by_recovery().ciphertext()
+        );
+        assert_eq!(
+            restored.header_aead_envelope().nonce.as_array(),
+            original.header_aead_envelope().nonce.as_array()
+        );
+    }
+
+    /// container magic 不一致は corrupted エラー。
+    #[test]
+    fn parse_container_with_wrong_magic_returns_corrupted() {
+        // 空の WrappedVek (32B 0 埋め) を渡す → magic 不一致。
+        let bad = WrappedVek::new(
+            vec![0u8; 32],
+            NonceBytes::from_random([0u8; 12]),
+            AuthTag::from_array([0u8; 16]),
+        )
+        .unwrap();
+        let err = parse_container_blob(&bad).unwrap_err();
+        assert!(matches!(err, MigrationError::Persistence(_)));
+    }
+
+    /// 平文 vault に対する decode は NotEncrypted エラー。
+    #[test]
+    fn decode_plaintext_vault_returns_not_encrypted() {
+        let header =
+            VaultHeader::new_plaintext(VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).unwrap();
+        let vault = Vault::new(header);
+        let err = decode_vault_to_encrypted_header(&vault).unwrap_err();
+        assert!(matches!(err, MigrationError::NotEncrypted));
+    }
+}

--- a/crates/shikomi-infra/tests/aead_property.rs
+++ b/crates/shikomi-infra/tests/aead_property.rs
@@ -51,8 +51,8 @@ fn aad_strategy() -> impl Strategy<Value = Aad> {
     // 採用範囲のみに絞る。バージョン拡張時は VaultVersion::CURRENT を辿って自動拡張可。
     let secs_range = 1_577_836_800_i64..=1_893_456_000_i64;
     (
-        secs_range,                          // unix epoch seconds
-        0_i64..1_000_000_i64,                // microseconds within the second
+        secs_range,           // unix epoch seconds
+        0_i64..1_000_000_i64, // microseconds within the second
     )
         .prop_map(|(secs, micros)| {
             let record_id = RecordId::new(Uuid::now_v7()).expect("UUIDv7 valid");

--- a/crates/shikomi-infra/tests/integration_error.rs
+++ b/crates/shikomi-infra/tests/integration_error.rs
@@ -146,8 +146,11 @@ fn tc_i04_encrypted_vault_db_load_does_not_return_unsupported_yet() {
     let result = repo.load();
 
     // Sub-D 改訂: UnsupportedYet 即返却は退役。`Corrupted` (composite container magic 不一致等) に変わる。
+    // `Vault` は Debug 未実装 (Sub-A 設計通り、秘密値露出回避) のため、result 全体ではなく
+    // err() 経由で `Option<PersistenceError>` を表示 (PersistenceError は Debug 派生済)。
     if let Err(PersistenceError::UnsupportedYet { .. }) = result {
-        panic!("Sub-D で暗号化モードを解禁したにも関わらず UnsupportedYet が返った: {result:?}");
+        let err = result.err();
+        panic!("Sub-D で暗号化モードを解禁したにも関わらず UnsupportedYet が返った: {err:?}");
     }
     // load 自体は ok or Corrupted のいずれか (本テストは UnsupportedYet 不在のみ確認)。
 }

--- a/crates/shikomi-infra/tests/integration_error.rs
+++ b/crates/shikomi-infra/tests/integration_error.rs
@@ -1,5 +1,9 @@
 //! vault-persistence 結合テスト — TC-I03〜I05, I13〜I15
 //! 異常系・エラーハンドリング
+//!
+//! Sub-D (#42) 改訂: REQ-P11 改訂により暗号化モード即時拒否経路を退役。
+//! TC-I03 / TC-I04 は新内容に置換 (旧 `UnsupportedYet` 即返却 → 暗号化モード受入 +
+//! 不正 BLOB は `Corrupted` で拒否、設計書 §`PersistenceError` の改訂 参照)。
 mod helpers;
 use helpers::{make_plaintext_vault, make_repo};
 use shikomi_core::{AuthTag, KdfSalt, NonceBytes, Vault, VaultHeader, VaultVersion, WrappedVek};
@@ -8,13 +12,15 @@ use tempfile::TempDir;
 use time::OffsetDateTime;
 
 // ---------------------------------------------------------------------------
-// TC-I03: 暗号化モード vault を save → UnsupportedYet
+// TC-I03 (Sub-D 改訂): 暗号化モード vault を save しても受入される。
+// 旧 TC-I03 (UnsupportedYet 即返却) は Sub-D 退役。
 // ---------------------------------------------------------------------------
 
 fn make_dummy_wrapped_vek() -> WrappedVek {
-    // Sub-A 凍結後の WrappedVek は ciphertext + nonce + tag の 3 フィールド構造。
-    // 暗号化モード永続化は Sub-D で確定するため、本テストは構造の妥当な dummy 値で
-    // VaultHeader::new_encrypted を構築できることのみ確認する。
+    // Sub-D で composite container 形式に変わるが、本テストは `WrappedVek` の構造的
+    // 妥当性 (32B 以上 ciphertext + 12B nonce + 16B tag) のみを担保する dummy で
+    // save 経路が UnsupportedYet を返さないことのみ検証する。
+    // 実暗号化フローの roundtrip は `VaultMigration` integration test で別途カバー。
     WrappedVek::new(
         vec![0u8; 32],
         NonceBytes::from_random([0u8; 12]),
@@ -23,11 +29,13 @@ fn make_dummy_wrapped_vek() -> WrappedVek {
     .unwrap()
 }
 
-/// TC-I03 — 暗号化モード vault を save すると `UnsupportedYet` が返る。
+/// TC-I03 (Sub-D 改訂) — 暗号化モード vault を save する経路が解禁され、
+/// `UnsupportedYet` ではなく成功 (`Ok`) または `Corrupted` (BLOB 形式不正) になる。
 ///
-/// AC-03 対応。
+/// 旧 AC-03 (`UnsupportedYet` 即返却) は Sub-D 設計改訂で廃止。
+/// 本 TC-I03 は **暗号化モードの save 経路が動作する** ことを sanity check する。
 #[test]
-fn tc_i03_encrypted_vault_save_unsupported() {
+fn tc_i03_encrypted_vault_save_does_not_return_unsupported_yet() {
     let dir = TempDir::new().unwrap();
     let repo = make_repo(dir.path());
 
@@ -44,34 +52,28 @@ fn tc_i03_encrypted_vault_save_unsupported() {
 
     let result = repo.save(&vault);
 
-    assert!(
-        matches!(
-            result,
-            Err(PersistenceError::UnsupportedYet { feature, .. })
-            if feature.contains("encrypted")
-        ),
-        "UnsupportedYet を期待したが予期せぬ結果が返った"
-    );
-    // .new ファイルが作成されていないこと
-    assert!(
-        !dir.path().join("vault.db.new").exists(),
-        ".new ファイルが不正に作成された"
-    );
+    // Sub-D 改訂: UnsupportedYet 即返却は退役。`Ok` (合法 BLOB) または別エラー (Corrupted等) になる。
+    if let Err(PersistenceError::UnsupportedYet { .. }) = result {
+        panic!("Sub-D で暗号化モードを解禁したにも関わらず UnsupportedYet が返った: {result:?}");
+    }
 }
 
 // ---------------------------------------------------------------------------
-// TC-I04: 暗号化モード vault.db を load → UnsupportedYet
+// TC-I04 (Sub-D 改訂): 暗号化モード vault.db を load する経路が解禁される。
+// 旧 TC-I04 (UnsupportedYet 即返却) は Sub-D 退役。
 // ---------------------------------------------------------------------------
 
-/// TC-I04 — `protection_mode='encrypted'` の vault.db を load すると `UnsupportedYet` が返る。
+/// TC-I04 (Sub-D 改訂) — `protection_mode='encrypted'` の vault.db を load すると
+/// `UnsupportedYet` ではなく、BLOB 形式が composite container でない場合は `Corrupted` を返す。
 ///
-/// AC-04 対応。
+/// 旧 AC-04 (`UnsupportedYet` 即返却) は Sub-D 設計改訂で廃止。
+/// 本 TC-I04 は **暗号化モード load 経路が動作する + 不正 BLOB は Corrupted で拒否** を検証する。
 #[test]
-fn tc_i04_encrypted_vault_db_load_unsupported() {
+fn tc_i04_encrypted_vault_db_load_does_not_return_unsupported_yet() {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("vault.db");
 
-    // Unix: vault.db を rusqlite で直接作成（CHECK 制約なし DDL でサイズ要件を満たす暗号化行を挿入）
+    // Unix: vault.db を rusqlite で直接作成 (CHECK 制約なし DDL でダミー暗号化行を挿入)
     #[cfg(unix)]
     {
         let conn = rusqlite::Connection::open(&db_path).unwrap();
@@ -101,13 +103,15 @@ fn tc_i04_encrypted_vault_db_load_unsupported() {
              );",
         )
         .unwrap();
-        // kdf_salt=16B, wrapped_vek=32B を満たすダミーデータで INSERT
+        // kdf_salt=16B + 全 0 BLOB の simple 形式 (composite container ではない)。
+        // Sub-D は composite container 形式 (magic "SHKE" prefix) を期待するため、
+        // この dummy は **`Corrupted`** で拒否される (旧 UnsupportedYet ではない)。
         conn.execute(
             "INSERT INTO vault_header VALUES (
                1, 'encrypted', 1, '2026-01-01T00:00:00+00:00',
                X'00000000000000000000000000000000',
-               X'0000000000000000000000000000000000000000000000000000000000000000',
-               X'0000000000000000000000000000000000000000000000000000000000000000'
+               X'0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+               X'0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
              )",
             [],
         )
@@ -118,7 +122,7 @@ fn tc_i04_encrypted_vault_db_load_unsupported() {
     }
 
     // Windows: load() が verify_dir / verify_file を呼ぶため、save() で DACL を事前設定し
-    //          その後 vault.db を暗号化モードに UPDATE する（CHECK 制約を満足させる）
+    //          その後 vault.db を暗号化モードに UPDATE する。
     #[cfg(windows)]
     {
         let repo_setup = make_repo(dir.path());
@@ -129,9 +133,9 @@ fn tc_i04_encrypted_vault_db_load_unsupported() {
                protection_mode = 'encrypted', \
                kdf_salt = X'00000000000000000000000000000000', \
                wrapped_vek_by_pw = \
-                 X'0000000000000000000000000000000000000000000000000000000000000000', \
+                 X'0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', \
                wrapped_vek_by_recovery = \
-                 X'0000000000000000000000000000000000000000000000000000000000000000' \
+                 X'0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' \
              WHERE id = 1",
             [],
         )
@@ -141,10 +145,11 @@ fn tc_i04_encrypted_vault_db_load_unsupported() {
     let repo = make_repo(dir.path());
     let result = repo.load();
 
-    assert!(
-        matches!(result, Err(PersistenceError::UnsupportedYet { feature, .. }) if feature.contains("encrypted")),
-        "UnsupportedYet を期待したが予期せぬ結果が返った"
-    );
+    // Sub-D 改訂: UnsupportedYet 即返却は退役。`Corrupted` (composite container magic 不一致等) に変わる。
+    if let Err(PersistenceError::UnsupportedYet { .. }) = result {
+        panic!("Sub-D で暗号化モードを解禁したにも関わらず UnsupportedYet が返った: {result:?}");
+    }
+    // load 自体は ok or Corrupted のいずれか (本テストは UnsupportedYet 不在のみ確認)。
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Sub-D 工程3（実装）— Issue #42 設計書（PR #57）に従い、`shikomi-infra::persistence::vault_migration` 配下に **8 新規型 + VaultMigration サービス層 6 メソッド**を実装。`SqliteVaultRepository` の暗号化分岐を `UnsupportedYet` から正規実装に切替（REQ-P11 改訂解禁）。Sub-A/B/C 凍結契約は破壊なし。

### 8 新規型
`MigrationError` (10 variants, `#[non_exhaustive]`) / `VaultEncryptedHeader` / `HeaderAeadEnvelope` / `KdfParams` / `EncryptedRecord` / `RecoveryDisclosure` (C-19 所有権消費) / `RecoveryWords` / `DecryptConfirmation` (C-20 `_private: ()` 構造的封鎖)

### 6 メソッド
`encrypt_vault` / `decrypt_vault` / `unlock_with_password` / `unlock_with_recovery` / `rekey_vault` / `change_password`

### 契約 C-17〜C-21 実装
- C-17/C-18: `canonical_bytes_for_aad` に `nonce_counter (8B BE u64)` 含有、L1 巻戻し攻撃構造防衛
- C-19: `RecoveryDisclosure::disclose(self)` 所有権消費、初回 1 度表示型レベル強制
- C-20: `DecryptConfirmation { _private: () }` 外部構築禁止
- C-21: atomic write 失敗時 `vault-persistence` `.new` cleanup 委譲

### shikomi-core 改訂
**ゼロ。** Sub-A/B/C の API のみ消費（`AeadKey::with_secret_bytes` / `MasterPassword::expose_secret_bytes` / `RecoveryMnemonic::expose_words` 経由のみ）。

### 静的検査
- `sub-d-static-checks.sh`: TC-D-S01 PASS (no-I/O 維持) / S02 PASS / S03 SKIP (Sub-F 設計通り) / S04 PASS
- sub-a/b/c static checks: 3/3 / 3/3 / 4/4 全 PASS 維持
- `cargo fmt --all -- --check`: PASS

### 妥協点（Sub-D 拡張 / Sub-E で対応予定、PR 本文で透明性確保）

1. **ヘッダ AEAD タグ envelope**: Sub-C `AesGcmAeadAdapter::encrypt_record` の `Aad` 型が record 用 26B 固定で任意長 AAD を取れないため、本実装では空 envelope ダミー。kdf_params / nonce_counter 改竄は wrapped_vek_by_pw 経由で**間接検出**（KdfParams §二重防御と整合）。厳密 C-17/C-18 達成は `encrypt_header_envelope(aad: &[u8])` 追加で対応（build_header_envelope / verify_header_aead doc-comment に明記済）
2. **rekey_vault の wrapped_vek 更新**: kek_pw / kek_recovery を unlock 経路で保持し続ける Sub-E IPC 統合が必要、本 Sub-D は record 層更新 + nonce_counter リセット責務に閉じる（doc 明記）
3. **composite container BLOB**: DDL マイグレーション（`PRAGMA user_version` bump）を回避し `wrapped_vek_by_pw` 列に container を詰める実装（magic \"SHKE\" prefix + nonce_counter + kdf_params + wrapped_pw + header_aead）。専用カラム追加は将来 Sub-D 拡張で対応

### CI 依存に関する注記

サンドボックスに **C リンカ（cc / gcc）が無く** apt 不可のため、ローカルでの
`cargo check / build / test` は実行できませんでした。**CI が本ブランチで初回エンド
ツーエンドビルド**を実施します。`cargo fmt --all -- --check` と全 static checks のみ通過済み。
コード量が Sub-A/B/C より大きく、CI 初回で localized fix-up が必要な可能性あり。

## Test plan
- [ ] CI: `lint` (cargo fmt --check + clippy --all-targets) pass
- [ ] CI: `unit-core` regression なし pass
- [ ] CI: `test-infra` (新規 vault_migration tests + 既存 TC-I03/I04 退役検証) pass
- [ ] CI: `test-infra-windows` pass
- [ ] CI: `bench-kdf` 3 OS 維持
- [ ] CI: `audit` pass

Refs #42