### PR TITLE
fix(clippy): resolve Rust 1.95.0 default_constructed_unit_structs + single_match_else

### DIFF
--- a/crates/shikomi-daemon/src/lib.rs
+++ b/crates/shikomi-daemon/src/lib.rs
@@ -104,15 +104,12 @@ pub async fn run() -> ExitCode {
         return DaemonExit::EncryptionUnsupported.into();
     }
 
-    let listener = match single_instance.take_listener() {
-        Some(l) => l,
-        None => {
-            tracing::error!(
-                target: "shikomi_daemon::lifecycle",
-                "internal: listener missing after acquisition"
-            );
-            return DaemonExit::SystemError.into();
-        }
+    let Some(listener) = single_instance.take_listener() else {
+        tracing::error!(
+            target: "shikomi_daemon::lifecycle",
+            "internal: listener missing after acquisition"
+        );
+        return DaemonExit::SystemError.into();
     };
 
     let repo = Arc::new(repo);

--- a/crates/shikomi-infra/tests/vault_migration_integration.rs
+++ b/crates/shikomi-infra/tests/vault_migration_integration.rs
@@ -44,9 +44,9 @@ fn build_migration_set() -> (
 ) {
     (
         Argon2idAdapter::default(),
-        Bip39Pbkdf2Hkdf::default(),
+        Bip39Pbkdf2Hkdf,
         AesGcmAeadAdapter,
-        Rng::default(),
+        Rng,
         ZxcvbnGate::default(),
     )
 }

--- a/crates/shikomi-infra/tests/vault_migration_property.rs
+++ b/crates/shikomi-infra/tests/vault_migration_property.rs
@@ -105,9 +105,9 @@ proptest! {
 
         // encrypt → decrypt 往復
         let kdf_pw = Argon2idAdapter::default();
-        let kdf_recovery = Bip39Pbkdf2Hkdf::default();
+        let kdf_recovery = Bip39Pbkdf2Hkdf;
         let aead = AesGcmAeadAdapter;
-        let rng = Rng::default();
+        let rng = Rng;
         let gate = ZxcvbnGate::default();
         let migration = VaultMigration::new(&repo, &kdf_pw, &kdf_recovery, &aead, &rng, &gate);
 


### PR DESCRIPTION
## Summary

Sub-D (#42) 3 PR (#58 / #59 / #60) を develop に squash merge した後、Rust 1.95.0 で `clippy::all` (deny) に追加された `default_constructed_unit_structs` lint が新規発火し `lint` / `test-infra` / `test-infra-windows` ジョブが落ちていた。本 fix で develop の CI green を回復する。

(注: 旧 PR #61 は `hotfix/*` ブランチ名が `branch-policy` の `hotfix/X.Y.Z` 命名規則と衝突したため close → `fix/*` で再作成。`hotfix/*` は main 向けリリース版緊急修正専用)

## 修正内容

### ① `default_constructed_unit_structs` (`clippy::all` deny — **真の CI fail 原因**)

```
error: use of `default` to create a unit struct
   --> crates/shikomi-infra/tests/vault_migration_property.rs:108
108 |         let kdf_recovery = Bip39Pbkdf2Hkdf::default();

error: use of `default` to create a unit struct
   --> crates/shikomi-infra/tests/vault_migration_property.rs:110
110 |         let rng = Rng::default();

error: could not compile `shikomi-infra` (test "vault_migration_property")
       due to 2 previous errors
```

unit struct (`pub struct Bip39Pbkdf2Hkdf;` / `pub struct Rng;`) は型名そのもので construct するのが正規化形式。`vault_migration_integration.rs:47,49` でも同型違反があったため一括修正。

### ② `single_match_else` (`clippy::pedantic` warn — Boy Scout)

`crates/shikomi-daemon/src/lib.rs:107` の単一 `Some` パターン分岐 `match` を `let-else` 構文 (Rust 1.65+) に書き換え。`take_listener` が `None` なら即 error log + early return という制御フローが文法レベルで明示される。Fail Fast / KISS 原則と整合。

## スコープ外

`shikomi-core` / `shikomi-infra` 配下の `clippy::pedantic` warning (item in documentation is missing backticks / similar_names / unused_import 等、合計約 70 件) は `pedantic` カテゴリ `warn` レベル。`-D warnings` 指定なしの CI policy では fail 原因とならないため、本 fix では触らない。Boy Scout で次回 touch 時に該当ファイル単位で清掃する方針。

## Test plan

- [ ] `lint` SUCCESS (clippy errors 0)
- [ ] `test-infra` / `test-infra-windows` SUCCESS
- [ ] `branch-policy` SUCCESS (fix/* は許容)
- [ ] その他 audit / unit-core / bench-kdf も従来通り SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)