### PR TITLE
docs(shikomi-gui): Sub-B — ipc-client 基本設計 / 詳細設計書

### DIFF
--- a/docs/features/shikomi-gui/ipc-client/basic-design.md
+++ b/docs/features/shikomi-gui/ipc-client/basic-design.md
@@ -12,7 +12,7 @@
 |---------|------|
 | REQ-IPC-01 | `list_entries` Tauri Command が `IpcRequest::ListRecords` を送信し、`IpcResponse::Records { records, protection_mode }` を SolidJS に返す（R1-GUI-04） |
 | REQ-IPC-02 | `add_entry` Tauri Command が `IpcRequest::AddRecord` を送信し、`IpcResponse::Added { id }` を返す。ラベル空文字・値空文字は Rust ハンドラ側で Fail Fast する（R1-GUI-05, R1-GUI-19） |
-| REQ-IPC-03 | `update_entry` Tauri Command が `IpcRequest::EditRecord` を送信し、`IpcResponse::Edited { id }` を返す。変更フィールドが全て `None` の場合は IPC 送信を省略し即時成功を返す（R1-GUI-06） |
+| REQ-IPC-03 | `update_entry` Tauri Command が `IpcRequest::EditRecord` を送信し、`IpcResponse::Edited { id }` を返す。ハンドラに到達した場合は**必ず** IPC 送信する（Silent Failure 禁止）。Sub-C（UI 層）が「変更なし時に `invoke` 自体を呼ばない」契約を持つ（Tell, Don't Ask）（R1-GUI-06） |
 | REQ-IPC-04 | `delete_entry` Tauri Command が `IpcRequest::RemoveRecord` を送信し、`IpcResponse::Removed { id }` を返す（R1-GUI-07） |
 | REQ-IPC-05 | `assign_hotkey` Tauri Command が `IpcRequest::EditRecord { hotkey: Some(combo), clear_hotkey: false }` を送信し、`IpcResponse::Edited { id }` を返す。combo は `Ctrl+Alt+[1-9]` 形式のみ許可、Rust ハンドラ側で検証する（R1-GUI-08, R1-GUI-09, R1-GUI-19） |
 | REQ-IPC-06 | `remove_hotkey` Tauri Command が `IpcRequest::EditRecord { clear_hotkey: true }` を送信し、`IpcResponse::Edited { id }` を返す（R1-GUI-08） |
@@ -21,7 +21,8 @@
 | REQ-IPC-09 | `decrypt_vault` Tauri Command が `IpcRequest::Decrypt { master_password, confirmed }` を送信し、`IpcResponse::Decrypted` を返す。`confirmed` は JS 側チェックボックス状態をそのまま受け取り、Rust ハンドラが `confirmed == false` を Fail Fast する（R1-GUI-12, R1-GUI-19） |
 | REQ-IPC-10 | `unlock_vault` Tauri Command が `IpcRequest::Unlock { master_password, recovery: None }` を送信し、`IpcResponse::Unlocked` を返す。vault がロック状態での書き込み操作前にアンロックモーダルから呼ばれる（R1-GUI-13） |
 | REQ-IPC-11 | `GuiIpcClient::connect()` が UDS（Unix）/ Named Pipe（Windows）経由で daemon に接続し、`IpcProtocolVersion::V2` Handshake を確立する。接続失敗・プロトコル不一致は `GUIError` に変換して Fail Fast する（R1-GUI-02, R1-GUI-03） |
-| REQ-IPC-12 | daemon 未接続状態での全 Tauri Command 呼び出しは即 `GUIError::DaemonNotRunning` を返す。サイレント失敗・リトライは行わない（tech-stack.md §2.6.2 Fail Fast 契約） |
+| REQ-IPC-12 | daemon 未接続状態での全 Tauri Command 呼び出しは即 `GUIError::NotConnected` を返す。サイレント失敗・リトライは行わない（tech-stack.md §2.6.2 Fail Fast 契約） |
+| REQ-IPC-13 | ソケットパス解決は `shikomi-infra::ipc::IpcEndpoint::default_for_current_user()` に一元化する。GUI の `lib.rs::setup()` も CLI の `IpcVaultRepository::default_socket_path()` も同メソッドを呼び出す。パス解決ロジックを複数箇所に重複させない（DRY）。`IpcEndpoint` は `shikomi-infra` crate 内に新設する |
 
 ## 1. モジュール構成
 
@@ -120,7 +121,33 @@ Tauri アプリ起動時に `lib.rs::setup()` フックが `GuiIpcClient::connec
 
 `AppState` は `tauri::Manager::manage()` で登録し、各 Command ハンドラが `tauri::State<AppState>` で受け取る。
 
-## 3. feature-spec との対応（R1-GUI → REQ-IPC トレーサビリティ）
+## 3. UX 設計上の考慮
+
+### 3.1 本 sub-feature の UI 保持有無
+
+本 sub-feature（ipc-client）は **UI を持たない**。Tauri Commands は Rust 層の IPC ブリッジのみを担い、画面表示・ユーザー操作の制御は Sub-C（ui sub-feature）の責務である。
+
+### 3.2 エラー構造と Sub-C の表示責務
+
+`GUIError` は `{ "kind": "...", "message": "..." }` 形式で SolidJS に届く（`detailed-design.md §2.2` 参照）。表示責務の分担は以下の通り：
+
+| フィールド | 用途 | 責務 |
+|-----------|------|------|
+| `kind` | エラー種別の機械的判別 | **Sub-C が `kind` を switch して日本語メッセージを表示する**（例: `"daemon_not_running"` → 「daemon が起動していません」）|
+| `message` | デバッグ・ログ記録用の英語技術情報 | **ユーザーに直接表示してはならない**（開発者ツール・ログファイル用途） |
+
+**この分担を破ると田中俊介さん・佐々木健二さんには意味不明な英語技術文字列が表示される**（ペルソナ A/C への配慮要件）。
+
+### 3.3 Sub-C への契約（`update_entry` の呼び出し規約）
+
+`update_entry` ハンドラはフィールド変更有無にかかわらずハンドラ到達時に必ず IPC 送信を行う（REQ-IPC-03、Tell, Don't Ask）。Sub-C は以下の契約を守ること：
+
+- **変更なし（ラベル・値ともに変更されていない）場合は `invoke('update_entry', ...)` を呼ばない**
+- 変更がある場合のみ invoke する
+
+これにより daemon への不要な往復を回避しつつ、ハンドラ側の Silent Failure（実在しない id で成功を返す）を構造的に排除する。
+
+## 4. feature-spec との対応（R1-GUI → REQ-IPC トレーサビリティ）
 
 | R1-GUI | REQ-IPC | 実装 Command |
 |--------|---------|-------------|
@@ -136,6 +163,9 @@ Tauri アプリ起動時に `lib.rs::setup()` フックが `GuiIpcClient::connec
 | R1-GUI-11 | REQ-IPC-08 | `encrypt_vault`（`disclosure` 返却） |
 | R1-GUI-12 | REQ-IPC-09 | `decrypt_vault`（`confirmed` Fail Fast） |
 | R1-GUI-13 | REQ-IPC-10, REQ-IPC-07 | `unlock_vault`, `get_vault_status` |
+| R1-GUI-14 | 該当なし — Sub-D（system-tray）スコープ | — |
+| R1-GUI-15 | 該当なし — Sub-D（system-tray）スコープ | — |
+| R1-GUI-16 | 該当なし — Sub-E（build CI）スコープ | — |
 | R1-GUI-17 | 該当なし — Sub-A で `tauri.conf.json` に設定済み | — |
 | R1-GUI-18 | 該当なし — Sub-C（UI コンポーネント層）の責務 | — |
-| R1-GUI-19 | REQ-IPC-02, REQ-IPC-05, REQ-IPC-09 | `add_entry`, `assign_hotkey`, `decrypt_vault` の Rust 側検証 |
+| R1-GUI-19 | REQ-IPC-02, REQ-IPC-05, REQ-IPC-08, REQ-IPC-09, REQ-IPC-10 | `add_entry`, `assign_hotkey`, `encrypt_vault`, `decrypt_vault`, `unlock_vault` の Rust 側検証 |

--- a/docs/features/shikomi-gui/ipc-client/basic-design.md
+++ b/docs/features/shikomi-gui/ipc-client/basic-design.md
@@ -1,0 +1,141 @@
+# 基本設計書 — ipc-client（shikomi-gui）
+
+<!-- feature: shikomi-gui / sub-feature: ipc-client / Issue #95 -->
+<!-- 配置先: docs/features/shikomi-gui/ipc-client/basic-design.md -->
+<!-- 疑似コード・実装コードブロック禁止 -->
+<!-- 参照: docs/features/shikomi-gui/feature-spec.md（凍結済み）-->
+<!-- 参照: docs/architecture/tech-stack.md §2.6 -->
+
+## §モジュール契約（機能要件マッピング）
+
+| 要件 ID | 契約 |
+|---------|------|
+| REQ-IPC-01 | `list_entries` Tauri Command が `IpcRequest::ListRecords` を送信し、`IpcResponse::Records { records, protection_mode }` を SolidJS に返す（R1-GUI-04） |
+| REQ-IPC-02 | `add_entry` Tauri Command が `IpcRequest::AddRecord` を送信し、`IpcResponse::Added { id }` を返す。ラベル空文字・値空文字は Rust ハンドラ側で Fail Fast する（R1-GUI-05, R1-GUI-19） |
+| REQ-IPC-03 | `update_entry` Tauri Command が `IpcRequest::EditRecord` を送信し、`IpcResponse::Edited { id }` を返す。変更フィールドが全て `None` の場合は IPC 送信を省略し即時成功を返す（R1-GUI-06） |
+| REQ-IPC-04 | `delete_entry` Tauri Command が `IpcRequest::RemoveRecord` を送信し、`IpcResponse::Removed { id }` を返す（R1-GUI-07） |
+| REQ-IPC-05 | `assign_hotkey` Tauri Command が `IpcRequest::EditRecord { hotkey: Some(combo), clear_hotkey: false }` を送信し、`IpcResponse::Edited { id }` を返す。combo は `Ctrl+Alt+[1-9]` 形式のみ許可、Rust ハンドラ側で検証する（R1-GUI-08, R1-GUI-09, R1-GUI-19） |
+| REQ-IPC-06 | `remove_hotkey` Tauri Command が `IpcRequest::EditRecord { clear_hotkey: true }` を送信し、`IpcResponse::Edited { id }` を返す（R1-GUI-08） |
+| REQ-IPC-07 | `get_vault_status` Tauri Command が `IpcRequest::ListRecords` を送信し、`protection_mode` のみ SolidJS に返す。vault 状態の単独取得 API として機能する（R1-GUI-04, R1-GUI-13） |
+| REQ-IPC-08 | `encrypt_vault` Tauri Command が `IpcRequest::Encrypt { master_password, accept_limits: false }` を送信し、`IpcResponse::Encrypted { disclosure }` の `disclosure`（BIP-39 24 語）を SolidJS に返す（R1-GUI-10, R1-GUI-11） |
+| REQ-IPC-09 | `decrypt_vault` Tauri Command が `IpcRequest::Decrypt { master_password, confirmed }` を送信し、`IpcResponse::Decrypted` を返す。`confirmed` は JS 側チェックボックス状態をそのまま受け取り、Rust ハンドラが `confirmed == false` を Fail Fast する（R1-GUI-12, R1-GUI-19） |
+| REQ-IPC-10 | `unlock_vault` Tauri Command が `IpcRequest::Unlock { master_password, recovery: None }` を送信し、`IpcResponse::Unlocked` を返す。vault がロック状態での書き込み操作前にアンロックモーダルから呼ばれる（R1-GUI-13） |
+| REQ-IPC-11 | `GuiIpcClient::connect()` が UDS（Unix）/ Named Pipe（Windows）経由で daemon に接続し、`IpcProtocolVersion::V2` Handshake を確立する。接続失敗・プロトコル不一致は `GUIError` に変換して Fail Fast する（R1-GUI-02, R1-GUI-03） |
+| REQ-IPC-12 | daemon 未接続状態での全 Tauri Command 呼び出しは即 `GUIError::DaemonNotRunning` を返す。サイレント失敗・リトライは行わない（tech-stack.md §2.6.2 Fail Fast 契約） |
+
+## 1. モジュール構成
+
+変更対象 crate: **`shikomi-gui`**
+
+```
+crates/shikomi-gui/src/
+  ipc_client/
+    mod.rs              ← GuiIpcClient struct + AppState 型エイリアス
+    error.rs            ← GUIError enum（Serialize 実装含む）
+    commands/
+      mod.rs            ← invoke_handler に渡す全 Command の再エクスポート
+      entries.rs        ← list_entries / add_entry / update_entry / delete_entry
+      hotkey.rs         ← assign_hotkey / remove_hotkey
+      vault.rs          ← get_vault_status / encrypt_vault / decrypt_vault / unlock_vault
+  lib.rs                ← AppState を manage()、invoke_handler に全 Command 登録
+```
+
+## 2. コンポーネント設計
+
+```mermaid
+flowchart TB
+    subgraph GUI["shikomi-gui プロセス"]
+        direction TB
+        SolidJS["SolidJS UI\n(invoke)"]
+        TC["Tauri Commands\n10 本"]
+        AppState["AppState\nArc&lt;Mutex&lt;Option&lt;GuiIpcClient&gt;&gt;&gt;"]
+        IpcClient["GuiIpcClient\nRust 非同期 IPC クライアント"]
+        GUIError["GUIError enum\nSerialize 済、SolidJS へ透過伝搬"]
+    end
+    Daemon["shikomi-daemon\n(UDS / Named Pipe)"]
+
+    SolidJS -- "invoke('list_entries', ...)" --> TC
+    TC -- "State&lt;AppState&gt;" --> AppState
+    AppState -- "lock().as_mut()" --> IpcClient
+    IpcClient -- "MessagePack over UDS / Named Pipe" --> Daemon
+    TC -- "Err(GUIError)" --> SolidJS
+```
+
+### 2.1 `GuiIpcClient`
+
+daemon との非同期 IPC 接続を保持する構造体。CLI の `IpcClient`（`shikomi-cli::io::ipc_client`）と同一のトランスポート設計を踏襲しつつ、エラー型を `GUIError` に置き換える。
+
+| メソッド | 説明 |
+|---------|------|
+| `connect(socket_path)` | UDS / Named Pipe に接続し、V2 Handshake を行う。失敗時は `GUIError` を返す |
+| `round_trip(request)` | リクエスト送信 + レスポンス受信の 1 往復 helper |
+
+**依存方針**: `shikomi-core::ipc` の型を直接使用（DRY）。`shikomi-cli::io::ipc_client` とは別実装として `shikomi-gui` 内に閉じる。詳細は `detailed-design.md §1` を参照。
+
+### 2.2 `GUIError`
+
+Tauri Commands の統一エラー型。`serde::Serialize` を実装し、SolidJS 側で JSON として受け取れる。
+
+| variant | 意味 |
+|---------|------|
+| `DaemonNotRunning` | UDS / Named Pipe が存在しない（daemon 未起動） |
+| `ConnectionFailed(String)` | 接続確立後の IO エラー |
+| `ProtocolVersionMismatch { server, client }` | プロトコルバージョン不一致 |
+| `Ipc(IpcErrorCode)` | daemon から返却された `IpcErrorCode` の透過伝搬 |
+| `Encode(String)` | MessagePack シリアライズ失敗 |
+| `Decode(String)` | MessagePack デシリアライズ失敗 |
+| `UnexpectedResponse(String)` | 予期しない `IpcResponse` variant |
+| `InvalidInput(String)` | Rust 側 input validation 失敗（R1-GUI-19） |
+| `NotConnected` | AppState が未接続（`connect()` 未呼び出しまたは切断後） |
+
+`GUIError` は `thiserror::Error` を derive し、`Serialize` 実装で `{ "kind": "...", "message": "..." }` 形式に写像する（詳細は `detailed-design.md §2` 参照）。
+
+### 2.3 Tauri Commands 一覧
+
+| Command 関数名 | 対応 IpcRequest | 正常時 IpcResponse | 機能要件 |
+|---|---|---|---|
+| `list_entries` | `ListRecords` | `Records { records, protection_mode }` | REQ-IPC-01 |
+| `add_entry` | `AddRecord` | `Added { id }` | REQ-IPC-02 |
+| `update_entry` | `EditRecord` | `Edited { id }` | REQ-IPC-03 |
+| `delete_entry` | `RemoveRecord` | `Removed { id }` | REQ-IPC-04 |
+| `assign_hotkey` | `EditRecord { hotkey: Some, clear_hotkey: false }` | `Edited { id }` | REQ-IPC-05 |
+| `remove_hotkey` | `EditRecord { clear_hotkey: true }` | `Edited { id }` | REQ-IPC-06 |
+| `get_vault_status` | `ListRecords` | `protection_mode`（`Records` から抽出） | REQ-IPC-07 |
+| `encrypt_vault` | `Encrypt` | `Encrypted { disclosure }` | REQ-IPC-08 |
+| `decrypt_vault` | `Decrypt` | `Decrypted` | REQ-IPC-09 |
+| `unlock_vault` | `Unlock { recovery: None }` | `Unlocked` | REQ-IPC-10 |
+
+全 Command は `async fn` で実装する（tech-stack.md §2.6.2）。
+
+### 2.4 `AppState`（接続状態管理）
+
+```
+AppState = Arc<Mutex<Option<GuiIpcClient>>>
+```
+
+- `None`: daemon 未接続状態（起動直後 / 切断後）
+- `Some(client)`: daemon 接続済み
+
+Tauri アプリ起動時に `lib.rs::setup()` フックが `GuiIpcClient::connect()` を呼び、成功すれば `Some` に遷移させる。接続失敗は UI パネルで通知し `None` のまま保持する（R1-GUI-03）。
+
+`AppState` は `tauri::Manager::manage()` で登録し、各 Command ハンドラが `tauri::State<AppState>` で受け取る。
+
+## 3. feature-spec との対応（R1-GUI → REQ-IPC トレーサビリティ）
+
+| R1-GUI | REQ-IPC | 実装 Command |
+|--------|---------|-------------|
+| R1-GUI-02 | REQ-IPC-11 | `GuiIpcClient::connect` |
+| R1-GUI-03 | REQ-IPC-12 | 全 Commands（NotConnected ガード） |
+| R1-GUI-04 | REQ-IPC-01, REQ-IPC-07 | `list_entries`, `get_vault_status` |
+| R1-GUI-05 | REQ-IPC-02 | `add_entry` |
+| R1-GUI-06 | REQ-IPC-03 | `update_entry` |
+| R1-GUI-07 | REQ-IPC-04 | `delete_entry` |
+| R1-GUI-08 | REQ-IPC-05, REQ-IPC-06 | `assign_hotkey`, `remove_hotkey` |
+| R1-GUI-09 | REQ-IPC-05 | `assign_hotkey`（`Ctrl+Alt+[1-9]` 検証） |
+| R1-GUI-10 | REQ-IPC-08 | `encrypt_vault` |
+| R1-GUI-11 | REQ-IPC-08 | `encrypt_vault`（`disclosure` 返却） |
+| R1-GUI-12 | REQ-IPC-09 | `decrypt_vault`（`confirmed` Fail Fast） |
+| R1-GUI-13 | REQ-IPC-10, REQ-IPC-07 | `unlock_vault`, `get_vault_status` |
+| R1-GUI-17 | 該当なし — Sub-A で `tauri.conf.json` に設定済み | — |
+| R1-GUI-18 | 該当なし — Sub-C（UI コンポーネント層）の責務 | — |
+| R1-GUI-19 | REQ-IPC-02, REQ-IPC-05, REQ-IPC-09 | `add_entry`, `assign_hotkey`, `decrypt_vault` の Rust 側検証 |

--- a/docs/features/shikomi-gui/ipc-client/detailed-design.md
+++ b/docs/features/shikomi-gui/ipc-client/detailed-design.md
@@ -23,6 +23,10 @@
 | Unix（macOS / Linux） | `tokio::net::UnixStream` |
 | Windows | `tokio::net::windows::named_pipe::NamedPipeClient` |
 
+**セキュリティ前提（UDS ピア認証）**:
+
+本クライアントが接続する UDS ソケットの認可（同一ユーザー UID の確認）は **daemon 側が `SO_PEERCRED` / Windows ACL で担保**している（`docs/architecture/context/threat-model.md §7` および `crates/shikomi-daemon/src/permission/` 参照）。`GuiIpcClient` はトランスポート層のみを担い、追加の認証処理は行わない。これは daemon が自身と同一 UID のクライアントのみ接続を受理する設計に依存しており、GUI プロセスが異なるユーザーで動作する場合は daemon が接続を拒否する。
+
 ### 1.2 接続・ハンドシェイクフロー
 
 ```mermaid
@@ -69,24 +73,31 @@ CLI の `IpcClient` と同一仕様で実装する（共通 daemon への接続�
 #### `round_trip(request: &IpcRequest) → Result<IpcResponse, GUIError>`
 
 1. `rmp_serde::to_vec(request)` でシリアライズ失敗時は `GUIError::Encode`
-2. `framed.send(bytes)` の IO 失敗は `GUIError::ConnectionFailed`
-3. `framed.next()` で受信。`None`（EOF）は `GUIError::ConnectionFailed`
+2. `framed.send(bytes)` の IO 失敗は `GUIError::ConnectionFailed(io_error.kind().to_string())`
+   — `std::io::Error` の `kind()` のみを文字列化し、OS 内部情報（ソケットパス・FD 番号等）を含む生メッセージは**使用しない**（OWASP A04 エラーメッセージ漏洩対策）
+3. `framed.next()` で受信。`None`（EOF）は `GUIError::ConnectionFailed("connection closed")`
 4. `rmp_serde::from_slice(&bytes)` のデシリアライズ失敗は `GUIError::Decode`
 5. 成功時は `IpcResponse` を返す
 
-### 1.5 ソケットパス解決
+### 1.5 ソケットパス解決（`IpcEndpoint`、REQ-IPC-13）
 
 `GuiIpcClient::connect()` は呼び出し元（`lib.rs::setup()`）から `socket_path: &Path` を受け取る。パス解決ロジックは `setup()` が担い、`GuiIpcClient` 自体はパス解決を行わない（単一責務）。
 
-パス解決の優先順位（`setup()` 内で実装）：
+**DRY 設計**: ソケットパス解決ロジックを CLI（`IpcVaultRepository::default_socket_path()`）と GUI（`lib.rs::setup()`）の2箇所に重複させない。`shikomi-infra` crate に新設する `IpcEndpoint::default_for_current_user()` に一元化し、両者がこれを呼び出す。
+
+#### `IpcEndpoint`（`shikomi-infra::ipc::IpcEndpoint`、Sub-B で新設）
+
+| メソッド | 戻り値 | 説明 |
+|---------|--------|------|
+| `IpcEndpoint::default_for_current_user()` | `Result<PathBuf, PersistenceError>` | 現ユーザーのデフォルト IPC ソケットパスを解決。優先順位は下表 |
 
 | 優先度 | パス | 条件 |
 |--------|------|------|
-| 1 | `$SHIKOMI_VAULT_DIR/shikomi.sock`（Unix）/ `\\.\pipe\shikomi`（Windows） | 環境変数 `SHIKOMI_VAULT_DIR` が設定されている場合 |
+| 1 | `$SHIKOMI_VAULT_DIR/shikomi.sock`（Unix）/ `\\.\pipe\shikomi-{username}`（Windows） | 環境変数 `SHIKOMI_VAULT_DIR` が設定されている場合 |
 | 2 | `$XDG_RUNTIME_DIR/shikomi/shikomi.sock` | Linux / macOS（XDG 準拠） |
 | 3 | `dirs::data_dir()/shikomi/shikomi.sock`（Unix）/ `\\.\pipe\shikomi`（Windows） | フォールバック |
 
-CLI（`IpcVaultRepository::default_socket_path()`）と同一の優先順位に従い、daemon との接続先を一致させる。
+**移行計画**: CLI の `IpcVaultRepository::default_socket_path()` は本 Sub-B で `IpcEndpoint::default_for_current_user()` への委譲に書き換える（Boy Scout Rule）。
 
 ---
 
@@ -97,7 +108,7 @@ CLI（`IpcVaultRepository::default_socket_path()`）と同一の優先順位に�
 | variant | フィールド | Serialize 後の `kind` 文字列 | 意味 |
 |---------|-----------|--------------------------|------|
 | `DaemonNotRunning` | なし | `"daemon_not_running"` | UDS / Named Pipe ファイルが存在しない（daemon 未起動） |
-| `ConnectionFailed(String)` | `message: String` | `"connection_failed"` | 接続後の IO エラー（切断含む） |
+| `ConnectionFailed(String)` | `message: String` | `"connection_failed"` | 接続後の IO エラー（切断含む）。`message` には `io::Error::kind().to_string()` のみを使用し、生の OS エラーメッセージ（ソケットパス・FD番号等）を含めない（OWASP A04） |
 | `ProtocolVersionMismatch` | `server: String, client: String` | `"protocol_version_mismatch"` | Handshake バージョン不一致 |
 | `Ipc(IpcErrorCode)` | なし（`IpcErrorCode` の `Display` を `message` に使用） | `"ipc_error"` | daemon 返却 `IpcErrorCode` の透過伝搬 |
 | `Encode(String)` | `message: String` | `"encode_error"` | MessagePack シリアライズ失敗 |
@@ -111,10 +122,16 @@ CLI（`IpcVaultRepository::default_socket_path()`）と同一の優先順位に�
 SolidJS 側が `switch` でエラー分岐できるよう、以下の JSON 構造に写像する：
 
 ```
-{ "kind": "<上記の kind 文字列>", "message": "<人間可読エラーメッセージ>" }
+{ "kind": "<上記の kind 文字列>", "message": "<デバッグ用英語技術情報>" }
 ```
 
 `IpcErrorCode` の `Display` 実装（`shikomi-core::ipc::error_code`）を `message` フィールドに使用する。
+
+**`message` フィールドの用途制限**:
+
+- `message` は**開発者向けデバッグ・ログ記録用途のみ**。ユーザーへの直接表示に使ってはならない
+- Sub-C（UI 層）は `kind` フィールドを switch して**日本語メッセージを自前で表示する責務を持つ**（例: `"daemon_not_running"` → 「daemon が起動していません。`shikomi start` を実行してください」）
+- `message` を画面表示すると、ペルソナ A/C（田中俊介・佐々木健二）には意味不明な英語技術文字列が表示される（personas.md §ペルソナ A/C）
 
 ### 2.3 `IpcErrorCode` の透過伝搬
 
@@ -157,9 +174,9 @@ SolidJS 側が `switch` でエラー分岐できるよう、以下の JSON 構�
 | 項目 | 内容 |
 |------|------|
 | 入力 | `id: String, label: Option<String>, value: Option<String>` |
-| 処理 | 全フィールドが `None` かつ変更なし → 即時 `{ id }` 返却（IPC 省略）。それ以外は `EditRecord` round_trip |
+| 処理 | ハンドラに到達した場合は**必ず** `EditRecord` を IPC 送信する。Silent Failure（IPC 省略して `Ok` を返す）を**行わない**。Sub-C が変更なし時に `invoke` を呼ばない契約を持つ（`basic-design.md §3.3` 参照）。`id` は `RecordId::try_from_str` で検証 → 失敗時は `InvalidInput` |
 | 出力 | `{ id: String }` |
-| エラー時 | `InvalidInput` / `NotConnected` / `Ipc(NotFound)` / `Ipc(InvalidLabel)` 等 |
+| エラー時 | `InvalidInput`（不正 UUID）/ `NotConnected` / `Ipc(NotFound)` / `Ipc(InvalidLabel)` 等 |
 
 ### 3.4 `delete_entry`
 
@@ -270,8 +287,11 @@ JS 側バリデーションは `window.__TAURI__.invoke` 直接呼び出しで�
 | `add_entry::label` | 空文字列は拒否 | `InvalidInput("label must not be empty")` |
 | `add_entry::value` | 空文字列は拒否 | `InvalidInput("value must not be empty")` |
 | `assign_hotkey::combo` | `Ctrl+Alt+[1-9]` 形式以外は拒否 | `InvalidInput("hotkey must be Ctrl+Alt+[1-9]")` |
+| `encrypt_vault::master_password` | 空文字列は拒否 | `InvalidInput("master password must not be empty")` |
+| `decrypt_vault::master_password` | 空文字列は拒否 | `InvalidInput("master password must not be empty")` |
 | `decrypt_vault::confirmed` | `false` は拒否 | `InvalidInput("decrypt confirmation required")` |
-| `delete_entry::id` / `update_entry::id` 等 | `RecordId::try_from_str` 失敗は拒否 | `InvalidInput("invalid record id format")` |
+| `unlock_vault::master_password` | 空文字列は拒否 | `InvalidInput("master password must not be empty")` |
+| `delete_entry::id` / `update_entry::id` / `assign_hotkey::id` 等 | `RecordId::try_from_str` 失敗は拒否 | `InvalidInput("invalid record id format")` |
 
 ---
 

--- a/docs/features/shikomi-gui/ipc-client/detailed-design.md
+++ b/docs/features/shikomi-gui/ipc-client/detailed-design.md
@@ -1,0 +1,294 @@
+# 詳細設計書 — ipc-client（shikomi-gui）
+
+<!-- feature: shikomi-gui / sub-feature: ipc-client / Issue #95 -->
+<!-- 配置先: docs/features/shikomi-gui/ipc-client/detailed-design.md -->
+<!-- 疑似コード・実装コードブロック禁止 -->
+<!-- 参照: docs/features/shikomi-gui/ipc-client/basic-design.md -->
+<!-- 参照: docs/features/shikomi-gui/feature-spec.md（凍結済み）-->
+<!-- 参照: docs/architecture/tech-stack.md §2.6 -->
+<!-- 参照: docs/architecture/context/threat-model.md §7.3 -->
+
+## 1. `GuiIpcClient` 詳細
+
+### 1.1 フィールド
+
+| フィールド | 型 | 説明 |
+|-----------|----|------|
+| `framed` | `Framed<Stream, LengthDelimitedCodec>` | MessagePack フレーム化されたストリーム |
+
+`Stream` は `cfg` でプラットフォーム別に切り替える：
+
+| OS | Stream 型 |
+|----|-----------|
+| Unix（macOS / Linux） | `tokio::net::UnixStream` |
+| Windows | `tokio::net::windows::named_pipe::NamedPipeClient` |
+
+### 1.2 接続・ハンドシェイクフロー
+
+```mermaid
+sequenceDiagram
+    participant GUI as shikomi-gui (setup hook)
+    participant AppState
+    participant Daemon as shikomi-daemon (UDS / Named Pipe)
+
+    GUI->>Daemon: open_stream(socket_path)
+    alt 接続失敗
+        Daemon-->>GUI: OS エラー
+        GUI->>AppState: None（DaemonNotRunning）
+    end
+    GUI->>Daemon: IpcRequest::Handshake { client_version: V2 }
+    Daemon-->>GUI: IpcResponse::Handshake { server_version: V2 }
+    alt server_version != V2
+        Daemon-->>GUI: IpcResponse::ProtocolVersionMismatch
+        GUI->>AppState: None（ProtocolVersionMismatch）
+    end
+    GUI->>AppState: Some(GuiIpcClient)
+```
+
+### 1.3 フレームコーデック仕様
+
+CLI の `IpcClient` と同一仕様で実装する（共通 daemon への接続のため仕様は固定）。
+
+| パラメータ | 値 | 根拠 |
+|------------|------|------|
+| バイト順 | little-endian | CLI・daemon 既存仕様に準拠（`tech-stack.md §2.1`） |
+| 長さフィールド長 | 4 バイト | 同上 |
+| 最大フレーム長 | 16 MiB（`MAX_FRAME_LENGTH`） | `shikomi-core::ipc::MAX_FRAME_LENGTH`（DoS 対策） |
+| シリアライズ形式 | MessagePack（`rmp-serde`） | 同上 |
+
+### 1.4 メソッド仕様
+
+#### `connect(socket_path: &Path) → Result<Self, GUIError>`
+
+1. `open_stream(socket_path)` で OS 別ストリームを開く。失敗時は `GUIError::DaemonNotRunning`
+2. `Framed::new(stream, codec())` でフレーマを初期化
+3. `IpcRequest::Handshake { client_version: IpcProtocolVersion::current() }` を `rmp_serde::to_vec` でシリアライズして送信
+4. レスポンス受信 → `rmp_serde::from_slice` でデシリアライズ
+5. `IpcResponse::Handshake { server_version: V2 }` 以外は `GUIError` に変換して返却
+
+#### `round_trip(request: &IpcRequest) → Result<IpcResponse, GUIError>`
+
+1. `rmp_serde::to_vec(request)` でシリアライズ失敗時は `GUIError::Encode`
+2. `framed.send(bytes)` の IO 失敗は `GUIError::ConnectionFailed`
+3. `framed.next()` で受信。`None`（EOF）は `GUIError::ConnectionFailed`
+4. `rmp_serde::from_slice(&bytes)` のデシリアライズ失敗は `GUIError::Decode`
+5. 成功時は `IpcResponse` を返す
+
+### 1.5 ソケットパス解決
+
+`GuiIpcClient::connect()` は呼び出し元（`lib.rs::setup()`）から `socket_path: &Path` を受け取る。パス解決ロジックは `setup()` が担い、`GuiIpcClient` 自体はパス解決を行わない（単一責務）。
+
+パス解決の優先順位（`setup()` 内で実装）：
+
+| 優先度 | パス | 条件 |
+|--------|------|------|
+| 1 | `$SHIKOMI_VAULT_DIR/shikomi.sock`（Unix）/ `\\.\pipe\shikomi`（Windows） | 環境変数 `SHIKOMI_VAULT_DIR` が設定されている場合 |
+| 2 | `$XDG_RUNTIME_DIR/shikomi/shikomi.sock` | Linux / macOS（XDG 準拠） |
+| 3 | `dirs::data_dir()/shikomi/shikomi.sock`（Unix）/ `\\.\pipe\shikomi`（Windows） | フォールバック |
+
+CLI（`IpcVaultRepository::default_socket_path()`）と同一の優先順位に従い、daemon との接続先を一致させる。
+
+---
+
+## 2. `GUIError` 詳細定義
+
+### 2.1 variant 一覧
+
+| variant | フィールド | Serialize 後の `kind` 文字列 | 意味 |
+|---------|-----------|--------------------------|------|
+| `DaemonNotRunning` | なし | `"daemon_not_running"` | UDS / Named Pipe ファイルが存在しない（daemon 未起動） |
+| `ConnectionFailed(String)` | `message: String` | `"connection_failed"` | 接続後の IO エラー（切断含む） |
+| `ProtocolVersionMismatch` | `server: String, client: String` | `"protocol_version_mismatch"` | Handshake バージョン不一致 |
+| `Ipc(IpcErrorCode)` | なし（`IpcErrorCode` の `Display` を `message` に使用） | `"ipc_error"` | daemon 返却 `IpcErrorCode` の透過伝搬 |
+| `Encode(String)` | `message: String` | `"encode_error"` | MessagePack シリアライズ失敗 |
+| `Decode(String)` | `message: String` | `"decode_error"` | MessagePack デシリアライズ失敗 |
+| `UnexpectedResponse(String)` | `message: String` | `"unexpected_response"` | 予期しない `IpcResponse` variant |
+| `InvalidInput(String)` | `message: String` | `"invalid_input"` | Rust 側 input validation 失敗（R1-GUI-19） |
+| `NotConnected` | なし | `"not_connected"` | AppState が `None`（daemon 未接続） |
+
+### 2.2 Serialize 出力仕様
+
+SolidJS 側が `switch` でエラー分岐できるよう、以下の JSON 構造に写像する：
+
+```
+{ "kind": "<上記の kind 文字列>", "message": "<人間可読エラーメッセージ>" }
+```
+
+`IpcErrorCode` の `Display` 実装（`shikomi-core::ipc::error_code`）を `message` フィールドに使用する。
+
+### 2.3 `IpcErrorCode` の透過伝搬
+
+`GUIError::Ipc(IpcErrorCode)` は daemon 側エラーコードを変換せずに SolidJS に届ける。Sub-C（UI 層）は `kind == "ipc_error"` かつ `IpcErrorCode` variant に応じた表示制御を行う。
+
+| `IpcErrorCode` variant | GUI での表示責務（Sub-C 実装） |
+|------------------------|------------------------------|
+| `VaultLocked` | アンロックモーダルを表示（R1-GUI-13） |
+| `HotkeyConflict` | 「競合エントリ名」を表示（R1-GUI-08, UC-GUI-003） |
+| `NotFound { id }` | 「エントリが見つかりません」エラーダイアログ |
+| `Crypto { reason: "wrong-password" }` | 「パスワードが一致しません」を表示（UC-GUI-006） |
+| `BackoffActive { wait_secs }` | Backoff 待ち時間を表示 |
+
+---
+
+## 3. Tauri Commands 詳細仕様
+
+### 3.1 `list_entries`
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | なし |
+| 処理 | AppState から `GuiIpcClient` を取得 → `ListRecords` round_trip → `Records { records, protection_mode }` を返す |
+| 出力 | `{ entries: RecordSummary[], vault_status: ProtectionModeBanner }` |
+| エラー時 | `NotConnected` / `ConnectionFailed` / `Decode` / `Ipc(VaultLocked)` 等 |
+
+### 3.2 `add_entry`
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `kind: RecordKind, label: String, value: String, hotkey: Option<String>` |
+| 処理 | Rust 側 validation（ラベル空文字 → `InvalidInput`、値空文字 → `InvalidInput`）→ `now = OffsetDateTime::now_utc()` 生成 → `AddRecord` round_trip → `Added { id }` |
+| 出力 | `{ id: String }` |
+| エラー時 | `InvalidInput` / `NotConnected` / `Ipc(InvalidLabel)` / `Ipc(HotkeyConflict)` 等 |
+
+**注**: `value: String` は受け取り次第 `SerializableSecretBytes` に変換し、元の `String` は即ドロップする。詳細は §4.1 参照。
+
+### 3.3 `update_entry`
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `id: String, label: Option<String>, value: Option<String>` |
+| 処理 | 全フィールドが `None` かつ変更なし → 即時 `{ id }` 返却（IPC 省略）。それ以外は `EditRecord` round_trip |
+| 出力 | `{ id: String }` |
+| エラー時 | `InvalidInput` / `NotConnected` / `Ipc(NotFound)` / `Ipc(InvalidLabel)` 等 |
+
+### 3.4 `delete_entry`
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `id: String` |
+| 処理 | `RemoveRecord { id: RecordId::try_from_str(id) }` round_trip → `Removed { id }` |
+| 出力 | `{ id: String }` |
+| エラー時 | `NotConnected` / `Ipc(NotFound)` / `InvalidInput`（不正 UUID 形式） |
+
+### 3.5 `assign_hotkey`
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `id: String, combo: String` |
+| 処理 | Rust 側 validation：`combo` が `Ctrl+Alt+[1-9]` 形式以外 → `InvalidInput`。`EditRecord { id, hotkey: Some(combo), clear_hotkey: false, now, label: None, value: None }` round_trip |
+| 出力 | `{ id: String }` |
+| エラー時 | `InvalidInput`（形式違反）/ `Ipc(HotkeyConflict)` / `Ipc(HotkeyParseError)` |
+
+**ホットキー形式検証仕様（Rust 側、R1-GUI-09, R1-GUI-19）**:
+- 正規表現パターン: `^Ctrl\+Alt\+[1-9]$`
+- 一致しない場合は `GUIError::InvalidInput("hotkey must be Ctrl+Alt+[1-9]")` を即返却
+- JS 側セレクタ UI（Sub-C）による事前制限とは独立した独自検証（R1-GUI-19 バイパス対策）
+
+### 3.6 `remove_hotkey`
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `id: String` |
+| 処理 | `EditRecord { id, clear_hotkey: true, hotkey: None, label: None, value: None, now }` round_trip |
+| 出力 | `{ id: String }` |
+| エラー時 | `NotConnected` / `Ipc(NotFound)` |
+
+### 3.7 `get_vault_status`
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | なし |
+| 処理 | `ListRecords` round_trip → `Records { protection_mode, .. }` → `protection_mode` のみ返却 |
+| 出力 | `{ vault_status: ProtectionModeBanner }` |
+| エラー時 | `NotConnected` / `ConnectionFailed` / `Decode` |
+
+### 3.8 `encrypt_vault`
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `master_password: String` |
+| 処理 | `master_password` を `SerializableSecretBytes` に変換後即ドロップ → `Encrypt { master_password, accept_limits: false }` round_trip → `Encrypted { disclosure }` の `disclosure`（Vec of `SerializableSecretBytes`）を `Vec<String>` に変換して返却 |
+| 出力 | `{ disclosure: String[] }` — BIP-39 24 語（R1-GUI-11） |
+| エラー時 | `NotConnected` / `Ipc(Crypto { reason: "weak-password" })` / `Ipc(Crypto { reason: "wrong-password" })` 等 |
+
+**注**: `disclosure` の各語は Rust 側で `String` に変換した後、即 `Vec<String>` として返却する。SolidJS 側での表示後は R1-GUI-18 に従い変数を `null` で上書きする（Sub-C 責務）。
+
+### 3.9 `decrypt_vault`
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `master_password: String, confirmed: bool` |
+| 処理 | Rust 側 validation：`confirmed == false` → `InvalidInput("decrypt confirmation required")` で Fail Fast。`master_password` を `SerializableSecretBytes` に変換後即ドロップ → `Decrypt { master_password, confirmed: true }` round_trip |
+| 出力 | `{}` （成功のみ。UI は `get_vault_status()` で vault 状態を再取得） |
+| エラー時 | `InvalidInput`（`confirmed == false`）/ `Ipc(Crypto { reason: "wrong-password" })` / `NotConnected` |
+
+**`confirmed` の意味論（R1-GUI-12）**: JS 側チェックボックスが `checked == true` の場合のみ `confirmed: true` で本 Command を呼び出す。Rust ハンドラは `confirmed == false` をバイパス試行として即 Fail Fast する。
+
+### 3.10 `unlock_vault`
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `master_password: String` |
+| 処理 | `master_password` を `SerializableSecretBytes` に変換後即ドロップ → `Unlock { master_password, recovery: None }` round_trip → `Unlocked` |
+| 出力 | `{}` |
+| エラー時 | `Ipc(Crypto { reason: "wrong-password" })` / `Ipc(BackoffActive)` / `Ipc(RecoveryRequired)` / `NotConnected` |
+
+---
+
+## 4. 機密情報ライフサイクル（R1-GUI-18 / R1-GUI-19）
+
+### 4.1 JS → Rust 機密情報受け取りフロー
+
+```mermaid
+sequenceDiagram
+    participant JS as SolidJS（DOM ref）
+    participant TC as Tauri Command ハンドラ（Rust）
+    participant IPC as GuiIpcClient
+
+    JS->>TC: invoke("encrypt_vault", { master_password: "..." })
+    Note over TC: master_password: String を受け取り
+    TC->>TC: SerializableSecretBytes::new(SecretBytes::from(master_password))\nmaster_password（String）即ドロップ
+    TC->>IPC: round_trip(Encrypt { master_password: SerializableSecretBytes, ... })
+    Note over IPC: rmp_serde シリアライズ後の元データは SecretBytes::drop() で zeroize
+    IPC-->>TC: IpcResponse::Encrypted { disclosure }
+    TC-->>JS: { disclosure: ["word1", ..., "word24"] }
+```
+
+**Rust ハンドラ側の機密情報取り扱い原則**:
+
+1. `String` パラメータとして受け取ったパスワード等は、最初の処理で `SerializableSecretBytes` に変換する
+2. 元の `String` は変換後に即ドロップされる（Rust の所有権移動でコンパイラが保証）
+3. `SerializableSecretBytes` は Drop 時に内部の `SecretBytes` が `zeroize` を呼ぶ（`shikomi-core::ipc::secret_bytes` の設計継承）
+4. Tauri Command のパラメータログ出力は `tracing` の DEBUG レベル以上に**機密フィールドを含めない**（`master_password` は常にマスク表示またはログ除外）
+
+### 4.2 Rust 側バリデーション仕様（R1-GUI-19）
+
+JS 側バリデーションは `window.__TAURI__.invoke` 直接呼び出しでバイパス可能なため、Rust ハンドラが最終防御線となる。
+
+| 検証対象 | 検証ルール | エラー |
+|---------|------------|--------|
+| `add_entry::label` | 空文字列は拒否 | `InvalidInput("label must not be empty")` |
+| `add_entry::value` | 空文字列は拒否 | `InvalidInput("value must not be empty")` |
+| `assign_hotkey::combo` | `Ctrl+Alt+[1-9]` 形式以外は拒否 | `InvalidInput("hotkey must be Ctrl+Alt+[1-9]")` |
+| `decrypt_vault::confirmed` | `false` は拒否 | `InvalidInput("decrypt confirmation required")` |
+| `delete_entry::id` / `update_entry::id` 等 | `RecordId::try_from_str` 失敗は拒否 | `InvalidInput("invalid record id format")` |
+
+---
+
+## 5. daemon 未接続時 Fail Fast（R1-GUI-02 / R1-GUI-03）
+
+全 Tauri Command の先頭で以下のガードを実行する：
+
+```mermaid
+flowchart TD
+    A["Command 呼び出し"] --> B{"AppState::lock()"}
+    B --> C{"Option<GuiIpcClient>"}
+    C -- "None" --> D["GUIError::NotConnected を即返却\n（IPC 送信なし）"]
+    C -- "Some(client)" --> E["round_trip 実行"]
+    E -- "IO エラー" --> F["GUIError::ConnectionFailed\nAppState を None にリセット"]
+    E -- "正常" --> G["IpcResponse 処理"]
+```
+
+**`AppState::None` へのリセット**:
+
+`round_trip` 中に `ConnectionFailed`（接続切断等）が発生した場合、ハンドラは `AppState` を `None` にリセットする。次回の Command 呼び出しで `NotConnected` を返すことで、切断状態が SolidJS に即通知される（Fail Fast、サイレント再接続なし）。

--- a/docs/features/shikomi-gui/ipc-client/test-design.md
+++ b/docs/features/shikomi-gui/ipc-client/test-design.md
@@ -1,0 +1,429 @@
+# テスト設計書 — ipc-client（shikomi-gui）
+
+<!-- feature: shikomi-gui / sub-feature: ipc-client / Issue #95 -->
+<!-- 配置先: docs/features/shikomi-gui/ipc-client/test-design.md -->
+<!-- システムテストは system-test-design.md に記述。本ファイルは IT + UT のみ -->
+<!-- 参照: basic-design.md §モジュール契約 / detailed-design.md §1〜5 -->
+
+## 0. テスト方針参照
+
+本テスト設計書は `config/prompts/test_strategy.md` に定めるテスト戦略（Vモデル階層化・ダブル方針・CI ワークフロー対応）に準拠する。本ファイルは IT + UT のみを記述し、システムテストは親 `system-test-design.md` に委ねる。
+
+---
+
+## 1. 外部 I/O 依存マップ
+
+| テスト | 外部 I/O | 依存対象 | 対処 | Fixture 状態 |
+|-------|---------|---------|------|------------|
+| IT（接続・Commands） | UDS / Named Pipe（daemon接続） | `tokio::net::UnixStream` / Named Pipe | `MockDaemon`（テスト用UDSサーバー）で差し替え | 要起票（characterization不要：既存CLI IPC仕様と同一フォーマット、raw fixtureはCLI統合テストで管理済み） |
+| IT（接続） | `OffsetDateTime::now_utc()` | 時刻 | テスト実装内で固定 UUID / 固定時刻を使用（Vault ヘルパ経由） | 不要 |
+| UT（validation） | なし | 純粋計算（正規表現・String比較） | モック不要 | 不要 |
+| UT（GUIError Serialize） | `serde_json` | 純粋計算 | モック不要 | 不要 |
+
+> **assumed mock 禁止**: IT 用 `MockDaemon` は `shikomi-core::ipc` の実 MessagePack フォーマットを使用する。
+> fixture 構造は CLI・daemon 間で既に検証済みの仕様に依存するため、別途 characterization task は不要。
+> ただし GUI 側 IPC 型変換（`IpcResponse` → GUI JSON）は IT で実観測を行うこと。
+
+---
+
+## 2. テスト配置方針
+
+| テストレベル | 配置先 | 実行コマンド |
+|------------|--------|------------|
+| UT（validation + Serialize） | `crates/shikomi-gui/src/ipc_client/error.rs` 内 `#[cfg(test)]` | `cargo test -p shikomi-gui` |
+| UT（validation） | `crates/shikomi-gui/src/ipc_client/commands/entries.rs` 内 `#[cfg(test)]` | `cargo test -p shikomi-gui` |
+| UT（validation） | `crates/shikomi-gui/src/ipc_client/commands/hotkey.rs` 内 `#[cfg(test)]` | `cargo test -p shikomi-gui` |
+| UT（validation） | `crates/shikomi-gui/src/ipc_client/commands/vault.rs` 内 `#[cfg(test)]` | `cargo test -p shikomi-gui` |
+| IT（接続 + round_trip） | `crates/shikomi-gui/tests/it_ipc_client.rs` | `cargo test -p shikomi-gui` |
+| IT（Tauri Commands） | `crates/shikomi-gui/tests/it_ipc_commands.rs` | `cargo test -p shikomi-gui` |
+
+---
+
+## 3. テスト用ダブルの方針
+
+### 3.1 `MockDaemon`
+
+IT 専用テスト用 UDS サーバー。`tests/common/mock_daemon.rs` に物理分離して配置する（本番コードへの混入禁止）。
+
+| 項目 | 仕様 |
+|------|------|
+| 実装 | `tokio` 非同期タスク。`tempfile::TempDir` で一時ソケットパスを生成 |
+| 接続受付 | 1 接続のみ受け付け、Handshake を処理後に事前設定レスポンスを返す |
+| フレームコーデック | `basic-design.md §1.3` と同一（little-endian 4バイト長 / MessagePack） |
+| 設定 | `MockDaemon::new(response: IpcResponse)` で返却レスポンスを 1 件設定 |
+| 返却方法 | Handshake 受信後、最初の `IpcRequest` に対して設定済み `IpcResponse` を返して終了 |
+
+### 3.2 `AppState` の直接構築
+
+Tauri Command ハンドラは `tauri::State<AppState>` を受け取る。テストでは `AppState`（`Arc<Mutex<Option<GuiIpcClient>>>`）を直接構築してハンドラに渡す。
+
+| パターン | 構築方法 |
+|---------|---------|
+| daemon 接続済み | `Arc::new(tokio::sync::Mutex::new(Some(client)))` |
+| daemon 未接続（Fail Fast検証） | `Arc::new(tokio::sync::Mutex::new(None))` |
+
+---
+
+## 4. テストマトリクス（トレーサビリティ）
+
+### 4.1 ユニットテスト
+
+| テスト ID | REQ-IPC | 設計根拠 | テスト内容 | 種別 |
+|---------|---------|--------|----------|------|
+| TC-GUI-IPC-UT01 | REQ-IPC-02 | `detailed-design.md §4.2` | `add_entry` — ラベル空文字 → `GUIError::InvalidInput("label must not be empty")` | 異常系 |
+| TC-GUI-IPC-UT02 | REQ-IPC-02 | `detailed-design.md §4.2` | `add_entry` — 値空文字 → `GUIError::InvalidInput("value must not be empty")` | 異常系 |
+| TC-GUI-IPC-UT03 | REQ-IPC-05 | `detailed-design.md §3.5` | `assign_hotkey` — `Ctrl+Alt+0`（1-9 範囲外）→ `GUIError::InvalidInput("hotkey must be Ctrl+Alt+[1-9]")` | 異常系（境界値） |
+| TC-GUI-IPC-UT04 | REQ-IPC-05 | `detailed-design.md §3.5` | `assign_hotkey` — `ctrl+alt+1`（小文字）→ `GUIError::InvalidInput` | 異常系 |
+| TC-GUI-IPC-UT05 | REQ-IPC-05 | `detailed-design.md §3.5` | `assign_hotkey` — `Ctrl+Alt+1`（正常最小値）→ validation PASS | 正常系（境界値） |
+| TC-GUI-IPC-UT06 | REQ-IPC-05 | `detailed-design.md §3.5` | `assign_hotkey` — `Ctrl+Alt+9`（正常最大値）→ validation PASS | 正常系（境界値） |
+| TC-GUI-IPC-UT07 | REQ-IPC-09 | `detailed-design.md §3.9` | `decrypt_vault` — `confirmed: false` → `GUIError::InvalidInput("decrypt confirmation required")` | 異常系 |
+| TC-GUI-IPC-UT08 | REQ-IPC-04 | `detailed-design.md §4.2` | `delete_entry` — 不正 UUID 文字列 → `GUIError::InvalidInput("invalid record id format")` | 異常系 |
+| TC-GUI-IPC-UT09 | REQ-IPC-03 | `detailed-design.md §3.3` | `update_entry` — `label: None, value: None`（全フィールド `None`）→ IPC 送信省略、即時 `Edited { id }` 返却 | 正常系 |
+| TC-GUI-IPC-UT10 | `basic-design.md §2.2` | `detailed-design.md §2.1` | `GUIError::DaemonNotRunning` を `serde_json::to_value` → `kind == "daemon_not_running"` | 正常系 |
+| TC-GUI-IPC-UT11 | `basic-design.md §2.2` | `detailed-design.md §2.1` | `GUIError::NotConnected` → `kind == "not_connected"` | 正常系 |
+| TC-GUI-IPC-UT12 | `basic-design.md §2.2` | `detailed-design.md §2.1` | `GUIError::ProtocolVersionMismatch { server: "V1", client: "V2" }` → `kind == "protocol_version_mismatch"` | 正常系 |
+| TC-GUI-IPC-UT13 | `basic-design.md §2.2` | `detailed-design.md §2.3` | `GUIError::Ipc(IpcErrorCode::VaultLocked)` → `kind == "ipc_error"`、`message` に `IpcErrorCode::VaultLocked` の `Display` 文字列 | 正常系 |
+| TC-GUI-IPC-UT14 | `basic-design.md §2.2` | `detailed-design.md §2.2` | `GUIError::InvalidInput("test message")` → `kind == "invalid_input"`, `message == "test message"` | 正常系 |
+
+### 4.2 結合テスト
+
+| テスト ID | REQ-IPC | 設計根拠 | テスト内容 | 種別 |
+|---------|---------|--------|----------|------|
+| TC-GUI-IPC-IT01 | REQ-IPC-11 | `detailed-design.md §1.4` | `GuiIpcClient::connect()` — ソケットファイル不存在 → `GUIError::DaemonNotRunning` | 異常系 |
+| TC-GUI-IPC-IT02 | REQ-IPC-11 | `detailed-design.md §1.2` | `GuiIpcClient::connect()` — MockDaemon が V2 Handshake 成功 → `Ok(GuiIpcClient)` | 正常系 |
+| TC-GUI-IPC-IT03 | REQ-IPC-11 | `detailed-design.md §1.2` | `GuiIpcClient::connect()` — MockDaemon が `IpcResponse::Handshake { server_version: V1 }` → `GUIError::ProtocolVersionMismatch` | 異常系 |
+| TC-GUI-IPC-IT04 | REQ-IPC-12 | `basic-design.md §2.4` / `detailed-design.md §5` | `AppState = None` で `list_entries` 呼び出し → `GUIError::NotConnected`（IPC 送信なし） | 異常系（Fail Fast） |
+| TC-GUI-IPC-IT05 | REQ-IPC-12 | `detailed-design.md §5` | `AppState = None` で `add_entry` 呼び出し → `GUIError::NotConnected` | 異常系（Fail Fast） |
+| TC-GUI-IPC-IT06 | REQ-IPC-01 | `detailed-design.md §3.1` | `list_entries` — MockDaemon `IpcResponse::Records { records, protection_mode }` → `{ entries, vault_status }` が返る | 正常系 |
+| TC-GUI-IPC-IT07 | REQ-IPC-02 | `detailed-design.md §3.2` | `add_entry` 正常系 — MockDaemon `IpcResponse::Added { id }` → `{ id }` が返る | 正常系 |
+| TC-GUI-IPC-IT08 | REQ-IPC-02 | `detailed-design.md §3.2` | `add_entry` — MockDaemon `IpcResponse::Error(IpcErrorCode::HotkeyConflict)` → `GUIError::Ipc(HotkeyConflict)` | 異常系 |
+| TC-GUI-IPC-IT09 | REQ-IPC-03 | `detailed-design.md §3.3` | `update_entry` — MockDaemon `IpcResponse::Edited { id }` → `{ id }` が返る | 正常系 |
+| TC-GUI-IPC-IT10 | REQ-IPC-04 | `detailed-design.md §3.4` | `delete_entry` 正常系 — MockDaemon `IpcResponse::Removed { id }` → `{ id }` が返る | 正常系 |
+| TC-GUI-IPC-IT11 | REQ-IPC-05 | `detailed-design.md §3.5` | `assign_hotkey` `Ctrl+Alt+3` 正常系 — MockDaemon `IpcResponse::Edited { id }` → `{ id }` が返る | 正常系 |
+| TC-GUI-IPC-IT12 | REQ-IPC-05 | `detailed-design.md §3.5` | `assign_hotkey` — MockDaemon `IpcResponse::Error(HotkeyConflict)` → `GUIError::Ipc(HotkeyConflict)` | 異常系 |
+| TC-GUI-IPC-IT13 | REQ-IPC-06 | `detailed-design.md §3.6` | `remove_hotkey` — MockDaemon `IpcResponse::Edited { id }` → `{ id }` が返る | 正常系 |
+| TC-GUI-IPC-IT14 | REQ-IPC-07 | `detailed-design.md §3.7` | `get_vault_status` — MockDaemon `IpcResponse::Records { protection_mode: Encrypted, records: [] }` → `{ vault_status: Encrypted }` のみ返る（records は含まれない） | 正常系 |
+| TC-GUI-IPC-IT15 | REQ-IPC-08 | `detailed-design.md §3.8` | `encrypt_vault` — MockDaemon `IpcResponse::Encrypted { disclosure: [24語] }` → `{ disclosure: Vec<String> }` 24 件 | 正常系 |
+| TC-GUI-IPC-IT16 | REQ-IPC-09 | `detailed-design.md §3.9` | `decrypt_vault` `confirmed: true` — MockDaemon `IpcResponse::Decrypted` → `{}` 成功 | 正常系 |
+| TC-GUI-IPC-IT17 | REQ-IPC-10 | `detailed-design.md §3.10` | `unlock_vault` — MockDaemon `IpcResponse::Unlocked` → `{}` 成功 | 正常系 |
+| TC-GUI-IPC-IT18 | REQ-IPC-11, REQ-IPC-12 | `detailed-design.md §5` | `round_trip` 中に MockDaemon が接続を強制切断 → `GUIError::ConnectionFailed`、`AppState` が `None` にリセットされる | 異常系（切断復旧） |
+
+---
+
+## 5. ユニットテスト詳細設計
+
+### TC-GUI-IPC-UT01: `add_entry` — ラベル空文字
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-UT01 |
+| 対応する要件ID | REQ-IPC-02（R1-GUI-05, R1-GUI-19） |
+| 対応する工程 | 階層 3 詳細設計（`detailed-design.md §4.2`） |
+| 種別 | 異常系 |
+| 前提条件 | `AppState = Some(client)`（Validation は IPC 送信前に実行される） |
+| 操作 | `add_entry(state, kind=Text, label="", value="hello", hotkey=None)` |
+| 期待結果 | `Err(GUIError::InvalidInput("label must not be empty"))` が返る。IPC 送信は行われない |
+
+### TC-GUI-IPC-UT02: `add_entry` — 値空文字
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-UT02 |
+| 対応する要件ID | REQ-IPC-02（R1-GUI-19） |
+| 対応する工程 | 階層 3 詳細設計（`detailed-design.md §4.2`） |
+| 種別 | 異常系 |
+| 前提条件 | `AppState = Some(client)` |
+| 操作 | `add_entry(state, kind=Text, label="my label", value="", hotkey=None)` |
+| 期待結果 | `Err(GUIError::InvalidInput("value must not be empty"))` |
+
+### TC-GUI-IPC-UT03〜UT06: `assign_hotkey` — ホットキー形式検証
+
+| テスト ID | 入力 combo | 期待結果 | 種別 |
+|---------|----------|---------|------|
+| TC-GUI-IPC-UT03 | `"Ctrl+Alt+0"` | `Err(GUIError::InvalidInput("hotkey must be Ctrl+Alt+[1-9]"))` | 異常系（境界値） |
+| TC-GUI-IPC-UT04 | `"ctrl+alt+1"` | `Err(GUIError::InvalidInput("hotkey must be Ctrl+Alt+[1-9]"))` | 異常系（大文字小文字） |
+| TC-GUI-IPC-UT05 | `"Ctrl+Alt+1"` | 検証通過（`Ok` または IPC 送信ステップへ進む） | 正常系（最小境界値） |
+| TC-GUI-IPC-UT06 | `"Ctrl+Alt+9"` | 検証通過 | 正常系（最大境界値） |
+
+**前提条件**: 検証のみを単体で呼ぶ。`AppState` は未使用（validation 層のみテスト）
+**操作**: `validate_hotkey_combo(combo)` または相当するヘルパ関数を直接呼び出す
+
+### TC-GUI-IPC-UT07: `decrypt_vault` — `confirmed: false` Fail Fast
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-UT07 |
+| 対応する要件ID | REQ-IPC-09（R1-GUI-12, R1-GUI-19） |
+| 対応する工程 | 階層 3 詳細設計（`detailed-design.md §3.9`） |
+| 種別 | 異常系 |
+| 前提条件 | `AppState = Some(client)` |
+| 操作 | `decrypt_vault(state, master_password="correct", confirmed=false)` |
+| 期待結果 | `Err(GUIError::InvalidInput("decrypt confirmation required"))` が返る。IPC 送信は行われない |
+
+### TC-GUI-IPC-UT08: `delete_entry` — 不正 UUID
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-UT08 |
+| 対応する要件ID | REQ-IPC-04（`detailed-design.md §4.2`） |
+| 対応する工程 | 階層 3 詳細設計 |
+| 種別 | 異常系 |
+| 操作 | `delete_entry(state, id="not-a-uuid")` |
+| 期待結果 | `Err(GUIError::InvalidInput("invalid record id format"))` |
+
+### TC-GUI-IPC-UT09: `update_entry` — 全フィールド `None`（IPC 省略）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-UT09 |
+| 対応する要件ID | REQ-IPC-03（`detailed-design.md §3.3`） |
+| 対応する工程 | 階層 3 詳細設計 |
+| 種別 | 正常系（IPC 省略経路） |
+| 前提条件 | `AppState = Some(client)`（IPC は呼ばれないはずだが、AppState は接続済みで準備） |
+| 操作 | `update_entry(state, id=valid_uuid, label=None, value=None)` |
+| 期待結果 | `Ok({ id: valid_uuid })` が返る。MockDaemon への IPC リクエストは 0 件 |
+
+### TC-GUI-IPC-UT10〜UT14: `GUIError` Serialize 検証
+
+| テスト ID | 入力 GUIError | 期待 `kind` | 期待 `message` | 種別 |
+|---------|-------------|-----------|--------------|------|
+| TC-GUI-IPC-UT10 | `GUIError::DaemonNotRunning` | `"daemon_not_running"` | 非空文字列 | 正常系 |
+| TC-GUI-IPC-UT11 | `GUIError::NotConnected` | `"not_connected"` | 非空文字列 | 正常系 |
+| TC-GUI-IPC-UT12 | `GUIError::ProtocolVersionMismatch { server: "V1", client: "V2" }` | `"protocol_version_mismatch"` | `"V1"` / `"V2"` 両方含む | 正常系 |
+| TC-GUI-IPC-UT13 | `GUIError::Ipc(IpcErrorCode::VaultLocked)` | `"ipc_error"` | `IpcErrorCode::VaultLocked` の Display 文字列と一致 | 正常系 |
+| TC-GUI-IPC-UT14 | `GUIError::InvalidInput("test message")` | `"invalid_input"` | `"test message"` と完全一致 | 正常系 |
+
+**操作共通**: `serde_json::to_value(&error).unwrap()` で JSON 変換し、`["kind"]` / `["message"]` フィールドを assert する
+
+---
+
+## 6. 結合テスト詳細設計
+
+### TC-GUI-IPC-IT01: `connect()` — daemon 未起動（ソケット不存在）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT01 |
+| 対応する要件ID | REQ-IPC-11（R1-GUI-02） |
+| 対応する工程 | 階層 3 基本設計（`detailed-design.md §1.4`） |
+| 種別 | 異常系 |
+| 前提条件 | ソケットファイルが存在しないパスを用意（`TempDir` の未作成ファイルパス） |
+| 操作 | `GuiIpcClient::connect(&non_existent_path).await` |
+| 期待結果 | `Err(GUIError::DaemonNotRunning)` が返る |
+
+### TC-GUI-IPC-IT02: `connect()` — V2 Handshake 成功
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT02 |
+| 対応する要件ID | REQ-IPC-11（R1-GUI-02） |
+| 対応する工程 | 階層 3 基本設計（`detailed-design.md §1.2`） |
+| 種別 | 正常系 |
+| 前提条件 | `MockDaemon` を起動（V2 Handshake を正常処理） |
+| 操作 | `GuiIpcClient::connect(&socket_path).await` |
+| 期待結果 | `Ok(GuiIpcClient)` が返る。接続済み状態に遷移 |
+
+### TC-GUI-IPC-IT03: `connect()` — プロトコルバージョン不一致
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT03 |
+| 対応する要件ID | REQ-IPC-11（R1-GUI-02） |
+| 対応する工程 | 階層 3 基本設計（`detailed-design.md §1.2`） |
+| 種別 | 異常系 |
+| 前提条件 | `MockDaemon` が Handshake に `server_version: V1`（仮の古いバージョン）を返すよう設定 |
+| 操作 | `GuiIpcClient::connect(&socket_path).await` |
+| 期待結果 | `Err(GUIError::ProtocolVersionMismatch { server: "V1", client: "V2" })` |
+
+### TC-GUI-IPC-IT04〜IT05: daemon 未接続 Fail Fast（REQ-IPC-12）
+
+| テスト ID | 呼び出す Command | 期待結果 |
+|---------|--------------|---------|
+| TC-GUI-IPC-IT04 | `list_entries` | `Err(GUIError::NotConnected)` |
+| TC-GUI-IPC-IT05 | `add_entry` (label/value 非空) | `Err(GUIError::NotConnected)` |
+
+**前提条件**: `AppState = Arc::new(Mutex::new(None))`（未接続状態）
+**操作**: 各 Command ハンドラを直接呼び出す
+**期待結果共通**: IPC 送信は発生しない（MockDaemon はリクエストを受け取らない）
+
+> 全 10 Commands は同一ガードロジックを経由するため、TC-IT04〜IT05 の 2 件で代表検証する。
+> 全件を個別に実行する場合は実装担当と調整のこと。
+
+### TC-GUI-IPC-IT06: `list_entries` 正常系
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT06 |
+| 対応する要件ID | REQ-IPC-01（R1-GUI-04） |
+| 対応する工程 | 階層 3 基本設計（`detailed-design.md §3.1`） |
+| 種別 | 正常系 |
+| 前提条件 | `AppState = Some(client)`、MockDaemon が `IpcResponse::Records { records: [1件], protection_mode: Plaintext }` を返す |
+| 操作 | `list_entries(state).await` |
+| 期待結果 | `Ok({ entries: [1件], vault_status: Plaintext })` が返る |
+
+### TC-GUI-IPC-IT07: `add_entry` 正常系
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT07 |
+| 対応する要件ID | REQ-IPC-02（R1-GUI-05） |
+| 対応する工程 | 階層 3 基本設計（`detailed-design.md §3.2`） |
+| 種別 | 正常系 |
+| 前提条件 | MockDaemon が `IpcResponse::Added { id: some_uuid }` を返す |
+| 操作 | `add_entry(state, kind=Text, label="my label", value="hello", hotkey=None).await` |
+| 期待結果 | `Ok({ id: some_uuid })` が返る |
+
+### TC-GUI-IPC-IT08: `add_entry` — daemon が HotkeyConflict を返す
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT08 |
+| 対応する要件ID | REQ-IPC-02（`detailed-design.md §2.3`） |
+| 対応する工程 | 階層 3 基本設計 |
+| 種別 | 異常系 |
+| 前提条件 | MockDaemon が `IpcResponse::Error(IpcErrorCode::HotkeyConflict { combo, conflicting_label })` を返す |
+| 操作 | `add_entry(state, kind=Text, label="new", value="v", hotkey=Some("Ctrl+Alt+1")).await` |
+| 期待結果 | `Err(GUIError::Ipc(IpcErrorCode::HotkeyConflict { .. }))` が返る |
+
+### TC-GUI-IPC-IT09: `update_entry` 正常系
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT09 |
+| 対応する要件ID | REQ-IPC-03（R1-GUI-06） |
+| 操作 | `update_entry(state, id=valid_uuid, label=Some("new label"), value=None).await` |
+| 期待結果 | MockDaemon が `Edited { id }` を返す → `Ok({ id })` |
+
+### TC-GUI-IPC-IT10: `delete_entry` 正常系
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT10 |
+| 対応する要件ID | REQ-IPC-04（R1-GUI-07） |
+| 操作 | `delete_entry(state, id=valid_uuid).await` |
+| 期待結果 | MockDaemon が `Removed { id }` を返す → `Ok({ id })` |
+
+### TC-GUI-IPC-IT11: `assign_hotkey` 正常系
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT11 |
+| 対応する要件ID | REQ-IPC-05（R1-GUI-08, R1-GUI-09） |
+| 操作 | `assign_hotkey(state, id=valid_uuid, combo="Ctrl+Alt+3").await` |
+| 期待結果 | MockDaemon が `Edited { id }` を返す → `Ok({ id })`。daemon 送信リクエストの `hotkey == Some("Ctrl+Alt+3")`, `clear_hotkey == false` |
+
+### TC-GUI-IPC-IT12: `assign_hotkey` — HotkeyConflict
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT12 |
+| 対応する要件ID | REQ-IPC-05（`detailed-design.md §2.3`） |
+| 操作 | `assign_hotkey(state, id=valid_uuid, combo="Ctrl+Alt+5").await`、MockDaemon が `Error(HotkeyConflict)` 返却 |
+| 期待結果 | `Err(GUIError::Ipc(IpcErrorCode::HotkeyConflict { .. }))` |
+
+### TC-GUI-IPC-IT13: `remove_hotkey` 正常系
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT13 |
+| 対応する要件ID | REQ-IPC-06（R1-GUI-08） |
+| 操作 | `remove_hotkey(state, id=valid_uuid).await` |
+| 期待結果 | MockDaemon が `Edited { id }` を返す → `Ok({ id })`。送信リクエストの `clear_hotkey == true` |
+
+### TC-GUI-IPC-IT14: `get_vault_status` — `protection_mode` のみ返却
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT14 |
+| 対応する要件ID | REQ-IPC-07（R1-GUI-04, R1-GUI-13） |
+| 対応する工程 | 階層 3 基本設計（`detailed-design.md §3.7`） |
+| 種別 | 正常系 |
+| 前提条件 | MockDaemon が `IpcResponse::Records { records: [2件], protection_mode: Encrypted }` を返す |
+| 操作 | `get_vault_status(state).await` |
+| 期待結果 | `Ok({ vault_status: Encrypted })` が返る。`entries` フィールドは含まれない（R1-GUI-13：vault 状態のみ返却） |
+
+### TC-GUI-IPC-IT15: `encrypt_vault` — disclosure 24 語
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT15 |
+| 対応する要件ID | REQ-IPC-08（R1-GUI-10, R1-GUI-11） |
+| 前提条件 | MockDaemon が `IpcResponse::Encrypted { disclosure: [24語分のバイト列] }` を返す |
+| 操作 | `encrypt_vault(state, master_password="StrongPass123!").await` |
+| 期待結果 | `Ok({ disclosure: Vec<String> })` が返り、`disclosure.len() == 24` |
+
+### TC-GUI-IPC-IT16: `decrypt_vault` — confirmed=true 正常系
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT16 |
+| 対応する要件ID | REQ-IPC-09（R1-GUI-12） |
+| 前提条件 | MockDaemon が `IpcResponse::Decrypted` を返す |
+| 操作 | `decrypt_vault(state, master_password="correct", confirmed=true).await` |
+| 期待結果 | `Ok({})` が返る |
+
+### TC-GUI-IPC-IT17: `unlock_vault` 正常系
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT17 |
+| 対応する要件ID | REQ-IPC-10（R1-GUI-13） |
+| 前提条件 | MockDaemon が `IpcResponse::Unlocked` を返す |
+| 操作 | `unlock_vault(state, master_password="correct").await` |
+| 期待結果 | `Ok({})` が返る。送信リクエストの `recovery == None` |
+
+### TC-GUI-IPC-IT18: IO 切断 → AppState が None にリセット
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-GUI-IPC-IT18 |
+| 対応する要件ID | REQ-IPC-11, REQ-IPC-12（`detailed-design.md §5`） |
+| 対応する工程 | 階層 3 基本設計（`detailed-design.md §1.4 round_trip`） |
+| 種別 | 異常系（切断復旧） |
+| 前提条件 | `AppState = Some(client)` 接続済み。MockDaemon が `round_trip` 中に接続を強制切断 |
+| 操作 | 任意の Command（例: `list_entries(state).await`） |
+| 期待結果 | `Err(GUIError::ConnectionFailed("..."))` が返る。呼び出し後に `AppState.lock() == None`（リセット確認） |
+
+---
+
+## 7. モック方針まとめ
+
+| テスト対象 | モック要否 | 実装方法 |
+|----------|---------|---------|
+| UDS / Named Pipe（daemon接続） | **IT で差し替え** | `MockDaemon`（tokio UDS）を `tests/common/mock_daemon.rs` に配置 |
+| `OffsetDateTime::now_utc()` | **差し替え不要** | Tauri Command 内部で生成。テストは ID とレスポンス一致を確認 |
+| MessagePack エンコード/デコード | **差し替え不要** | 純粋計算。実 `rmp-serde` を通す |
+| `AppState` | **UT は不要、IT は直接構築** | `Arc::new(Mutex::new(Some(client)))` / `None` で構築 |
+
+**assumed mock 禁止**: `MockDaemon` が返す `IpcResponse` は `shikomi-core::ipc` の実型を使い、実 MessagePack でシリアライズして送信すること。インライン辞書リテラルや手動バイト列の使用は却下対象。
+
+---
+
+## 8. CI ワークフロー対応
+
+| テスト | ワークフロー | 備考 |
+|-------|------------|------|
+| TC-GUI-IPC-UT01〜UT14 | `lint.yml` + 新設 `test-gui.yml` | UDS 不使用のためヘッドレス OK |
+| TC-GUI-IPC-IT01〜IT18 | 新設 `test-gui.yml` | tempfile + UDS 使用。Linux/macOS で実行 |
+| Windows IT | `windows.yml`（拡張要）| Named Pipe 経路で TC-GUI-IPC-IT01〜IT05 相当を実行（UDS → Named Pipe 切り替え） |
+
+> **`test-gui.yml` 新設要**: `shikomi-gui` 用 CI ワークフローが Sub-A では存在しない。
+> Sub-B 実装時に `cargo test -p shikomi-gui` を実行するワークフローを追加すること。
+> Tauri ビルド（バイナリビルド）は不要。Rust ライブラリ単体の `cargo test` で十分。
+
+---
+
+## 9. カバレッジ基準
+
+| 観点 | 基準 |
+|------|------|
+| REQ-IPC 全件網羅 | REQ-IPC-01〜12 全件が IT または UT でカバーされること |
+| 正常系 | 全 Command の正常経路（IT）必須 |
+| 異常系 | Fail Fast（NotConnected）、validation 失敗（InvalidInput）、daemon エラー透過伝搬（Ipc）を網羅 |
+| 境界値 | `Ctrl+Alt+1`（最小）、`Ctrl+Alt+9`（最大）、`Ctrl+Alt+0`（範囲外）を必ず含む |
+| Serialize | `GUIError` 全 variant（9 種）のうち IT で直接現れない variant は UT で補完すること |
+
+---
+
+*作成: 涅マユリ（テスト担当）/ 2026-05-11*
+*設計根拠: `docs/features/shikomi-gui/ipc-client/basic-design.md` §モジュール契約 / `detailed-design.md` §1〜5 / Issue #95*


### PR DESCRIPTION
## 概要

Issue #95（Sub-B）の設計書を新規作成。`docs/features/shikomi-gui/ipc-client/` に2ファイルを追加。

Closes #95（設計フェーズ）

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `ipc-client/basic-design.md` | §モジュール契約（REQ-IPC-01〜12）/ GuiIpcClient・GUIError・10本のTauri Commands一覧 / R1-GUI→REQ-IPCトレーサビリティ |
| `ipc-client/detailed-design.md` | GuiIpcClient接続フロー・フレームコーデック仕様・ソケットパス解決 / GUIError全variant・Serialize仕様 / 10 Tauri Commands詳細（入力/処理/出力/エラー時）/ 機密情報ライフサイクル（R1-GUI-18/19）/ daemon未接続Fail Fast |

## 設計根拠

- `docs/features/shikomi-gui/feature-spec.md`（凍結済み）R1-GUI-02〜19 を参照
- `docs/architecture/tech-stack.md §2.6`（Tauri Commands 設計規約）と整合
- `docs/architecture/context/threat-model.md §7.3`（WebView STRIDE 補足）と整合
- `shikomi-core::ipc` の `IpcRequest` / `IpcResponse` / `IpcErrorCode` を DRY 再利用

## スコープ（Sub-B 設計書のみ）

| 含む | 含まない |
|------|---------|
| basic-design.md / detailed-design.md | 実装（Issue #95 本体） |
| 10本の Tauri Commands 仕様 | test-design.md（テスト担当スコープ） |
| GuiIpcClient・GUIError 詳細定義 | UI コンポーネント（Sub-C） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)