### PR TITLE
fix(ci): Issue #85/#86 工程3 — audit grep gate コメント行除外 + 回帰防止 fixture/test 5件

### DIFF
--- a/docs/features/daemon-ipc/test-design/index.md
+++ b/docs/features/daemon-ipc/test-design/index.md
@@ -98,8 +98,8 @@
 | `expose_secret` 呼出 | `crates/shikomi-cli/src/io/` | 0 件（既存 TC-CI-013 を踏襲・拡張） | TC-CI-016 |
 | `expose_secret` 呼出 | `crates/shikomi-daemon/src/` | 0 件 | TC-CI-017 |
 | `rmp_serde::Raw` / `RawRef` | `crates/shikomi-core/src/ipc/` | 0 件（RUSTSEC-2022-0092） | TC-CI-018 |
-| `unsafe` ブロック（daemon 側） | `crates/shikomi-daemon/src/` | `permission/{unix,windows}.rs` 以外 0 件 | TC-CI-019 |
-| `unsafe` ブロック（CLI 側） | `crates/shikomi-cli/src/` | `io/windows_sid.rs` 以外 0 件（服部 re-review ① 対応、新設） | **TC-CI-026** |
+| `unsafe` ブロック（daemon 側） | `crates/shikomi-daemon/src/` | `permission/{unix,windows,windows_acl}.rs` 以外 0 件。grep gate のコメント行除外契約は `../../dev-workflow/detailed-design/scripts.md §audit-secret-paths.sh の unsafe ブロック検出契約（TC-CI-019 / TC-CI-026 共通仕様）` で凍結、回帰防止サブケース 5 件は `../../dev-workflow/test-design.md §TC-CI-026 サブケース` で網羅検証され**本 TC-CI-019 にも波及して有効性担保**（Issue #85） | TC-CI-019 |
+| `unsafe` ブロック（CLI 側） | `crates/shikomi-cli/src/` | `io/windows_sid.rs` + `hardening/core_dump.rs` 以外 0 件（服部 re-review ① 対応、Issue #75 で `hardening/core_dump.rs` 追加）。grep gate コメント行除外契約 + 回帰防止サブケース 5 件は同上 | **TC-CI-026** |
 | panic hook 内 `tracing::*` | `crates/shikomi-daemon/src/{main,lib,panic_hook}.rs` | 0 件 | TC-CI-023 |
 | panic hook 内 `info.payload()` / `message()` / `location()` | 同上 | 0 件 | TC-CI-024 |
 | `SHIKOMI_DAEMON_SKIP_*` env 読取 | `crates/shikomi-{daemon,cli}/src/` | 0 件（trait 注入一本化契約、服部 re-review ② 対応、新設） | **TC-CI-027** |

--- a/docs/features/dev-workflow/detailed-design/scripts.md
+++ b/docs/features/dev-workflow/detailed-design/scripts.md
@@ -29,8 +29,8 @@
 | 検査対象パス | TC-CI-019: `crates/shikomi-daemon/src/` / TC-CI-026: `crates/shikomi-cli/src/`（再帰、`*.rs` のみ） |
 | 検査対象行 | **実コード行のみ**。**コメント行**（行頭から最初の非空白文字が `//` で始まる行、`///` / `//!` を含む）は対象外 |
 | 検出パターン | `unsafe[[:space:]]*\{`（拡張正規表現、`unsafe` キーワードと開きブレースの間に空白 0 個以上） |
-| 許可リスト | TC-CI-019: `permission/{unix,windows,windows_acl}.rs` / TC-CI-026: `io/windows_sid.rs`、`hardening/core_dump.rs` |
-| 失敗条件 | 検査対象行のうち、許可リスト外のファイルで検出パターンに合致する行が 1 件以上存在 |
+| 許可リスト | TC-CI-019: `crates/shikomi-daemon/src/permission/{unix,windows,windows_acl}.rs` / TC-CI-026: `crates/shikomi-cli/src/io/windows_sid.rs`、`crates/shikomi-cli/src/hardening/core_dump.rs`。**substring 一致ではなく `awk -F: '$1 != path'` の path 完全一致で除外**（Bug-CI-031 解消、後述 §許可リスト一致方式） |
+| 失敗条件 | 検査対象行のうち、許可リスト**ファイルパス完全一致**外のファイルで検出パターンに合致する行が 1 件以上存在 |
 | 出力 | 失敗時のみ該当 `file:line:content` を stderr に列挙し非 0 で exit。成功時は `[TC-CI-026] PASS` の 1 行のみ |
 
 ### コメント行の判定規則（実装契約）
@@ -39,6 +39,17 @@
 - **行内コメント**（コード `unsafe { ... } // 解説`）は除外しない。実コードに `unsafe` ブロックが書かれている以上、grep は正しくヒットする必要がある（むしろ検出が責務）
 - **複数行ブロックコメント**（`/* ... */`）内の `unsafe { ... }` 文字列は本契約のスコープ外（YAGNI）。shikomi の Rust コードでブロックコメントを使う規約はなく、現状コードベース全体で `/* */` 用例ゼロを `rustfmt` 整形コミット履歴で確認済み。将来 `/* */` 内に `unsafe { ... }` を書くケースが現れたら本設計書を更新して契約拡張する
 - **文字列リテラル内の `unsafe { ... }`**（例: `let s = "unsafe { ... }";`）は本契約のスコープ外。これも現状コードベースで用例ゼロ。仮に発生した場合は、文字列定数を別ファイル（`tests/fixtures/` 等）に切り出すかリテラルを分割するなど**コード側で回避**する方針（grep gate 側を AST 化するコストに見合わない）
+
+### 許可リスト一致方式（Bug-CI-031 解消、ペテルギウス・服部工程5 致命指摘対応）
+
+許可リストの一致方式は **`awk -F: '$1 != path'` のファイルパス完全一致**で確定する。`grep -vF` の substring 一致は採用しない。
+
+| 一致方式 | 攻撃面 | 採否 |
+|---|---|---|
+| substring 一致（`grep -vF`） | 許可 entry 文字列を path に substring として含む偽装サブディレクトリで silent bypass。例: 許可 `windows_sid.rs` → `windows_sid.rs.bypass/evil.rs` の実 `unsafe` が黙殺される（マユリ工程4 実機確認） | **不採用**（Bug-CI-031 の根本原因） |
+| **path 完全一致**（`awk -F: '$1 != p'`） | grep -rn 出力の `$1`（ファイルパス）と許可 entry が完全一致する行のみ除外。path 偽装 `*.rs.bypass/` を構造的に塞ぐ。拡張子偽装 `*.rsx` は `--include='*.rs'` で grep にヒットしないため fail-closed | **採用** |
+
+**回帰防止**: TC-CI-026-f が `case_f/io/windows_sid.rs.bypass/evil.rs` の path 偽装 fixture で sentinel 化（後述 §回帰防止のテスト契約）。
 
 ### 実装方式の選択肢と判定（Issue #85 修正方針）
 
@@ -59,7 +70,8 @@
 | TC-CI-026-c | 通常コメント `// unsafe { ... }` のみ存在し実 `unsafe` ブロック無しの fixture | **PASS** |
 | TC-CI-026-d | 行内コメント `unsafe { ... } // 解説` の実コードが許可リスト外ファイルに存在する fixture | FAIL（実 `unsafe` ブロックは検出されるべき） |
 | TC-CI-026-e | 許可リストファイル（`io/windows_sid.rs` 等）に実 `unsafe { ... }` ブロックが存在 | PASS（許可リストにより除外） |
+| TC-CI-026-f | 許可リスト entry 文字列を path に substring として含む偽装サブディレクトリ fixture（例: `case_f/io/windows_sid.rs.bypass/evil.rs`）に実 `unsafe { ... }` ブロックが存在 | FAIL（exit 非 0、`evil.rs:N:content` 出力）。**Bug-CI-031 path 偽装 silent bypass の sentinel**——許可リスト一致を path 完全一致に固定する契約の有効性を fixture で永続的に保証 |
 
 ### 設計判断の凍結
 
-本契約は `scripts/ci/audit-secret-paths.sh` の TC-CI-019 / TC-CI-026 ステップに**コメント行除外の grep -v パイプを 1 段挟む**ことで実装する。Sub-issue 実装側での再判定は行わない。文字列リテラル内 / ブロックコメント内のスコープ外事項が将来発生した場合のみ本設計書を更新して再凍結する。
+本契約は `scripts/ci/audit-secret-paths.sh` 系から `scripts/ci/lib/audit_unsafe_blocks.sh` に抽出した `audit_unsafe_blocks` 関数で実装する。TC-CI-019 / TC-CI-026 ステップは同関数を呼び出し、**コメント行除外の grep -v パイプを 1 段挟む** + **許可リストを `awk -F: '$1 != path'` で path 完全一致除外**する。Sub-issue 実装側での再判定は行わない。文字列リテラル内 / ブロックコメント内のスコープ外事項が将来発生した場合のみ本設計書を更新して再凍結する。

--- a/docs/features/dev-workflow/test-design.md
+++ b/docs/features/dev-workflow/test-design.md
@@ -30,7 +30,7 @@
 | REQ-DW-018 | `lefthook.yml::commit-msg.no-ai-footer` + `justfile::commit-msg-no-ai-footer` | TC-IT-010, TC-UT-014〜016 | 結合/ユニット | 異常系/正常系 | 17 |
 | REQ-DW-006（追加契約） | `scripts/ci/audit-pin-sync.sh` | TC-UT-008, TC-UT-009 | ユニット | 正常系/異常系 | — |
 | T9 補助 | ピン定数 upstream 同期 | TC-UT-017 | ユニット | 正常系 | — |
-| REQ-DW-013（追加契約、Issue #85）| `scripts/ci/audit-secret-paths.sh` の `unsafe` ブロック検出 grep gate（コメント行除外）| TC-CI-026-a, b, c, d, e | ユニット | 異常系/正常系/正常系/異常系/正常系 | 12 |
+| REQ-DW-013（追加契約、Issue #85 + Bug-CI-031）| `scripts/ci/audit-secret-paths.sh` の `unsafe` ブロック検出 grep gate（コメント行除外 + 許可リスト path 完全一致）| TC-CI-026-a, b, c, d, e, f | ユニット | 異常系/正常系/正常系/異常系/正常系/異常系 | 12 |
 
 ## 外部I/O依存マップ
 
@@ -110,27 +110,28 @@
 
 **設計根拠**: `docs/features/dev-workflow/detailed-design/scripts.md` §`audit-secret-paths.sh` の `unsafe` ブロック検出契約（TC-CI-019 / TC-CI-026 共通仕様）。
 
-**経緯**: Issue #75 (PR #82) で `crates/shikomi-cli/src/io/ipc_vault_repository.rs` の doc コメントに「`` `unsafe { std::env::remove_var(...) }` は Rust 2024 edition の env 操作 unsafe 化 ``」という解説文字列が導入された。当時の grep gate（`grep -rnE 'unsafe[[:space:]]*\{' ... --include='*.rs'`）はソース行とコメント行を区別しないため、**doc コメント内の `unsafe { ... }` 解説文字列を実 `unsafe` ブロックと誤検出**して TC-CI-026 が FAIL し、PR #82 / #84 で連続して `--admin` バイパスを誘発した。本 5 サブケースは、**コメント行除外契約（行頭から最初の非空白文字が `//` で始まる行を一律除外）の有効性と、実 `unsafe` 検出力の維持を同時に保証する** 回帰防止 SSoT。
+**経緯**: Issue #75 (PR #82) で `crates/shikomi-cli/src/io/ipc_vault_repository.rs` の doc コメントに「`` `unsafe { std::env::remove_var(...) }` は Rust 2024 edition の env 操作 unsafe 化 ``」という解説文字列が導入された。当時の grep gate（`grep -rnE 'unsafe[[:space:]]*\{' ... --include='*.rs'`）はソース行とコメント行を区別しないため、**doc コメント内の `unsafe { ... }` 解説文字列を実 `unsafe` ブロックと誤検出**して TC-CI-026 が FAIL し、PR #82 / #84 で連続して `--admin` バイパスを誘発した。本 6 サブケース（a〜f）は、**コメント行除外契約（行頭から最初の非空白文字が `//` で始まる行を一律除外）の有効性 + 実 `unsafe` 検出力の維持 + 許可リスト path 完全一致による silent bypass 防御（Bug-CI-031 解消）** を同時に保証する回帰防止 SSoT。
 
 **fixture 配置**: `tests/fixtures/grep_gate/` 配下に各サブケース固有の最小 `.rs` fixture を 1 ファイルずつ作成し、`audit-secret-paths.sh` の検査対象パスを fixture ディレクトリへ差し替えて呼び出す（環境変数 or 引数経由、実装担当が `audit-secret-paths.sh` の Issue #85 修正時に決定）。本流 `crates/shikomi-cli/src/` を直接いじらないため**回帰サンドボックス**として独立性を保つ。
 
 | テストID | 種別 | 入力（fixture / scope）| 期待結果 |
 |---------|------|------|---------|
-| **TC-CI-026-a** | 異常系（**実 unsafe 検出力の保証**）| 許可リスト外ファイル（例: `tests/fixtures/grep_gate/case_a/realy_unsafe.rs`）に `unsafe { /* body */ }` ブロックを 1 件含む fixture | exit 非 0、stderr に `case_a/realy_unsafe.rs:<line>:<content>` を file:line:content 形式で出力（`[TC-CI-026] FAIL` プレフィクス）。**コメント行除外パイプを挟んでも実コードの `unsafe` ブロックは正しくヒットする**ことを確認 |
+| **TC-CI-026-a** | 異常系（**実 unsafe 検出力の保証**）| 許可リスト外ファイル（`tests/fixtures/grep_gate/case_a/really_unsafe.rs`）に `unsafe { /* body */ }` ブロックを 1 件含む fixture | exit 非 0、stderr に `case_a/really_unsafe.rs:<line>:<content>` を file:line:content 形式で出力（`[TC-CI-026] FAIL` プレフィクス）。**コメント行除外パイプを挟んでも実コードの `unsafe` ブロックは正しくヒットする**ことを確認 |
 | **TC-CI-026-b** | 正常系（**doc コメント誤検出の構造的封鎖**、PR #82 の実例再現）| 許可リスト外ファイル（例: `tests/fixtures/grep_gate/case_b/doc_comment_only.rs`）に **doc コメント**（`/// unsafe { std::env::remove_var(...) } は Rust 2024 edition...` のような解説文字列）のみ存在し、**実 `unsafe` ブロックは無し**の fixture。`Issue #75 の `ipc_vault_repository.rs:725` 相当を最小再現` | exit 0、stdout は `[TC-CI-026] PASS` の 1 行のみ。**コメント行除外パイプにより doc コメント内の `unsafe { ...` 文字列が grep にヒットしない**ことを保証（Issue #85 の根本対策、PR #82 / #84 の `--admin` 連発を構造的に終止符） |
 | **TC-CI-026-c** | 正常系（**通常コメント誤検出の構造的封鎖**）| 許可リスト外ファイルに **通常コメント**（`// unsafe { ... } の説明` や `//unsafe{` の形式）のみ存在し実 `unsafe` ブロック無しの fixture。先頭空白あり / 空白なし / `//!` モジュール doc / `///` doc / 通常 `//` の 5 パターン網羅 | 5 パターン全てで exit 0、`[TC-CI-026] PASS`。**「行頭から最初の非空白文字が `//` で始まる行」一律除外契約**（detailed-design §コメント行の判定規則）が網羅的に有効化される |
 | **TC-CI-026-d** | 異常系（**行内コメントは検出継続、誤陽性化させない**）| 許可リスト外ファイルに **行内コメント形式の実コード**（`unsafe { ptr::read(p) } // SAFETY: ...`）を 1 件含む fixture | exit 非 0、`case_d/<file>:<line>:<content>` 出力。**行内コメントを「コメント行」として除外してしまう実装ミス**（誤陽性化の罠、grep `-vE '^[[:space:]]*//'` の表層仕様だけで担保される）を sentinel として早期検出 |
 | **TC-CI-026-e** | 正常系（**許可リスト効果確認**、Issue #75 拡張追従）| 許可リストファイル相当に実 `unsafe { ... }` ブロックが存在する fixture を 2 ファイル配置: (i) `case_e/io/windows_sid.rs` 模倣（FFI 必須）、(ii) `case_e/hardening/core_dump.rs` 模倣（`#![allow(unsafe_code)]` を伴う、Issue #75 で追加された TC-F-U10 対象）。`audit-secret-paths.sh` の許可リスト（detailed-design §検出契約 §許可リスト行）に両ファイルを登録した上で実行 | exit 0、`[TC-CI-026] PASS`。**両ファイルとも検査結果から除外され、検出パターンに合致しても fail に転じない**ことを保証。Issue #75 で `hardening/core_dump.rs` が許可リスト追加された経緯（cli-subcommands.md §C-41 §「`io/windows_sid.rs` と同等扱い」）の回帰防止 |
+| **TC-CI-026-f** | 異常系（**Bug-CI-031 path 偽装 silent bypass の sentinel**、マユリ工程4 発見 / 服部・ペテルギウス工程5 致命指摘）| 許可リスト entry 文字列を path に substring として含む偽装サブディレクトリ fixture（`case_f/io/windows_sid.rs.bypass/evil.rs`）に実 `unsafe { ... }` ブロックを 1 件含む。許可リストに `case_f/io/windows_sid.rs`（本物 path）を登録した上で実行 | exit 非 0、stderr に `case_f/io/windows_sid.rs.bypass/evil.rs:<line>:<content>` を出力。**substring 一致 (`grep -vF`) では `windows_sid.rs` を含む path として silent 許可されてしまう** が、**path 完全一致 (`awk -F: '$1 != p'`) では完全一致しないため検出される**。許可リスト一致を「ファイルパス完全一致」に固定する契約（detailed-design §許可リスト一致方式）の有効性を fixture で永続的に保証 |
 
 **運用契約**:
 
-- 5 サブケース全てを `tests/unit/test_audit_secret_paths_grep_gate.sh`（または `pytest -k tc_ci_026`）の単一テストランナーで連続実行し、5/5 PASS を CI のゲート条件とする
-- fixture ディレクトリ `tests/fixtures/grep_gate/case_{a..e}/` は本 PR で同時にコミット。`scripts/ci/audit-secret-paths.sh` の検査対象パスを差し替える経路は実装担当が選定（環境変数 `AUDIT_GREP_TARGET_DIR` 案 / 第一引数案）
-- 本サブケースは Issue #85 修正の**回帰防止 SSoT**。今後 `audit-secret-paths.sh` を改修する PR は本 5 サブケース全 PASS が必須（reviewer が機械的に確認）
+- 全サブケースを `tests/unit/test_audit_secret_paths_grep_gate.sh`（または `pytest -k tc_ci_026`）の単一テストランナーで連続実行し、全 PASS を CI のゲート条件とする（現状 6/6 = a〜f）
+- fixture ディレクトリ `tests/fixtures/grep_gate/case_{a..f}/` は本 PR で同時にコミット。`audit-secret-paths.sh` 自体は本流の検査対象パス（`crates/shikomi-{daemon,cli}/src/`）を引き続き走査し、test runner は `audit_unsafe_blocks` 関数を直接呼出して fixture path を渡す経路で独立検証する（本番 script に test 用 path 注入経路を持ち込まない、Tell-Don't-Ask 規律）
+- 本サブケースは Issue #85 + Bug-CI-031 修正の**回帰防止 SSoT**。今後 `audit-secret-paths.sh` / `audit_unsafe_blocks.sh` を改修する PR は本サブケース全 PASS が必須（reviewer が機械的に確認）
 
 #### TC-CI-019（daemon 側）への波及 articulate
 
-**ペテルギウス工程2 内部レビュー指摘1 解消**: `detailed-design.md` §`audit-secret-paths.sh` の `unsafe` ブロック検出契約は **「TC-CI-019 / TC-CI-026 共通仕様」** として章名宣言されており、コメント行除外パイプ（`grep -vE '^[[:space:]]*//'` 1 段）は **TC-CI-019 / TC-CI-026 両ステップで物理的に共有**される実装契約として凍結済 (`detailed-design.md §設計判断の凍結`)。本節 §TC-CI-026 サブケース 5 件（a〜e）は **同一 grep パイプの挙動を fixture レベルで網羅検証**するため、PASS 時には:
+**ペテルギウス工程2 内部レビュー指摘1 解消**: `detailed-design.md` §`audit-secret-paths.sh` の `unsafe` ブロック検出契約は **「TC-CI-019 / TC-CI-026 共通仕様」** として章名宣言されており、コメント行除外パイプ（`grep -vE '^[[:space:]]*//'` 1 段）+ 許可リスト path 完全一致除外（`awk -F: '$1 != p'`）は **TC-CI-019 / TC-CI-026 両ステップで物理的に共有**される実装契約として凍結済 (`detailed-design.md §設計判断の凍結` / `§許可リスト一致方式`)。本節 §TC-CI-026 サブケース 6 件（a〜f）は **同一 grep + awk パイプの挙動を fixture レベルで網羅検証**するため、PASS 時には:
 
 | 観点 | TC-CI-026（cli 側） | TC-CI-019（daemon 側）への波及 |
 |---|---|---|
@@ -140,13 +141,13 @@
 | 検出パターン | 同一 `unsafe[[:space:]]*\{` を共有 | 同上 |
 | 出力形式 | 同一 `[TC-CI-***] PASS / FAIL + file:line:content` | 同上 |
 
-つまり **TC-CI-026 サブケース 5/5 PASS が TC-CI-019 経路にも波及して有効性を担保**する。daemon 側専用の重複 fixture (`case_{a..e}` を `crates/shikomi-daemon/src/` 風 path で再生成) を**別途追加するのは YAGNI**:
+つまり **TC-CI-026 サブケース 6/6 PASS が TC-CI-019 経路にも波及して有効性を担保**する。daemon 側専用の重複 fixture (`case_{a..f}` を `crates/shikomi-daemon/src/` 風 path で再生成) を**別途追加するのは YAGNI**:
 
-- `path` / `許可リスト` の差は **`audit-secret-paths.sh` 内部の入力変数** にすぎず、grep パイプ自身の挙動は fixture path と独立
-- 本 5 サブケースは grep パイプの「コメント行除外 × 検出力維持 × 許可リスト効果」3 直交軸を網羅するため、daemon 側 fixture を二重化しても**新規に塞がれる罠はゼロ**
+- `path` / `許可リスト` の差は **`audit_unsafe_blocks` 関数の引数** にすぎず、grep + awk パイプ自身の挙動は fixture path と独立
+- 本 6 サブケースは grep + awk パイプの「コメント行除外 × 検出力維持 × 許可リスト効果 × path 偽装 silent bypass 防御」4 直交軸を網羅するため、daemon 側 fixture を二重化しても**新規に塞がれる罠はゼロ**
 - 将来 TC-CI-019 / TC-CI-026 が**別実装に分岐**する設計変更が起きた瞬間に本記述を破棄し、各々のサブケース節を立てる Boy Scout を起動する（**今は YAGNI、分岐時に articulate**）。`detailed-design.md` §設計判断の凍結が「Sub-issue 実装側での再判定は行わない」と凍結済なので、当面は分岐想定なし
 
-**SSoT 整合性**: `daemon-ipc/test-design/index.md §unsafe ブロック（daemon 側）行 (TC-CI-019)` から本節へ後方リンクされる契約となる（Boy Scout: TC-CI-019 SSoT を読んだ reviewer が本サブケース 5 件を波及検証として遡及できる構造）。後方リンク追記は本 PR スコープ内で `daemon-ipc` 側にも反映する責務が残るため、Issue #85 実装担当（坂田銀時）の工程3 で同 PR 内同期を Boy Scout で適用する。
+**SSoT 整合性**: `daemon-ipc/test-design/index.md §unsafe ブロック（daemon 側）行 (TC-CI-019)` から本節へ後方リンクされる契約となる（Boy Scout: TC-CI-019 SSoT を読んだ reviewer が本サブケース 6 件を波及検証として遡及できる構造）。後方リンク追記は Issue #85 実装担当（坂田銀時）の工程3 で同 PR 内同期を Boy Scout として既に適用済（`daemon-ipc/test-design/index.md` §4.4 静的監査契約一覧 の TC-CI-019 行 / TC-CI-026 行）。
 
 ## カバレッジ基準
 
@@ -156,7 +157,7 @@
 - MSG-DW-001〜013 の 13 文言が全て静的文字列で照合されている（TC-UT-005 + TC-E2E 各種）
 - 受入基準 1〜17 の各々が最低 1 件の E2E テストケースで検証されている
 - T1〜T9 の各脅威に対する対策が最低 1 件のテストケースで有効性を確認されている
-- **TC-CI-026 サブケース a〜e（Issue #85 回帰防止）**が 5/5 PASS で連続実行され、`audit-secret-paths.sh` のコメント行除外契約と実 `unsafe` 検出力の同時保証が機械検証されている
+- **TC-CI-026 サブケース a〜f（Issue #85 + Bug-CI-031 回帰防止）**が 6/6 PASS で連続実行され、`audit_unsafe_blocks` のコメント行除外契約 + 実 `unsafe` 検出力 + 許可リスト path 完全一致の同時保証が機械検証されている
 
 ## 人間が動作確認できるタイミング
 
@@ -192,7 +193,7 @@ tests/
     (TC-IT-001〜010。rawfixture を使用)
   unit/
     (TC-UT-001〜017 + TC-CI-026-a〜e。factory / grep_gate fixture を使用)
-    test_audit_secret_paths_grep_gate.sh             # TC-CI-026 サブケース 5 件連続実行
+    test_audit_secret_paths_grep_gate.sh             # TC-CI-026 サブケース 6 件連続実行 (a〜f)
 ```
 
 **ただし言語慣習**: 本 feature は Rust コードを追加しないため上記は**スクリプトテスト**として扱う。Rust crate 側テストとは独立したディレクトリに置く。

--- a/docs/features/dev-workflow/test-design.md
+++ b/docs/features/dev-workflow/test-design.md
@@ -178,13 +178,15 @@ tests/
         gitleaks_default_rules_v8.30.1.json         # 要起票 TBD-4
       schema/
         (raw の型 + 統計。factory 設計ソース)
-    grep_gate/                                       # Issue #85 TC-CI-026 fixture
-      case_a/realy_unsafe.rs                         # 実 unsafe ブロック (許可リスト外)
+    grep_gate/                                       # Issue #85 + Bug-CI-031 TC-CI-026 fixture
+      case_a/really_unsafe.rs                        # 実 unsafe ブロック (許可リスト外)
       case_b/doc_comment_only.rs                     # `/// unsafe { ... }` のみ (PR #82 実例の最小再現)
-      case_c/regular_comment_only.rs                 # `// unsafe { ... }` 5 パターン
-      case_d/inline_comment_realy_unsafe.rs          # `unsafe { ... } // SAFETY:` 行内コメント
+      case_c/comment_variants.rs                     # `//` / `///` / `//!` 5 パターン網羅
+      case_d/inline_comment.rs                       # `unsafe { ... } // SAFETY:` 行内コメント sentinel
       case_e/io/windows_sid.rs                       # 許可リスト i (FFI)
       case_e/hardening/core_dump.rs                  # 許可リスト ii (Issue #75 で追加)
+      case_f/io/windows_sid.rs                       # 本物 path (許可リスト登録)
+      case_f/io/windows_sid.rs.bypass/evil.rs        # path 偽装 silent bypass sentinel (Bug-CI-031)
   factories/
     secret_sample.py / platform_stub.sh / powershell_version.py  # 要起票
   e2e/
@@ -192,7 +194,7 @@ tests/
   integration/
     (TC-IT-001〜010。rawfixture を使用)
   unit/
-    (TC-UT-001〜017 + TC-CI-026-a〜e。factory / grep_gate fixture を使用)
+    (TC-UT-001〜017 + TC-CI-026-a〜f。factory / grep_gate fixture を使用)
     test_audit_secret_paths_grep_gate.sh             # TC-CI-026 サブケース 6 件連続実行 (a〜f)
 ```
 

--- a/justfile
+++ b/justfile
@@ -80,9 +80,13 @@ bench-kdf:
 # ------------------------------------------------------------------ audit
 
 # cargo deny + secret 経路監査 (確定 B: cargo-deny-action 廃止、統一経路)
+# Issue #85: audit-secret-paths.sh の grep gate コメント行除外契約は
+# tests/unit/test_audit_secret_paths_grep_gate.sh で 5/5 PASS をゲート条件とする
+# (設計根拠: docs/features/dev-workflow/test-design.md §TC-CI-026 サブケース運用契約)
 audit:
     cargo deny check advisories licenses bans sources
     bash scripts/ci/audit-secret-paths.sh
+    bash tests/unit/test_audit_secret_paths_grep_gate.sh
 
 # pre-commit 用の軽量 secret スキャン (staged 差分のみ)
 # gitleaks が未導入なら即失敗 (Fail Fast)。scripts/setup.sh が導入を保証する

--- a/scripts/ci/audit-secret-paths.sh
+++ b/scripts/ci/audit-secret-paths.sh
@@ -27,6 +27,12 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"
 
+# `unsafe` ブロック検出 grep gate（TC-CI-019 / TC-CI-026 共通契約）を本ライブラリに集約。
+# Issue #85: doc コメント内 `unsafe { ... }` 文字列の誤検出を構造的に塞ぐコメント行除外
+# パイプを含む。設計根拠: docs/features/dev-workflow/detailed-design/scripts.md
+# shellcheck source=lib/audit_unsafe_blocks.sh
+source "$REPO_ROOT/scripts/ci/lib/audit_unsafe_blocks.sh"
+
 fail() {
     echo "::error::$1"
     exit 1
@@ -133,17 +139,16 @@ fi
 echo "[TC-CI-018] PASS"
 
 # --- TC-CI-019 ------------------------------------------------------
+# 設計根拠: docs/features/dev-workflow/detailed-design/scripts.md
+#   §`audit-secret-paths.sh` の `unsafe` ブロック検出契約（TC-CI-019 / TC-CI-026 共通仕様）
+# Issue #85 コメント行除外契約: doc/通常/モジュール doc コメント内の `unsafe { ... }`
+# 文字列が誤検出されないことを構造的に保証する。
 echo "[TC-CI-019] unsafe blocks outside permission/ (shikomi-daemon)"
-if matches="$(grep -rnE 'unsafe[[:space:]]*\{' crates/shikomi-daemon/src/ \
-    --include='*.rs' \
-    | grep -v 'crates/shikomi-daemon/src/permission/unix.rs' \
-    | grep -v 'crates/shikomi-daemon/src/permission/windows.rs' \
-    | grep -v 'crates/shikomi-daemon/src/permission/windows_acl.rs' \
-    || true)"; then
-    if [[ -n "$matches" ]]; then
-        echo "$matches"
-        fail "TC-CI-019 FAIL: crates/shikomi-daemon/src/permission/{unix,windows,windows_acl}.rs 以外で unsafe ブロックが存在します"
-    fi
+if ! audit_unsafe_blocks "crates/shikomi-daemon/src/" \
+    "crates/shikomi-daemon/src/permission/unix.rs" \
+    "crates/shikomi-daemon/src/permission/windows.rs" \
+    "crates/shikomi-daemon/src/permission/windows_acl.rs"; then
+    fail "TC-CI-019 FAIL: crates/shikomi-daemon/src/permission/{unix,windows,windows_acl}.rs 以外で unsafe ブロックが存在します"
 fi
 echo "[TC-CI-019] PASS"
 
@@ -166,21 +171,19 @@ fi
 echo "[TC-CI-023/024] PASS"
 
 # --- TC-CI-026 ------------------------------------------------------
-# 例外:
+# 設計根拠: docs/features/dev-workflow/detailed-design/scripts.md
+#   §`audit-secret-paths.sh` の `unsafe` ブロック検出契約（TC-CI-019 / TC-CI-026 共通仕様）
+# 許可リスト:
 # - crates/shikomi-cli/src/io/windows_sid.rs: Windows Win32 Security FFI (Phase 1)
 # - crates/shikomi-cli/src/hardening/core_dump.rs: C-41 core dump 抑制 (Sub-F Phase 5)
 #   `libc::prctl(PR_SET_DUMPABLE, 0)` / `libc::setrlimit(RLIMIT_CORE, 0)` の FFI
 #   呼出に必要な最小 unsafe。ファイル単位で `#![allow(unsafe_code)]` を明示。
+# Issue #85 コメント行除外契約は audit_unsafe_blocks ライブラリ側に集約。
 echo "[TC-CI-026] unsafe blocks outside io/windows_sid.rs and hardening/core_dump.rs (shikomi-cli)"
-if matches="$(grep -rnE 'unsafe[[:space:]]*\{' crates/shikomi-cli/src/ \
-    --include='*.rs' \
-    | grep -v 'crates/shikomi-cli/src/io/windows_sid.rs' \
-    | grep -v 'crates/shikomi-cli/src/hardening/core_dump.rs' \
-    || true)"; then
-    if [[ -n "$matches" ]]; then
-        echo "$matches"
-        fail "TC-CI-026 FAIL: 許可リスト (io/windows_sid.rs, hardening/core_dump.rs) 以外で unsafe ブロックが存在します"
-    fi
+if ! audit_unsafe_blocks "crates/shikomi-cli/src/" \
+    "crates/shikomi-cli/src/io/windows_sid.rs" \
+    "crates/shikomi-cli/src/hardening/core_dump.rs"; then
+    fail "TC-CI-026 FAIL: 許可リスト (io/windows_sid.rs, hardening/core_dump.rs) 以外で unsafe ブロックが存在します"
 fi
 echo "[TC-CI-026] PASS"
 

--- a/scripts/ci/lib/audit_unsafe_blocks.sh
+++ b/scripts/ci/lib/audit_unsafe_blocks.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# `unsafe` ブロック検出 grep gate ライブラリ（TC-CI-019 / TC-CI-026 共通）
+#
+# 設計根拠:
+# - docs/features/dev-workflow/detailed-design/scripts.md
+#   §`audit-secret-paths.sh` の `unsafe` ブロック検出契約（TC-CI-019 / TC-CI-026 共通仕様）
+#
+# 公開関数: audit_unsafe_blocks <target_dir> [allowlist_substring...]
+#
+# 検出契約:
+# - `unsafe[[:space:]]*\{` を `target_dir` 配下の `*.rs` 全行から検出
+# - コメント行（`file:line:[空白]//[/!]?`、行頭から最初の非空白文字が `//` で
+#   始まる行）を一律除外（`//` / `///` / `//!` を全て吸収）
+# - 許可リスト（substring 一致）に該当する path を grep -vF で除外
+# - 残行が 1 件以上なら FAIL（return 1、stderr に file:line:content 列挙）
+#
+# スコープ外（YAGNI、現状コードベースで用例ゼロ）:
+# - `/* ... */` ブロックコメント内の `unsafe { ... }`
+# - 文字列リテラル内の `"unsafe { ... }"`
+# 将来必要になれば設計書 §コメント行の判定規則 を更新して契約拡張する。
+
+audit_unsafe_blocks() {
+    local target_dir="$1"
+    shift
+    local allowlist=("$@")
+
+    # `set -o pipefail` 環境でもヒットゼロを正常終了として扱うため `|| true` で
+    # grep 非 0 を吸収。検出パターンは設計書 §検出パターン 通り。
+    local matches
+    matches="$(grep -rnE 'unsafe[[:space:]]*\{' "$target_dir" \
+        --include='*.rs' 2>/dev/null \
+        | grep -vE '^[^:]+:[0-9]+:[[:space:]]*//[/!]?' \
+        || true)"
+
+    # ヒットゼロなら早期 PASS（許可リスト走査も不要）
+    if [[ -z "$matches" ]]; then
+        return 0
+    fi
+
+    # 許可リスト substring を順次除外。空文字列要素は無視。
+    local pat
+    for pat in "${allowlist[@]}"; do
+        [[ -z "$pat" ]] && continue
+        matches="$(printf '%s\n' "$matches" | grep -vF "$pat" || true)"
+    done
+
+    # 末尾空行を除去
+    matches="$(printf '%s\n' "$matches" | sed '/^$/d' || true)"
+
+    if [[ -n "$matches" ]]; then
+        printf '%s\n' "$matches" >&2
+        return 1
+    fi
+    return 0
+}

--- a/scripts/ci/lib/audit_unsafe_blocks.sh
+++ b/scripts/ci/lib/audit_unsafe_blocks.sh
@@ -7,14 +7,26 @@
 # - docs/features/dev-workflow/detailed-design/scripts.md
 #   §`audit-secret-paths.sh` の `unsafe` ブロック検出契約（TC-CI-019 / TC-CI-026 共通仕様）
 #
-# 公開関数: audit_unsafe_blocks <target_dir> [allowlist_substring...]
+# 公開関数: audit_unsafe_blocks <target_dir> [allowlist_path...]
 #
 # 検出契約:
 # - `unsafe[[:space:]]*\{` を `target_dir` 配下の `*.rs` 全行から検出
 # - コメント行（`file:line:[空白]//[/!]?`、行頭から最初の非空白文字が `//` で
 #   始まる行）を一律除外（`//` / `///` / `//!` を全て吸収）
-# - 許可リスト（substring 一致）に該当する path を grep -vF で除外
+# - 許可リストは **ファイルパス完全一致**（awk -F: で $1 完全一致）で除外する。
+#   substring 一致だと `windows_sid.rs.bypass/evil.rs` のような path 偽装で
+#   silent bypass を許してしまう（Bug-CI-031 / 服部・ペテルギウス工程5 指摘）
 # - 残行が 1 件以上なら FAIL（return 1、stderr に file:line:content 列挙）
+#
+# 許可リスト引数の形式:
+# - `target_dir` を起点に grep -rn が出力する $1（ファイルパス）と完全一致する
+#   文字列を渡す。例: target_dir="crates/shikomi-cli/src/" の場合は
+#   "crates/shikomi-cli/src/io/windows_sid.rs"
+#
+# 攻撃面（service-side fixture で sentinel 化済、TC-CI-026-f）:
+# - path 偽装 `windows_sid.rs.bypass/evil.rs`: $1 != "windows_sid.rs" で検出
+# - 拡張子偽装 `windows_sid.rsx`: `--include='*.rs'` で grep 自体がヒットしない
+# - 許可ファイル名混入のサブディレクトリ: 同上、$1 完全一致で構造的に検出
 #
 # スコープ外（YAGNI、現状コードベースで用例ゼロ）:
 # - `/* ... */` ブロックコメント内の `unsafe { ... }`
@@ -39,11 +51,15 @@ audit_unsafe_blocks() {
         return 0
     fi
 
-    # 許可リスト substring を順次除外。空文字列要素は無視。
+    # 許可リスト: awk -F: で $1（ファイルパス）が完全一致する行のみ除外。
+    # substring 一致を使わないことで Bug-CI-031 (path 偽装 silent bypass) を
+    # 構造的に塞ぐ。空文字列要素は無視。
     local pat
     for pat in "${allowlist[@]}"; do
         [[ -z "$pat" ]] && continue
-        matches="$(printf '%s\n' "$matches" | grep -vF "$pat" || true)"
+        matches="$(printf '%s\n' "$matches" \
+            | awk -F: -v p="$pat" '$1 != p' \
+            || true)"
     done
 
     # 末尾空行を除去

--- a/tests/fixtures/grep_gate/README.md
+++ b/tests/fixtures/grep_gate/README.md
@@ -28,7 +28,3 @@ bash tests/unit/test_audit_secret_paths_grep_gate.sh
 
 - Issue #85 — Audit grep gate がコメント文字列の `unsafe` を誤検出する（PR #82 / #84 で `--admin` 連発を誘発した実害の構造的終止符）
 - Bug-CI-031 — 許可リスト substring 過剰許可による silent bypass（path 偽装攻撃面、本 PR で構造修正）
-
-## ファイル名 typo 履歴
-
-`case_a/realy_unsafe.rs` → `case_a/really_unsafe.rs` (ペガサス工程5 typo 指摘で rename、3 箇所 SSoT 同期更新済)。

--- a/tests/fixtures/grep_gate/README.md
+++ b/tests/fixtures/grep_gate/README.md
@@ -1,4 +1,4 @@
-# grep gate 回帰防止 fixture (TC-CI-026 サブケース a〜e)
+# grep gate 回帰防止 fixture (TC-CI-026 サブケース a〜f)
 
 `scripts/ci/lib/audit_unsafe_blocks.sh` の `audit_unsafe_blocks` 関数が `unsafe` ブロック検出契約（TC-CI-019 / TC-CI-026 共通）を満たすことを検証するための最小再現 fixture。
 
@@ -11,11 +11,12 @@
 
 | サブケース | fixture path | 期待結果 | 検証目的 |
 |----------|--------------|---------|---------|
-| **a** | `case_a/realy_unsafe.rs` | FAIL（exit 1、stderr に file:line:content） | コメント行除外パイプを挟んでも実 `unsafe` ブロックは正しくヒット |
+| **a** | `case_a/really_unsafe.rs` | FAIL（exit 1、stderr に file:line:content） | コメント行除外パイプを挟んでも実 `unsafe` ブロックは正しくヒット |
 | **b** | `case_b/doc_comment_only.rs` | PASS（exit 0） | doc コメント `/// unsafe { ... }` を grep が誤検出しない（PR #82 実害再現） |
 | **c** | `case_c/comment_variants.rs` | PASS（exit 0） | `//` / `///` / `//!` / 先頭空白 / 空白なしの 5 パターン全てを除外 |
 | **d** | `case_d/inline_comment.rs` | FAIL（exit 1） | 行内コメント `unsafe { ... } // SAFETY: ...` の実コードは検出継続 |
-| **e** | `case_e/io/windows_sid.rs` + `case_e/hardening/core_dump.rs` | PASS（exit 0） | 許可リストに登録された 2 ファイルは検査結果から除外 |
+| **e** | `case_e/io/windows_sid.rs` + `case_e/hardening/core_dump.rs` | PASS（exit 0） | 許可リストに登録された 2 ファイルは path 完全一致除外で検査結果から外れる |
+| **f** | `case_f/io/windows_sid.rs.bypass/evil.rs` | FAIL（exit 1） | **Bug-CI-031** path 偽装 silent bypass を構造的に塞ぐ sentinel。許可リスト entry 文字列を path に substring として含む偽装サブディレクトリを完全一致除外で検出（マユリ工程4 発見、服部・ペテルギウス工程5 致命指摘解消） |
 
 ## 実行方法
 
@@ -25,4 +26,9 @@ bash tests/unit/test_audit_secret_paths_grep_gate.sh
 
 ## Issue 連動
 
-Issue #85 — Audit grep gate がコメント文字列の `unsafe` を誤検出する（PR #82 / #84 で `--admin` 連発を誘発した実害の構造的終止符）。
+- Issue #85 — Audit grep gate がコメント文字列の `unsafe` を誤検出する（PR #82 / #84 で `--admin` 連発を誘発した実害の構造的終止符）
+- Bug-CI-031 — 許可リスト substring 過剰許可による silent bypass（path 偽装攻撃面、本 PR で構造修正）
+
+## ファイル名 typo 履歴
+
+`case_a/realy_unsafe.rs` → `case_a/really_unsafe.rs` (ペガサス工程5 typo 指摘で rename、3 箇所 SSoT 同期更新済)。

--- a/tests/fixtures/grep_gate/README.md
+++ b/tests/fixtures/grep_gate/README.md
@@ -1,0 +1,28 @@
+# grep gate 回帰防止 fixture (TC-CI-026 サブケース a〜e)
+
+`scripts/ci/lib/audit_unsafe_blocks.sh` の `audit_unsafe_blocks` 関数が `unsafe` ブロック検出契約（TC-CI-019 / TC-CI-026 共通）を満たすことを検証するための最小再現 fixture。
+
+## 設計根拠
+
+- `docs/features/dev-workflow/detailed-design/scripts.md` §`audit-secret-paths.sh` の `unsafe` ブロック検出契約
+- `docs/features/dev-workflow/test-design.md` §TC-CI-026 サブケース
+
+## サブケース構成
+
+| サブケース | fixture path | 期待結果 | 検証目的 |
+|----------|--------------|---------|---------|
+| **a** | `case_a/realy_unsafe.rs` | FAIL（exit 1、stderr に file:line:content） | コメント行除外パイプを挟んでも実 `unsafe` ブロックは正しくヒット |
+| **b** | `case_b/doc_comment_only.rs` | PASS（exit 0） | doc コメント `/// unsafe { ... }` を grep が誤検出しない（PR #82 実害再現） |
+| **c** | `case_c/comment_variants.rs` | PASS（exit 0） | `//` / `///` / `//!` / 先頭空白 / 空白なしの 5 パターン全てを除外 |
+| **d** | `case_d/inline_comment.rs` | FAIL（exit 1） | 行内コメント `unsafe { ... } // SAFETY: ...` の実コードは検出継続 |
+| **e** | `case_e/io/windows_sid.rs` + `case_e/hardening/core_dump.rs` | PASS（exit 0） | 許可リストに登録された 2 ファイルは検査結果から除外 |
+
+## 実行方法
+
+```bash
+bash tests/unit/test_audit_secret_paths_grep_gate.sh
+```
+
+## Issue 連動
+
+Issue #85 — Audit grep gate がコメント文字列の `unsafe` を誤検出する（PR #82 / #84 で `--admin` 連発を誘発した実害の構造的終止符）。

--- a/tests/fixtures/grep_gate/case_a/really_unsafe.rs
+++ b/tests/fixtures/grep_gate/case_a/really_unsafe.rs
@@ -2,6 +2,7 @@
 // 期待: audit_unsafe_blocks が FAIL を返し、stderr に該当 file:line:content を出力
 //
 // 設計根拠: docs/features/dev-workflow/test-design.md §TC-CI-026-a
+// (rename: realy_unsafe.rs → really_unsafe.rs、ペガサス工程5 typo 指摘解消)
 
 pub fn deref_raw(p: *const u8) -> u8 {
     unsafe {

--- a/tests/fixtures/grep_gate/case_a/really_unsafe.rs
+++ b/tests/fixtures/grep_gate/case_a/really_unsafe.rs
@@ -2,7 +2,6 @@
 // 期待: audit_unsafe_blocks が FAIL を返し、stderr に該当 file:line:content を出力
 //
 // 設計根拠: docs/features/dev-workflow/test-design.md §TC-CI-026-a
-// (rename: realy_unsafe.rs → really_unsafe.rs、ペガサス工程5 typo 指摘解消)
 
 pub fn deref_raw(p: *const u8) -> u8 {
     unsafe {

--- a/tests/fixtures/grep_gate/case_a/realy_unsafe.rs
+++ b/tests/fixtures/grep_gate/case_a/realy_unsafe.rs
@@ -1,0 +1,10 @@
+// fixture for TC-CI-026-a — 許可リスト外ファイルに実 unsafe ブロックが存在
+// 期待: audit_unsafe_blocks が FAIL を返し、stderr に該当 file:line:content を出力
+//
+// 設計根拠: docs/features/dev-workflow/test-design.md §TC-CI-026-a
+
+pub fn deref_raw(p: *const u8) -> u8 {
+    unsafe {
+        *p
+    }
+}

--- a/tests/fixtures/grep_gate/case_b/doc_comment_only.rs
+++ b/tests/fixtures/grep_gate/case_b/doc_comment_only.rs
@@ -1,0 +1,12 @@
+// fixture for TC-CI-026-b — doc コメント内の `unsafe { ... }` 解説文字列のみ
+// 実 unsafe ブロックは存在しない。Issue #75 (PR #82) で
+// crates/shikomi-cli/src/io/ipc_vault_repository.rs:725 に混入した実例の最小再現。
+// 期待: コメント行除外パイプにより grep にヒットせず PASS（exit 0）
+//
+// 設計根拠: docs/features/dev-workflow/test-design.md §TC-CI-026-b
+
+/// `unsafe { std::env::remove_var(...) }` は Rust 2024 edition の env 操作 unsafe 化
+/// 規約に従う（test スコープ内のみ、`serial_test` で他スレッドと直列化済）。
+pub fn safe_only() -> i32 {
+    0
+}

--- a/tests/fixtures/grep_gate/case_c/comment_variants.rs
+++ b/tests/fixtures/grep_gate/case_c/comment_variants.rs
@@ -1,0 +1,25 @@
+//! fixture for TC-CI-026-c — コメント形式 5 パターン網羅
+//! 実 unsafe ブロックは存在しない。「行頭から最初の非空白文字が `//` で始まる行」
+//! 一律除外契約が doc/通常/モジュール doc/先頭空白あり/空白なし 全てを吸収する
+//! ことを保証。
+//!
+//! 設計根拠: docs/features/dev-workflow/test-design.md §TC-CI-026-c
+//
+// パターン 1: モジュール doc コメント（`//!`、行頭から）
+//! unsafe { module_doc_pretend() }
+//
+// パターン 2: doc コメント（`///`、行頭から）
+/// unsafe { doc_pretend() }
+//
+// パターン 3: 通常コメント（`//`、行頭から、空白なし）
+//unsafe{tight_no_space()}
+//
+// パターン 4: 通常コメント（`//`、先頭空白あり）
+    // unsafe { indented_with_space() }
+//
+// パターン 5: 通常コメント（`//`、先頭タブあり）
+	// unsafe { indented_with_tab() }
+
+pub fn safe_only() -> i32 {
+    42
+}

--- a/tests/fixtures/grep_gate/case_d/inline_comment.rs
+++ b/tests/fixtures/grep_gate/case_d/inline_comment.rs
@@ -1,0 +1,11 @@
+// fixture for TC-CI-026-d — 行内コメント形式の実 unsafe コード
+// `unsafe { ... } // SAFETY: ...` は実コードに unsafe ブロックがある以上 grep は
+// 正しくヒットしなければならない。コメント行除外パイプを「行内コメントまで除外」
+// に過剰一般化した実装ミスを sentinel として早期検出する。
+// 期待: FAIL（exit 1、stderr に file:line:content）
+//
+// 設計根拠: docs/features/dev-workflow/test-design.md §TC-CI-026-d
+
+pub fn read_raw(p: *const u8) -> u8 {
+    unsafe { *p } // SAFETY: caller guarantees p is valid for reads of u8
+}

--- a/tests/fixtures/grep_gate/case_e/hardening/core_dump.rs
+++ b/tests/fixtures/grep_gate/case_e/hardening/core_dump.rs
@@ -1,0 +1,19 @@
+// fixture for TC-CI-026-e (ii) — 許可リスト登録ファイル `hardening/core_dump.rs` 模倣
+// C-41 core dump 抑制 (Sub-F Phase 5) で `libc::prctl(PR_SET_DUMPABLE, 0)` /
+// `libc::setrlimit(RLIMIT_CORE, 0)` の FFI 呼出に必要な最小 unsafe。
+// Issue #75 で許可リスト追加された経緯（cli-subcommands.md §C-41）の回帰防止。
+// 期待: PASS（exit 0）
+//
+// 設計根拠: docs/features/dev-workflow/test-design.md §TC-CI-026-e
+
+#![allow(unsafe_code)]
+
+pub fn fake_set_dumpable() -> i32 {
+    let rc = unsafe { 0i32 };
+    rc
+}
+
+pub fn fake_setrlimit() -> i32 {
+    let rc = unsafe { 0i32 };
+    rc
+}

--- a/tests/fixtures/grep_gate/case_e/io/windows_sid.rs
+++ b/tests/fixtures/grep_gate/case_e/io/windows_sid.rs
@@ -1,0 +1,19 @@
+// fixture for TC-CI-026-e (i) — 許可リスト登録ファイル `io/windows_sid.rs` 模倣
+// Windows Win32 Security FFI の最小 unsafe（実コード相当）。許可リストに登録
+// された path として audit_unsafe_blocks の grep -vF 除外で検査結果から外れる。
+// 期待: PASS（exit 0）
+//
+// 設計根拠: docs/features/dev-workflow/test-design.md §TC-CI-026-e
+
+#![allow(unsafe_code)]
+
+pub fn fake_get_last_error() -> u32 {
+    let last_err = unsafe { 0u32 };
+    last_err
+}
+
+pub fn fake_open_token() {
+    unsafe {
+        // FFI 模倣
+    }
+}

--- a/tests/fixtures/grep_gate/case_f/io/windows_sid.rs
+++ b/tests/fixtures/grep_gate/case_f/io/windows_sid.rs
@@ -1,0 +1,14 @@
+// fixture for TC-CI-026-f (control file) — 許可リスト登録の本物 path
+// この path は許可リストに登録されるため、実 unsafe があっても除外される。
+// 比較対象として `windows_sid.rs.bypass/evil.rs` の bypass 試行を sentinel 化する。
+//
+// 設計根拠: docs/features/dev-workflow/test-design.md §TC-CI-026-f
+// 関連: Bug-CI-031（マユリ工程4 発見、服部・ペテルギウス工程5 致命指摘）
+
+#![allow(unsafe_code)]
+
+pub fn fake_legitimate_unsafe() {
+    unsafe {
+        // 許可リスト登録 path での実 unsafe（FFI 模倣）
+    }
+}

--- a/tests/fixtures/grep_gate/case_f/io/windows_sid.rs.bypass/evil.rs
+++ b/tests/fixtures/grep_gate/case_f/io/windows_sid.rs.bypass/evil.rs
@@ -1,0 +1,27 @@
+// fixture for TC-CI-026-f — Bug-CI-031 path 偽装 silent bypass の sentinel
+//
+// 攻撃シナリオ: 許可リスト entry 文字列 (`case_f/io/windows_sid.rs`) を path に
+// substring として含むサブディレクトリ (`windows_sid.rs.bypass/evil.rs`) を作り、
+// 内部に実 unsafe ブロックを書く。grep -vF substring 一致では `windows_sid.rs`
+// が含まれるため除外され、silent bypass が成立してしまう（マユリ工程4 実機確認）。
+//
+// 期待: awk -F: '$1 != "<allowlist>"' の path 完全一致除外により検出される。
+//       evil.rs:N:    unsafe { ... } が stderr に出力され FAIL（exit 1）。
+//
+// 攻撃面 articulate:
+// - path 偽装 `*.rs.bypass/`: 本 fixture の経路
+// - 拡張子偽装 `*.rsx`: `--include='*.rs'` で grep にヒットしないため fail-closed
+// - content 注入: 許可リスト文字列をコメント混入しても、grep 出力 $1 はファイルの
+//   実 path のみ抽出されるため $1 完全一致でブロック
+//
+// 設計根拠:
+// - docs/features/dev-workflow/test-design.md §TC-CI-026-f
+// - docs/features/dev-workflow/detailed-design/scripts.md §検出契約 §許可リスト
+// - 服部工程5 致命指摘: substring 一致 → path 完全一致への構造的修正
+// - ペテルギウス工程5 致命指摘1: 設計書 line 33「ファイル粒度」articulate との整合回復
+
+pub fn deref_raw(p: *const u8) -> u8 {
+    unsafe {
+        *p
+    }
+}

--- a/tests/unit/test_audit_secret_paths_grep_gate.sh
+++ b/tests/unit/test_audit_secret_paths_grep_gate.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# tests/unit/test_audit_secret_paths_grep_gate.sh
+#
+# TC-CI-026 サブケース a〜e の連続実行ランナー。`scripts/ci/lib/audit_unsafe_blocks.sh`
+# の `audit_unsafe_blocks` 関数を直接テストし、Issue #85 (grep gate コメント行
+# 誤検出) の回帰防止 SSoT を機械検証する。
+#
+# 設計根拠:
+# - docs/features/dev-workflow/detailed-design/scripts.md §`audit-secret-paths.sh` の
+#   `unsafe` ブロック検出契約（TC-CI-019 / TC-CI-026 共通仕様）
+# - docs/features/dev-workflow/test-design.md §TC-CI-026 サブケース
+#
+# 終了コード: 5/5 PASS で 0、1 件でも FAIL があれば 1
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# shellcheck source=../../scripts/ci/lib/audit_unsafe_blocks.sh
+source "$REPO_ROOT/scripts/ci/lib/audit_unsafe_blocks.sh"
+
+FIXTURE_ROOT="$REPO_ROOT/tests/fixtures/grep_gate"
+TMP_ERR="$(mktemp -t audit_grep_gate.XXXXXX)"
+trap 'rm -f "$TMP_ERR"' EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# 関数: 期待 PASS（exit 0）のサブケースを実行
+# 引数: <name> <target_dir> [allowlist_substring...]
+expect_pass() {
+    local name="$1"
+    local target="$2"
+    shift 2
+    local allowlist=("$@")
+
+    if audit_unsafe_blocks "$target" "${allowlist[@]}" 2>"$TMP_ERR"; then
+        echo "[$name] PASS — exit 0 (no unsafe detected outside allowlist)"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "[$name] FAIL — expected exit 0 but audit_unsafe_blocks returned non-0"
+        echo "  stderr was:"
+        sed 's/^/    /' "$TMP_ERR"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+# 関数: 期待 FAIL（exit 非 0）のサブケースを実行
+# 引数: <name> <expected_marker> <target_dir> [allowlist_substring...]
+expect_fail() {
+    local name="$1"
+    local expected_marker="$2"
+    local target="$3"
+    shift 3
+    local allowlist=("$@")
+
+    if audit_unsafe_blocks "$target" "${allowlist[@]}" 2>"$TMP_ERR"; then
+        echo "[$name] FAIL — expected non-0 exit but audit_unsafe_blocks returned 0"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        return
+    fi
+
+    if grep -qF "$expected_marker" "$TMP_ERR"; then
+        echo "[$name] PASS — non-0 exit + stderr contains '$expected_marker'"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "[$name] FAIL — non-0 exit ok but stderr missing marker '$expected_marker'"
+        echo "  stderr was:"
+        sed 's/^/    /' "$TMP_ERR"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+echo "=== TC-CI-026 grep gate サブケース 5 件 連続実行 ==="
+echo "fixture root: $FIXTURE_ROOT"
+echo
+
+# TC-CI-026-a: 許可リスト外で実 unsafe ブロック → FAIL 期待
+# 検証目的: コメント行除外パイプを挟んでも実コードの unsafe ブロックは正しくヒット
+expect_fail "TC-CI-026-a" "case_a/realy_unsafe.rs" \
+    "$FIXTURE_ROOT/case_a"
+
+# TC-CI-026-b: doc コメントのみ（PR #82 実例の最小再現）→ PASS 期待
+# 検証目的: doc コメント `/// unsafe { ... }` 文字列を grep が誤検出しない
+expect_pass "TC-CI-026-b" \
+    "$FIXTURE_ROOT/case_b"
+
+# TC-CI-026-c: コメント形式 5 パターン網羅 → PASS 期待
+# 検証目的: `//` / `///` / `//!` / 先頭空白あり / 空白なし 全てを除外
+expect_pass "TC-CI-026-c" \
+    "$FIXTURE_ROOT/case_c"
+
+# TC-CI-026-d: 行内コメント形式の実コード → FAIL 期待
+# 検証目的: 行内コメントを「コメント行」として除外する誤陽性化を sentinel 検出
+expect_fail "TC-CI-026-d" "case_d/inline_comment.rs" \
+    "$FIXTURE_ROOT/case_d"
+
+# TC-CI-026-e: 許可リスト登録 2 ファイルに実 unsafe → PASS 期待
+# 検証目的: 許可リスト substring 一致による grep -vF 除外が機能
+expect_pass "TC-CI-026-e" \
+    "$FIXTURE_ROOT/case_e" \
+    "case_e/io/windows_sid.rs" \
+    "case_e/hardening/core_dump.rs"
+
+echo
+echo "=== Summary ==="
+echo "PASS: $PASS_COUNT / 5"
+echo "FAIL: $FAIL_COUNT / 5"
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    echo "TC-CI-026 grep gate 回帰防止: ✗ FAIL"
+    exit 1
+fi
+
+echo "TC-CI-026 grep gate 回帰防止: ✓ ALL PASS"

--- a/tests/unit/test_audit_secret_paths_grep_gate.sh
+++ b/tests/unit/test_audit_secret_paths_grep_gate.sh
@@ -3,16 +3,16 @@
 #
 # tests/unit/test_audit_secret_paths_grep_gate.sh
 #
-# TC-CI-026 サブケース a〜e の連続実行ランナー。`scripts/ci/lib/audit_unsafe_blocks.sh`
+# TC-CI-026 サブケース a〜f の連続実行ランナー。`scripts/ci/lib/audit_unsafe_blocks.sh`
 # の `audit_unsafe_blocks` 関数を直接テストし、Issue #85 (grep gate コメント行
-# 誤検出) の回帰防止 SSoT を機械検証する。
+# 誤検出) と Bug-CI-031 (許可リスト substring 過剰許可) の回帰防止 SSoT を機械検証する。
 #
 # 設計根拠:
 # - docs/features/dev-workflow/detailed-design/scripts.md §`audit-secret-paths.sh` の
 #   `unsafe` ブロック検出契約（TC-CI-019 / TC-CI-026 共通仕様）
 # - docs/features/dev-workflow/test-design.md §TC-CI-026 サブケース
 #
-# 終了コード: 5/5 PASS で 0、1 件でも FAIL があれば 1
+# 終了コード: 全 PASS で 0、1 件でも FAIL があれば 1
 
 set -euo pipefail
 
@@ -22,20 +22,24 @@ cd "$REPO_ROOT"
 # shellcheck source=../../scripts/ci/lib/audit_unsafe_blocks.sh
 source "$REPO_ROOT/scripts/ci/lib/audit_unsafe_blocks.sh"
 
-FIXTURE_ROOT="$REPO_ROOT/tests/fixtures/grep_gate"
+# 全ての target / 許可リスト引数は REPO_ROOT 相対 path で渡す。grep -rn の出力
+# $1 と awk $1 完全一致除外がドリフトしないため。
+FIXTURE_ROOT_REL="tests/fixtures/grep_gate"
 TMP_ERR="$(mktemp -t audit_grep_gate.XXXXXX)"
 trap 'rm -f "$TMP_ERR"' EXIT
 
 PASS_COUNT=0
 FAIL_COUNT=0
+TOTAL_COUNT=0
 
 # 関数: 期待 PASS（exit 0）のサブケースを実行
-# 引数: <name> <target_dir> [allowlist_substring...]
+# 引数: <name> <target_dir> [allowlist_path...]
 expect_pass() {
     local name="$1"
     local target="$2"
     shift 2
     local allowlist=("$@")
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
 
     if audit_unsafe_blocks "$target" "${allowlist[@]}" 2>"$TMP_ERR"; then
         echo "[$name] PASS — exit 0 (no unsafe detected outside allowlist)"
@@ -49,13 +53,14 @@ expect_pass() {
 }
 
 # 関数: 期待 FAIL（exit 非 0）のサブケースを実行
-# 引数: <name> <expected_marker> <target_dir> [allowlist_substring...]
+# 引数: <name> <expected_marker> <target_dir> [allowlist_path...]
 expect_fail() {
     local name="$1"
     local expected_marker="$2"
     local target="$3"
     shift 3
     local allowlist=("$@")
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
 
     if audit_unsafe_blocks "$target" "${allowlist[@]}" 2>"$TMP_ERR"; then
         echo "[$name] FAIL — expected non-0 exit but audit_unsafe_blocks returned 0"
@@ -74,41 +79,51 @@ expect_fail() {
     fi
 }
 
-echo "=== TC-CI-026 grep gate サブケース 5 件 連続実行 ==="
-echo "fixture root: $FIXTURE_ROOT"
+echo "=== TC-CI-026 grep gate サブケース 連続実行 ==="
+echo "fixture root: $REPO_ROOT/$FIXTURE_ROOT_REL"
 echo
 
 # TC-CI-026-a: 許可リスト外で実 unsafe ブロック → FAIL 期待
 # 検証目的: コメント行除外パイプを挟んでも実コードの unsafe ブロックは正しくヒット
-expect_fail "TC-CI-026-a" "case_a/realy_unsafe.rs" \
-    "$FIXTURE_ROOT/case_a"
+expect_fail "TC-CI-026-a" "case_a/really_unsafe.rs" \
+    "$FIXTURE_ROOT_REL/case_a"
 
 # TC-CI-026-b: doc コメントのみ（PR #82 実例の最小再現）→ PASS 期待
 # 検証目的: doc コメント `/// unsafe { ... }` 文字列を grep が誤検出しない
 expect_pass "TC-CI-026-b" \
-    "$FIXTURE_ROOT/case_b"
+    "$FIXTURE_ROOT_REL/case_b"
 
 # TC-CI-026-c: コメント形式 5 パターン網羅 → PASS 期待
-# 検証目的: `//` / `///` / `//!` / 先頭空白あり / 空白なし 全てを除外
+# 検証目的: `//` / `///` / `//!` / 先頭空白あり / 空白なし / タブ 全てを除外
 expect_pass "TC-CI-026-c" \
-    "$FIXTURE_ROOT/case_c"
+    "$FIXTURE_ROOT_REL/case_c"
 
 # TC-CI-026-d: 行内コメント形式の実コード → FAIL 期待
 # 検証目的: 行内コメントを「コメント行」として除外する誤陽性化を sentinel 検出
 expect_fail "TC-CI-026-d" "case_d/inline_comment.rs" \
-    "$FIXTURE_ROOT/case_d"
+    "$FIXTURE_ROOT_REL/case_d"
 
 # TC-CI-026-e: 許可リスト登録 2 ファイルに実 unsafe → PASS 期待
-# 検証目的: 許可リスト substring 一致による grep -vF 除外が機能
+# 検証目的: 許可リスト path 完全一致による awk $1 != p 除外が機能
 expect_pass "TC-CI-026-e" \
-    "$FIXTURE_ROOT/case_e" \
-    "case_e/io/windows_sid.rs" \
-    "case_e/hardening/core_dump.rs"
+    "$FIXTURE_ROOT_REL/case_e" \
+    "$FIXTURE_ROOT_REL/case_e/io/windows_sid.rs" \
+    "$FIXTURE_ROOT_REL/case_e/hardening/core_dump.rs"
+
+# TC-CI-026-f: Bug-CI-031 path 偽装 sentinel → FAIL 期待
+# 検証目的: 許可リスト entry 文字列 (`windows_sid.rs`) を path に substring として
+#   含む `windows_sid.rs.bypass/evil.rs` の実 unsafe ブロックを silent 許可しない
+#   こと。awk $1 完全一致除外が path 偽装攻撃を構造的に塞ぐ sentinel。
+# 設計根拠: scripts.md §検出契約 §許可リスト「ファイル path 完全一致」、
+#   test-design.md §TC-CI-026-f
+expect_fail "TC-CI-026-f" "case_f/io/windows_sid.rs.bypass/evil.rs" \
+    "$FIXTURE_ROOT_REL/case_f" \
+    "$FIXTURE_ROOT_REL/case_f/io/windows_sid.rs"
 
 echo
 echo "=== Summary ==="
-echo "PASS: $PASS_COUNT / 5"
-echo "FAIL: $FAIL_COUNT / 5"
+echo "PASS: $PASS_COUNT / $TOTAL_COUNT"
+echo "FAIL: $FAIL_COUNT / $TOTAL_COUNT"
 
 if [[ "$FAIL_COUNT" -gt 0 ]]; then
     echo "TC-CI-026 grep gate 回帰防止: ✗ FAIL"


### PR DESCRIPTION
## Summary

Issue #85（grep gate `unsafe` 誤検出）と Issue #86（Windows CI DACL fixture 設計）の **工程3（実装）**。本 PR では Issue #85 の grep gate 実装を完結し、TC-CI-026 サブケース 5 件で回帰防止 SSoT を機械化する。

> **Issue #86 (Windows DACL fixture) の Rust 側実装は別 PR で対応**（本 PR は CI スクリプトレベルの grep gate 修正にスコープを限定）。

## 変更内容

| ファイル | 概要 |
|---|---|
| `scripts/ci/lib/audit_unsafe_blocks.sh`（新規） | grep gate ロジックを再利用可能関数 `audit_unsafe_blocks()` に抽出（DRY）。コメント行（`^[^:]+:[0-9]+:[[:space:]]*//[/!]?`）一律除外 + 許可リスト substring 除外 + 失敗時 `file:line:content` を stderr 出力 |
| `scripts/ci/audit-secret-paths.sh` | TC-CI-019 / TC-CI-026 の grep パイプを `audit_unsafe_blocks` 呼出に置換、`grep -v` 連結の重複構造を解消 |
| `tests/fixtures/grep_gate/case_{a..e}/` | 5 サブケースの最小再現 fixture |
| `tests/unit/test_audit_secret_paths_grep_gate.sh` | 5 サブケース連続実行ランナー（`expect_pass` / `expect_fail` で exit code + stderr marker を検証） |
| `justfile` | `audit` レシピに grep gate test を組込み、5/5 PASS を CI ゲート条件化 |
| `docs/features/daemon-ipc/test-design/index.md` | Boy Scout: TC-CI-019 行に dev-workflow 側 TC-CI-026 サブケースへの後方リンク追記（SSoT 整合性回復） |

## 設計書整合

- `docs/features/dev-workflow/detailed-design/scripts.md` §`audit-secret-paths.sh` の `unsafe` ブロック検出契約（TC-CI-019 / TC-CI-026 共通仕様）
- `docs/features/dev-workflow/test-design.md` §TC-CI-026 サブケース a〜e + §TC-CI-019 への波及 articulate

## fixture サブケース

| サブケース | 期待結果 | 検証目的 |
|---|---|---|
| TC-CI-026-a | FAIL | コメント除外パイプを挟んでも実 `unsafe` ブロックは正しくヒット |
| TC-CI-026-b | PASS | doc コメント `/// unsafe { ... }` を誤検出しない（PR #82 実害再現） |
| TC-CI-026-c | PASS | `//` / `///` / `//!` / 先頭空白あり / 空白なし 5 パターン全除外 |
| TC-CI-026-d | FAIL | 行内コメント `unsafe { ... } // SAFETY: ...` の実コードは検出継続（誤陽性化 sentinel） |
| TC-CI-026-e | PASS | 許可リスト `io/windows_sid.rs` + `hardening/core_dump.rs` は除外 |

## ローカル動作確認

```
$ bash scripts/ci/audit-secret-paths.sh
[TC-CI-019] PASS
[TC-CI-026] PASS
ALL secret-path audits PASS

$ bash tests/unit/test_audit_secret_paths_grep_gate.sh
[TC-CI-026-a] PASS — non-0 exit + stderr contains 'case_a/realy_unsafe.rs'
[TC-CI-026-b] PASS — exit 0 (no unsafe detected outside allowlist)
[TC-CI-026-c] PASS — exit 0 (no unsafe detected outside allowlist)
[TC-CI-026-d] PASS — non-0 exit + stderr contains 'case_d/inline_comment.rs'
[TC-CI-026-e] PASS — exit 0 (no unsafe detected outside allowlist)
PASS: 5 / 5
TC-CI-026 grep gate 回帰防止: ✓ ALL PASS
```

`crates/shikomi-cli/src/io/ipc_vault_repository.rs:725` の doc コメント `/// unsafe { std::env::remove_var(...) }` が誤検出されなくなったことを実証。

## Test plan

- [x] ローカル `bash scripts/ci/audit-secret-paths.sh` 全 PASS
- [x] ローカル `bash tests/unit/test_audit_secret_paths_grep_gate.sh` 5/5 PASS
- [ ] CI `audit` ジョブが緑（本 PR マージで `--admin` バイパス連発が構造的に終止）
- [ ] テスト担当によるサブケース粒度・ false positive/negative バランス再確認

## テスト担当に確認してほしい観点

- TC-CI-026-c の 5 パターン網羅性（`//`、`///`、`//!`、先頭空白あり、空白なし、タブ）が回帰防止 sentinel として十分か
- TC-CI-026-d の sentinel 設計（行内コメント除外を誤って実装した場合に確実に red になるか）
- 将来 TC-CI-019 / TC-CI-026 が分岐した場合の Boy Scout 起動条件の articulate（test-design.md §TC-CI-019 への波及 articulate）が機能するか

Refs #85, #86