### PR TITLE
fix(clippy): resolve Rust 1.95.0 default_constructed_unit_structs + single_match_else

### DIFF
--- a/crates/shikomi-daemon/src/lib.rs
+++ b/crates/shikomi-daemon/src/lib.rs
@@ -104,15 +104,12 @@ pub async fn run() -> ExitCode {
         return DaemonExit::EncryptionUnsupported.into();
     }
 
-    let listener = match single_instance.take_listener() {
-        Some(l) => l,
-        None => {
-            tracing::error!(
-                target: "shikomi_daemon::lifecycle",
-                "internal: listener missing after acquisition"
-            );
-            return DaemonExit::SystemError.into();
-        }
+    let Some(listener) = single_instance.take_listener() else {
+        tracing::error!(
+            target: "shikomi_daemon::lifecycle",
+            "internal: listener missing after acquisition"
+        );
+        return DaemonExit::SystemError.into();
     };
 
     let repo = Arc::new(repo);

--- a/crates/shikomi-infra/tests/vault_migration_integration.rs
+++ b/crates/shikomi-infra/tests/vault_migration_integration.rs
@@ -44,9 +44,9 @@ fn build_migration_set() -> (
 ) {
     (
         Argon2idAdapter::default(),
-        Bip39Pbkdf2Hkdf::default(),
+        Bip39Pbkdf2Hkdf,
         AesGcmAeadAdapter,
-        Rng::default(),
+        Rng,
         ZxcvbnGate::default(),
     )
 }

--- a/crates/shikomi-infra/tests/vault_migration_property.rs
+++ b/crates/shikomi-infra/tests/vault_migration_property.rs
@@ -105,9 +105,9 @@ proptest! {
 
         // encrypt → decrypt 往復
         let kdf_pw = Argon2idAdapter::default();
-        let kdf_recovery = Bip39Pbkdf2Hkdf::default();
+        let kdf_recovery = Bip39Pbkdf2Hkdf;
         let aead = AesGcmAeadAdapter;
-        let rng = Rng::default();
+        let rng = Rng;
         let gate = ZxcvbnGate::default();
         let migration = VaultMigration::new(&repo, &kdf_pw, &kdf_recovery, &aead, &rng, &gate);
 


### PR DESCRIPTION
## Summary

Sub-D (#42) 3 PR (#58 / #59 / #60) を develop に squash merge した後、Rust 1.95.0 で `clippy::all` (deny) に追加された `default_constructed_unit_structs` lint が新規発火し `lint` / `test-infra` ジョブが落ちていた。本 PR で develop の CI green を回復する。

注: 過去 PR (#61 hotfix/* / #62 fix/* / #63 feature/[dot]) はそれぞれ branch-policy 命名規則違反で close。許容形式は `feature/[a-z0-9][a-z0-9/_-]+` のみ。

## 修正内容

### ① `default_constructed_unit_structs` (`clippy::all` deny — **真の CI fail 原因**)

```
error: use of `default` to create a unit struct
   --> crates/shikomi-infra/tests/vault_migration_property.rs:108
108 |         let kdf_recovery = Bip39Pbkdf2Hkdf::default();

error: use of `default` to create a unit struct
   --> crates/shikomi-infra/tests/vault_migration_property.rs:110
110 |         let rng = Rng::default();

error: could not compile `shikomi-infra` (test "vault_migration_property")
       due to 2 previous errors
```

unit struct (`pub struct Bip39Pbkdf2Hkdf;` / `pub struct Rng;`) は型名そのもので construct するのが正規化形式。`vault_migration_integration.rs:47,49` の同型違反も一括修正。

### ② `single_match_else` (`clippy::pedantic` warn — Boy Scout)

`crates/shikomi-daemon/src/lib.rs:107` の単一 `Some` パターン分岐 `match` を `let-else` 構文 (Rust 1.65+) に書き換え。Fail Fast / KISS 原則と整合。

## スコープ外

- `pedantic` warning 約 70 件 (warn レベル、CI fail 原因ではない)
- `test-infra-windows` の `AtomicWriteFailed { stage: Rename, code: 5 PermissionDenied }` は Windows rename semantics 起因の PR #59 integration test 別問題、本 clippy fix とは独立

## Test plan

- [x] `lint` SUCCESS (clippy errors 0、PR #63 で実証済)
- [x] `test-infra` (Linux) SUCCESS (PR #63 で実証済)
- [ ] `branch-policy` SUCCESS (本 PR で命名規則準拠を再確認)
- [ ] `test-infra-windows` の Windows rename 問題は別 issue (本 PR スコープ外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)