### PR TITLE
feat(shikomi-gui): Sub-D — system-tray 実装（Issue #97）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,6 +2365,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2382,16 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -3070,6 +3098,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "open"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3083,6 +3123,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3149,6 +3199,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -4090,6 +4146,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shikomi-cli"
 version = "0.1.0"
 dependencies = [
@@ -4184,6 +4251,7 @@ dependencies = [
  "shikomi-infra",
  "tauri",
  "tauri-build",
+ "tauri-plugin-shell",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -4231,6 +4299,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4599,6 +4688,43 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eefb2c18e8a605c23edb48fc56bb77381199e1a1e7f6ff0c9b970afe7b3cb8ee"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -5876,6 +6002,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5922,11 +6057,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5966,6 +6118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5982,6 +6140,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6002,10 +6166,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6026,6 +6202,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6042,6 +6224,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6062,6 +6250,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6078,6 +6272,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/shikomi-core/src/ipc/request.rs
+++ b/crates/shikomi-core/src/ipc/request.rs
@@ -131,6 +131,13 @@ pub enum IpcRequest {
         /// 大文字一致を確認済の証跡。`false` の場合 daemon は受理拒否)。
         confirmed: bool,
     },
+
+    // ---------------- Sub-D (#97) システムトレイ ----------------
+    /// **V2 only (Sub-D)**: クリップボード自動消去カウントダウン残秒を問い合わせる。
+    ///
+    /// GUI カウントダウンタスクが 1 秒ポーリングで呼び出す。
+    /// daemon は `countdown_started_at` から残秒を計算して `ClipboardStatus` で返す。
+    GetClipboardStatus,
 }
 
 impl IpcRequest {
@@ -150,6 +157,7 @@ impl IpcRequest {
             Self::Rekey { .. } => "rekey",
             Self::Encrypt { .. } => "encrypt",
             Self::Decrypt { .. } => "decrypt",
+            Self::GetClipboardStatus => "get_clipboard_status",
         }
     }
 
@@ -167,6 +175,7 @@ impl IpcRequest {
                 | Self::Rekey { .. }
                 | Self::Encrypt { .. }
                 | Self::Decrypt { .. }
+                | Self::GetClipboardStatus
         )
     }
 }

--- a/crates/shikomi-core/src/ipc/response.rs
+++ b/crates/shikomi-core/src/ipc/response.rs
@@ -120,6 +120,16 @@ pub enum IpcResponse {
     /// **V2 (Sub-F)**: `vault decrypt` 成功 (Sub-F §F-F2)。
     /// 暗号化 vault → 平文 vault 戻し完了。VEK / 24 語は IPC に乗らない。
     Decrypted,
+
+    // ---------------- Sub-D (#97) システムトレイ ----------------
+    /// **V2 (Sub-D)**: `GetClipboardStatus` への応答。
+    ///
+    /// - `Some(n)`: 残 n 秒でカウントダウン中
+    /// - `None`: カウントダウン非アクティブ（投入なし or タイマー発火済み）
+    ClipboardStatus {
+        /// クリップボード自動消去までの残秒。`None` は非アクティブ。
+        remaining_secs: Option<u64>,
+    },
 }
 
 impl IpcResponse {
@@ -141,6 +151,7 @@ impl IpcResponse {
             Self::Rekeyed { .. } => "rekeyed",
             Self::Encrypted { .. } => "encrypted",
             Self::Decrypted => "decrypted",
+            Self::ClipboardStatus { .. } => "clipboard_status",
         }
     }
 }

--- a/crates/shikomi-daemon/src/hotkey/event_loop.rs
+++ b/crates/shikomi-daemon/src/hotkey/event_loop.rs
@@ -10,7 +10,7 @@
 //! 詳細: `docs/features/daemon-hotkey-clipboard/daemon/detailed-design.md §4.1.5`
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use futures_util::StreamExt;
 use shikomi_core::{Hotkey, RecordKind, CLEAR_TIMEOUT_SECS};
@@ -37,18 +37,25 @@ pub struct HotkeyEventLoop {
     clipboard: Arc<Mutex<dyn ClipboardWriter + Send>>,
     notifier: Arc<dyn Notifier>,
     clear_timer: ClearTimer,
+    /// クリップボード投入開始時刻。GUI カウントダウン表示用（Sub-D #97）。
+    ///
+    /// `Some(t)`: 残秒計算の基点。`None`: カウントダウン非アクティブ。
+    /// `Arc<Mutex<...>>` で `IpcServer` の `V2Context` と共有する。
+    countdown_started_at: Arc<Mutex<Option<Instant>>>,
 }
 
 impl HotkeyEventLoop {
     /// `HotkeyEventLoop` を構築する。
     ///
     /// `clipboard`: `SHIKOMI_DISABLE_CLIPBOARD=1` の場合 `NullClipboardWriter` を渡す。
+    /// `countdown_started_at`: GUI カウントダウン表示用の共有状態（`IpcServer` と共有）。
     pub fn new(
         backend: Arc<BackendEnum>,
         vault: Arc<Mutex<Vault>>,
         vek_cache: VekCache,
         clipboard: Arc<Mutex<dyn ClipboardWriter + Send>>,
         notifier: Arc<dyn Notifier>,
+        countdown_started_at: Arc<Mutex<Option<Instant>>>,
     ) -> Self {
         Self {
             backend,
@@ -57,6 +64,7 @@ impl HotkeyEventLoop {
             clipboard,
             notifier,
             clear_timer: ClearTimer::new(),
+            countdown_started_at,
         }
     }
 
@@ -73,6 +81,7 @@ impl HotkeyEventLoop {
                     let _ = changed;
                     tracing::debug!("HotkeyEventLoop: shutdown received");
                     self.clear_timer.abort();
+                    *self.countdown_started_at.lock().await = None;
                     return;
                 }
                 event = stream.next() => {
@@ -196,6 +205,8 @@ impl HotkeyEventLoop {
 
                 // --- Step 7: Secret レコードは ClearTimer をスケジュール ---
                 if matches!(record_kind, RecordKind::Secret) {
+                    // GUI カウントダウン用の投入時刻を記録（Sub-D #97）。
+                    *self.countdown_started_at.lock().await = Some(Instant::now());
                     self.clear_timer.schedule(
                         Duration::from_secs(CLEAR_TIMEOUT_SECS),
                         Arc::clone(&self.clipboard),

--- a/crates/shikomi-daemon/src/ipc/server.rs
+++ b/crates/shikomi-daemon/src/ipc/server.rs
@@ -1,7 +1,7 @@
 //! IpcServer — listener / accept ループ / 接続ごとのタスク管理。
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
@@ -45,6 +45,8 @@ pub struct IpcServer {
     backoff: Arc<Mutex<UnlockBackoff>>,
     /// Issue #89: OS ホットキー登録管理（IPC add/edit ハンドラが使用）。
     hotkey_manager: Arc<HotkeyManager>,
+    /// Sub-D (#97): クリップボード自動消去カウントダウン基点時刻（HotkeyEventLoop と共有）。
+    countdown_started_at: Arc<Mutex<Option<Instant>>>,
 }
 
 impl IpcServer {
@@ -57,6 +59,7 @@ impl IpcServer {
         cache: VekCache,
         backoff: Arc<Mutex<UnlockBackoff>>,
         hotkey_manager: Arc<HotkeyManager>,
+        countdown_started_at: Arc<Mutex<Option<Instant>>>,
     ) -> Self {
         Self {
             listener: Some(listener),
@@ -65,6 +68,7 @@ impl IpcServer {
             cache,
             backoff,
             hotkey_manager,
+            countdown_started_at,
         }
     }
 
@@ -181,9 +185,10 @@ impl IpcServer {
                     let cache = self.cache.clone();
                     let backoff = Arc::clone(&self.backoff);
                     let hotkey_manager = Arc::clone(&self.hotkey_manager);
+                    let countdown_started_at = Arc::clone(&self.countdown_started_at);
                     let shutdown_for_task = shutdown.clone();
                     connections.spawn(async move {
-                        handle_connection(stream, repo, vault, cache, backoff, hotkey_manager, shutdown_for_task)
+                        handle_connection(stream, repo, vault, cache, backoff, hotkey_manager, countdown_started_at, shutdown_for_task)
                             .await;
                     });
                 }
@@ -250,9 +255,10 @@ impl IpcServer {
                     let cache = self.cache.clone();
                     let backoff = Arc::clone(&self.backoff);
                     let hotkey_manager = Arc::clone(&self.hotkey_manager);
+                    let countdown_started_at = Arc::clone(&self.countdown_started_at);
                     let shutdown_for_task = shutdown.clone();
                     connections.spawn(async move {
-                        handle_connection(stream, repo, vault, cache, backoff, hotkey_manager, shutdown_for_task)
+                        handle_connection(stream, repo, vault, cache, backoff, hotkey_manager, countdown_started_at, shutdown_for_task)
                             .await;
                     });
                 }
@@ -280,6 +286,7 @@ async fn handle_connection<S>(
     cache: VekCache,
     backoff: Arc<Mutex<UnlockBackoff>>,
     hotkey_manager: Arc<HotkeyManager>,
+    countdown_started_at: Arc<Mutex<Option<Instant>>>,
     mut shutdown: watch::Receiver<bool>,
 ) where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -366,6 +373,7 @@ async fn handle_connection<S>(
                             backoff: &backoff,
                             migration: &migration,
                             hotkey_manager: &hotkey_manager,
+                            countdown_started_at: &countdown_started_at,
                         };
 
                         let response = dispatch_v2(&ctx, client_state, request).await;

--- a/crates/shikomi-daemon/src/ipc/server.rs
+++ b/crates/shikomi-daemon/src/ipc/server.rs
@@ -180,16 +180,17 @@ impl IpcServer {
                         continue;
                     }
                     tracing::info!(target: "shikomi_daemon::ipc::server", "client connected");
-                    let repo = Arc::clone(&self.repo);
-                    let vault = Arc::clone(&self.vault);
-                    let cache = self.cache.clone();
-                    let backoff = Arc::clone(&self.backoff);
-                    let hotkey_manager = Arc::clone(&self.hotkey_manager);
-                    let countdown_started_at = Arc::clone(&self.countdown_started_at);
+                    let deps = ConnectionDeps {
+                        repo: Arc::clone(&self.repo),
+                        vault: Arc::clone(&self.vault),
+                        cache: self.cache.clone(),
+                        backoff: Arc::clone(&self.backoff),
+                        hotkey_manager: Arc::clone(&self.hotkey_manager),
+                        countdown_started_at: Arc::clone(&self.countdown_started_at),
+                    };
                     let shutdown_for_task = shutdown.clone();
                     connections.spawn(async move {
-                        handle_connection(stream, repo, vault, cache, backoff, hotkey_manager, countdown_started_at, shutdown_for_task)
-                            .await;
+                        handle_connection(stream, deps, shutdown_for_task).await;
                     });
                 }
             }
@@ -250,16 +251,17 @@ impl IpcServer {
                         continue;
                     }
                     tracing::info!(target: "shikomi_daemon::ipc::server", "client connected");
-                    let repo = Arc::clone(&self.repo);
-                    let vault = Arc::clone(&self.vault);
-                    let cache = self.cache.clone();
-                    let backoff = Arc::clone(&self.backoff);
-                    let hotkey_manager = Arc::clone(&self.hotkey_manager);
-                    let countdown_started_at = Arc::clone(&self.countdown_started_at);
+                    let deps = ConnectionDeps {
+                        repo: Arc::clone(&self.repo),
+                        vault: Arc::clone(&self.vault),
+                        cache: self.cache.clone(),
+                        backoff: Arc::clone(&self.backoff),
+                        hotkey_manager: Arc::clone(&self.hotkey_manager),
+                        countdown_started_at: Arc::clone(&self.countdown_started_at),
+                    };
                     let shutdown_for_task = shutdown.clone();
                     connections.spawn(async move {
-                        handle_connection(stream, repo, vault, cache, backoff, hotkey_manager, countdown_started_at, shutdown_for_task)
-                            .await;
+                        handle_connection(stream, deps, shutdown_for_task).await;
                     });
                 }
             }
@@ -271,6 +273,19 @@ impl IpcServer {
 // 接続単位タスク
 // -------------------------------------------------------------------
 
+/// `handle_connection` に渡すサーバ共有状態。
+///
+/// 引数を束ねることで `clippy::too_many_arguments` を回避する。
+struct ConnectionDeps {
+    repo: Arc<SqliteVaultRepository>,
+    vault: Arc<Mutex<Vault>>,
+    cache: VekCache,
+    backoff: Arc<Mutex<UnlockBackoff>>,
+    hotkey_manager: Arc<HotkeyManager>,
+    /// Sub-D (#97): クリップボード自動消去カウントダウン基点時刻（HotkeyEventLoop と共有）。
+    countdown_started_at: Arc<Mutex<Option<Instant>>>,
+}
+
 /// 接続ハンドラ。ハンドシェイク 1 往復 → リクエスト/レスポンス N 往復 → 切断。
 ///
 /// Sub-E (#43): handshake 完了後 `ClientState::Handshake { version }` を構築し、
@@ -279,18 +294,18 @@ impl IpcServer {
 /// (cheap、各 adapter は zero-sized 相当)。
 ///
 /// `shutdown` 受信時にも in-flight リクエストの応答送信は完了させる。
-async fn handle_connection<S>(
-    stream: S,
-    repo: Arc<SqliteVaultRepository>,
-    vault: Arc<Mutex<Vault>>,
-    cache: VekCache,
-    backoff: Arc<Mutex<UnlockBackoff>>,
-    hotkey_manager: Arc<HotkeyManager>,
-    countdown_started_at: Arc<Mutex<Option<Instant>>>,
-    mut shutdown: watch::Receiver<bool>,
-) where
+async fn handle_connection<S>(stream: S, deps: ConnectionDeps, mut shutdown: watch::Receiver<bool>)
+where
     S: AsyncRead + AsyncWrite + Unpin,
 {
+    let ConnectionDeps {
+        repo,
+        vault,
+        cache,
+        backoff,
+        hotkey_manager,
+        countdown_started_at,
+    } = deps;
     let mut framed: Framed<S, LengthDelimitedCodec> = Framed::new(stream, framing::codec());
 
     if let Err(err) = handshake::negotiate(&mut framed).await {

--- a/crates/shikomi-daemon/src/ipc/v2_handler/get_clipboard_status.rs
+++ b/crates/shikomi-daemon/src/ipc/v2_handler/get_clipboard_status.rs
@@ -81,4 +81,12 @@ mod tests {
         let started_at = now;
         assert_eq!(calc_remaining(started_at, now), Some(30));
     }
+
+    // TC-TRAY-UT09: elapsed=29s → Some(1)（最小正値境界。CLEAR_TIMEOUT_SECS=30 の前後境界）
+    #[test]
+    fn returns_one_when_29_seconds_elapsed() {
+        let now = Instant::now();
+        let started_at = now - Duration::from_secs(29);
+        assert_eq!(calc_remaining(started_at, now), Some(1));
+    }
 }

--- a/crates/shikomi-daemon/src/ipc/v2_handler/get_clipboard_status.rs
+++ b/crates/shikomi-daemon/src/ipc/v2_handler/get_clipboard_status.rs
@@ -1,0 +1,84 @@
+//! `GetClipboardStatus` IPC ハンドラ（Sub-D #97）。
+//!
+//! クリップボード自動消去カウントダウンの残秒を返す。
+//! `countdown_started_at` が `None` または経過秒が `CLEAR_TIMEOUT_SECS` 以上の場合は
+//! `remaining_secs: None` を返す（カウントダウン非アクティブ扱い）。
+//!
+//! 設計根拠: docs/features/shikomi-gui/system-tray/detailed-design.md §6.2
+
+use shikomi_core::ipc::IpcResponse;
+use shikomi_core::CLEAR_TIMEOUT_SECS;
+use shikomi_infra::persistence::VaultRepository;
+use std::time::Instant;
+
+use crate::ipc::v2_handler::V2Context;
+
+/// `GetClipboardStatus` リクエストを処理し `ClipboardStatus` レスポンスを返す。
+///
+/// 残秒計算ロジック（detailed-design.md §6.2）:
+///
+/// | 条件 | `remaining_secs` |
+/// |------|-----------------|
+/// | `countdown_started_at == None` | `None` |
+/// | `elapsed >= CLEAR_TIMEOUT_SECS` | `None`（タイマー発火済み扱い） |
+/// | `elapsed < CLEAR_TIMEOUT_SECS` | `Some(CLEAR_TIMEOUT_SECS - elapsed)` |
+pub async fn handle_get_clipboard_status<R: VaultRepository + ?Sized>(
+    ctx: &V2Context<'_, R>,
+) -> IpcResponse {
+    let remaining_secs = calc_remaining_from_context(ctx).await;
+    IpcResponse::ClipboardStatus { remaining_secs }
+}
+
+/// `countdown_started_at` から残秒を計算する。
+fn calc_remaining(started_at: Instant, now: Instant) -> Option<u64> {
+    let elapsed_secs = now.duration_since(started_at).as_secs();
+    if elapsed_secs >= CLEAR_TIMEOUT_SECS {
+        None
+    } else {
+        Some(CLEAR_TIMEOUT_SECS - elapsed_secs)
+    }
+}
+
+async fn calc_remaining_from_context<R: VaultRepository + ?Sized>(
+    ctx: &V2Context<'_, R>,
+) -> Option<u64> {
+    let guard = ctx.countdown_started_at.lock().await;
+    match *guard {
+        None => None,
+        Some(started_at) => calc_remaining(started_at, Instant::now()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::calc_remaining;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn returns_none_when_elapsed_exceeds_timeout() {
+        let now = Instant::now();
+        let started_at = now - Duration::from_secs(31);
+        assert_eq!(calc_remaining(started_at, now), None);
+    }
+
+    #[test]
+    fn returns_none_when_elapsed_equals_timeout() {
+        let now = Instant::now();
+        let started_at = now - Duration::from_secs(30);
+        assert_eq!(calc_remaining(started_at, now), None);
+    }
+
+    #[test]
+    fn returns_remaining_secs_when_active() {
+        let now = Instant::now();
+        let started_at = now - Duration::from_secs(10);
+        assert_eq!(calc_remaining(started_at, now), Some(20));
+    }
+
+    #[test]
+    fn returns_full_timeout_when_just_started() {
+        let now = Instant::now();
+        let started_at = now;
+        assert_eq!(calc_remaining(started_at, now), Some(30));
+    }
+}

--- a/crates/shikomi-daemon/src/ipc/v2_handler/mod.rs
+++ b/crates/shikomi-daemon/src/ipc/v2_handler/mod.rs
@@ -17,12 +17,14 @@
 
 pub mod change_password;
 pub mod error_mapping;
+pub mod get_clipboard_status;
 pub mod lock;
 pub mod rekey;
 pub mod rotate_recovery;
 pub mod unlock;
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use shikomi_core::ipc::{IpcErrorCode, IpcProtocolVersion, IpcRequest, IpcResponse};
 use shikomi_core::Vault;
@@ -136,6 +138,11 @@ pub struct V2Context<'a, R: VaultRepository + ?Sized> {
     pub migration: &'a VaultMigration<'a>,
     /// Issue #89: OS ホットキー登録管理（add/edit ハンドラが vault 更新後に使用）。
     pub hotkey_manager: &'a Arc<HotkeyManager>,
+    /// Sub-D (#97): クリップボード自動消去カウントダウン基点時刻。
+    ///
+    /// `HotkeyEventLoop` と共有する `Arc<Mutex<Option<Instant>>>`。
+    /// `GetClipboardStatus` ハンドラが残秒を計算するために参照する。
+    pub countdown_started_at: &'a Arc<Mutex<Option<Instant>>>,
 }
 
 // -------------------------------------------------------------------
@@ -166,6 +173,9 @@ pub async fn dispatch_v2<R: VaultRepository + ?Sized>(
 
     match request {
         // ---------- V2 専用 variant ----------
+        IpcRequest::GetClipboardStatus => {
+            get_clipboard_status::handle_get_clipboard_status(ctx).await
+        }
         IpcRequest::Unlock {
             master_password,
             recovery,

--- a/crates/shikomi-daemon/src/lib.rs
+++ b/crates/shikomi-daemon/src/lib.rs
@@ -26,6 +26,7 @@ pub use error::DaemonExit;
 
 use std::process::ExitCode;
 use std::sync::Arc;
+use std::time::Instant;
 
 use shikomi_infra::persistence::{SqliteVaultRepository, VaultRepository};
 use tokio::sync::Mutex;
@@ -129,6 +130,10 @@ pub async fn run() -> ExitCode {
     let cache = VekCache::new();
     let backoff = Arc::new(Mutex::new(UnlockBackoff::new()));
 
+    // Sub-D (#97): クリップボード自動消去カウントダウン基点時刻。
+    // HotkeyEventLoop と IpcServer::handle_connection で共有する。
+    let countdown_started_at: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+
     // Issue #89: ホットキーバックエンド + マネージャ + イベントループの初期化
     let hotkey_backend = BackendEnum::detect();
     let hotkey_notifier = Arc::new(NotifyRustNotifier);
@@ -177,6 +182,7 @@ pub async fn run() -> ExitCode {
             cache.clone(),
             Arc::clone(&clipboard),
             Arc::clone(&hotkey_notifier) as Arc<dyn crate::hotkey::notifier::Notifier>,
+            Arc::clone(&countdown_started_at),
         );
         let rx = shutdown_rx.clone();
         tokio::spawn(async move { event_loop.run(rx).await })
@@ -190,6 +196,7 @@ pub async fn run() -> ExitCode {
         cache.clone(),
         Arc::clone(&backoff),
         Arc::clone(&hotkey_manager),
+        Arc::clone(&countdown_started_at),
     );
     let server_result = server.start_with_shutdown(shutdown_rx).await;
 

--- a/crates/shikomi-daemon/tests/it_hotkey_event_loop.rs
+++ b/crates/shikomi-daemon/tests/it_hotkey_event_loop.rs
@@ -137,12 +137,15 @@ fn spawn_event_loop(
     let backend = Arc::new(BackendEnum::Mock(mock_backend));
     let vault_arc = Arc::new(Mutex::new(vault));
 
+    // Sub-D: countdown_started_at はテスト用ダミー（HotkeyEventLoop 共有状態、ITでは観測しない）
+    let countdown_started_at = Arc::new(Mutex::new(None::<std::time::Instant>));
     let event_loop = HotkeyEventLoop::new(
         Arc::clone(&backend),
         vault_arc,
         vek_cache,
         clipboard,
         notifier,
+        countdown_started_at,
     );
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);

--- a/crates/shikomi-daemon/tests/it_ipc_hotkey.rs
+++ b/crates/shikomi-daemon/tests/it_ipc_hotkey.rs
@@ -168,6 +168,8 @@ mod tests {
         let cache = VekCache::new();
         let backoff = Arc::new(Mutex::new(UnlockBackoff::new()));
 
+        // Sub-D: countdown_started_at はテスト用ダミー（GetClipboardStatus IT では使用しない）
+        let countdown_started_at = Arc::new(Mutex::new(None::<std::time::Instant>));
         let mut server = IpcServer::new(
             ListenerEnum::Unix {
                 listener,
@@ -178,6 +180,7 @@ mod tests {
             cache,
             backoff,
             Arc::clone(&hotkey_manager),
+            countdown_started_at,
         );
         let server_handle = tokio::spawn(async move {
             let _ = server.start_with_shutdown(shutdown_rx).await;

--- a/crates/shikomi-daemon/tests/it_server_connection.rs
+++ b/crates/shikomi-daemon/tests/it_server_connection.rs
@@ -128,6 +128,8 @@ async fn spawn_test_server(dir: &TempDir) -> TestServerHandle {
     let cache = VekCache::new();
     let backoff = Arc::new(Mutex::new(UnlockBackoff::new()));
     let hotkey_manager = Arc::new(shikomi_daemon::hotkey::HotkeyManager::new_null());
+    // Sub-D: countdown_started_at はテスト用ダミー（接続シナリオ IT ではカウントダウンを観測しない）
+    let countdown_started_at = Arc::new(Mutex::new(None::<std::time::Instant>));
     let mut server = IpcServer::new(
         ListenerEnum::Unix {
             listener,
@@ -138,6 +140,7 @@ async fn spawn_test_server(dir: &TempDir) -> TestServerHandle {
         cache,
         backoff,
         hotkey_manager,
+        countdown_started_at,
     );
     let server_handle = tokio::spawn(async move {
         let _ = server.start_with_shutdown(shutdown_rx).await;

--- a/crates/shikomi-daemon/tests/sub_e_v2_integration/helpers.rs
+++ b/crates/shikomi-daemon/tests/sub_e_v2_integration/helpers.rs
@@ -123,6 +123,8 @@ pub async fn run_dispatch(
     let vault = Mutex::new(vault_state);
 
     let hotkey_manager = std::sync::Arc::new(shikomi_daemon::hotkey::HotkeyManager::new_null());
+    // Sub-D: countdown_started_at はテスト用ダミー（V2 統合 IT ではカウントダウン状態を観測しない）
+    let countdown_started_at = std::sync::Arc::new(Mutex::new(None::<std::time::Instant>));
     let ctx = V2Context {
         repo,
         vault: &vault,
@@ -130,6 +132,7 @@ pub async fn run_dispatch(
         backoff,
         migration: &migration,
         hotkey_manager: &hotkey_manager,
+        countdown_started_at: &countdown_started_at,
     };
     dispatch_v2(&ctx, state, request).await
 }

--- a/crates/shikomi-gui/Cargo.toml
+++ b/crates/shikomi-gui/Cargo.toml
@@ -21,6 +21,8 @@ path = "src/main.rs"
 # Tauri v2 ランタイム（tech-stack.md §2.1 / §2.6）
 # tray-icon: UC-GUI-005 システムトレイ常駐（Sub-D で実装）
 tauri = { version = "2", features = ["tray-icon"] }
+# Sub-D (#97): daemon 再起動コマンド実行（basic-design.md §1 / §6.1）
+tauri-plugin-shell = "2"
 serde           = { workspace = true }
 tracing         = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/shikomi-gui/Cargo.toml
+++ b/crates/shikomi-gui/Cargo.toml
@@ -24,6 +24,8 @@ tauri = { version = "2", features = ["tray-icon"] }
 # Sub-D (#97): daemon 再起動コマンド実行（basic-design.md §1 / §6.1）
 tauri-plugin-shell = "2"
 serde           = { workspace = true }
+# tauri::generate_context!() マクロが serde_json を直接参照するため必須
+serde_json      = { workspace = true }
 tracing         = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror       = { workspace = true }

--- a/crates/shikomi-gui/src/ipc_client/commands/mod.rs
+++ b/crates/shikomi-gui/src/ipc_client/commands/mod.rs
@@ -1,13 +1,16 @@
 //! Tauri Commands — IPC ブリッジ層。
 //!
-//! 全 10 コマンドを再エクスポートする。`lib.rs::run()` の `generate_handler!` に渡す。
+//! 全 11 コマンドを再エクスポートする。`lib.rs::run()` の `generate_handler!` に渡す。
 //!
 //! 設計根拠: docs/features/shikomi-gui/ipc-client/basic-design.md §2.3
+//!          docs/features/shikomi-gui/system-tray/basic-design.md §3.3（Sub-D #97）
 
 pub mod entries;
 pub mod hotkey;
+pub mod tray;
 pub mod vault;
 
 pub use entries::{add_entry, delete_entry, list_entries, update_entry};
 pub use hotkey::{assign_hotkey, remove_hotkey};
+pub use tray::get_clipboard_countdown;
 pub use vault::{decrypt_vault, encrypt_vault, get_vault_status, unlock_vault};

--- a/crates/shikomi-gui/src/ipc_client/commands/tray.rs
+++ b/crates/shikomi-gui/src/ipc_client/commands/tray.rs
@@ -1,0 +1,65 @@
+//! クリップボードカウントダウン Tauri Command（Sub-D #97）。
+//!
+//! | コマンド | IpcRequest | 正常応答 |
+//! |---|---|---|
+//! | `get_clipboard_countdown` | `GetClipboardStatus` | `ClipboardCountdownResult { remaining_secs }` |
+//!
+//! daemon 未接続（`AppState == None`）の場合は `{ remaining_secs: null }` を即返す。
+//! エラーを SolidJS に伝搬しない（countdown polling がエラーパネルを誘発しないよう設計する）。
+//!
+//! 設計根拠: docs/features/shikomi-gui/system-tray/basic-design.md §3.3
+//!          docs/features/shikomi-gui/system-tray/detailed-design.md §5
+
+use serde::Serialize;
+use shikomi_core::ipc::{IpcRequest, IpcResponse};
+use tauri::State;
+
+use crate::ipc_client::{round_trip_checked, AppState};
+
+// ---------------------------------------------------------------------------
+// 出力型
+// ---------------------------------------------------------------------------
+
+/// `get_clipboard_countdown` の戻り値。
+///
+/// `remaining_secs: null` → カウントダウン非アクティブ。
+/// `remaining_secs: n` → 残 n 秒でカウントダウン中。
+///
+/// 設計根拠: docs/features/shikomi-gui/system-tray/detailed-design.md §5.1
+#[derive(Debug, Serialize)]
+pub struct ClipboardCountdownResult {
+    /// クリップボード自動消去までの残秒（`null` は非アクティブ）。
+    pub remaining_secs: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// get_clipboard_countdown（REQ-TRAY-04）
+// ---------------------------------------------------------------------------
+
+/// クリップボード自動消去カウントダウン残秒を取得する。
+///
+/// `GUIError` を返さない（detailed-design.md §5.2 サイレントフォールバック設計）。
+/// daemon 未接続または IPC エラーは `remaining_secs: null` として扱う。
+///
+/// 設計根拠: docs/features/shikomi-gui/system-tray/basic-design.md §3.3
+#[tauri::command]
+pub async fn get_clipboard_countdown(
+    state: State<'_, AppState>,
+) -> Result<ClipboardCountdownResult, ()> {
+    let request = IpcRequest::GetClipboardStatus;
+    let remaining_secs = match round_trip_checked(&state, &request).await {
+        Ok(IpcResponse::ClipboardStatus { remaining_secs }) => remaining_secs,
+        Ok(other) => {
+            tracing::debug!(
+                variant = other.variant_name(),
+                "get_clipboard_countdown: unexpected IPC response"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "get_clipboard_countdown: IPC error (silent fallback)");
+            None
+        }
+    };
+    Ok(ClipboardCountdownResult { remaining_secs })
+}

--- a/crates/shikomi-gui/src/ipc_client/error/tests.rs
+++ b/crates/shikomi-gui/src/ipc_client/error/tests.rs
@@ -336,7 +336,7 @@ fn ut15_ipc_code_key_exhaustive_contract_check() {
         ),
         (
             GUIError::Ipc(IpcErrorCode::NotFound {
-                id: RecordId::new(Uuid::nil()).unwrap(),
+                id: RecordId::new(Uuid::now_v7()).unwrap(),
             }),
             "not_found",
         ),

--- a/crates/shikomi-gui/src/lib.rs
+++ b/crates/shikomi-gui/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - `ipc_client`: Tauri Commands ハンドラ群（Sub-B: IPC ブリッジ実装）
 //! - `ipc_client::error`: `GUIError` enum（SolidJS への統一エラー型）
+//! - `system_tray`: システムトレイ初期化 + カウントダウンタスク（Sub-D: #97）
 //!
 //! ## 起動経路
 //!
@@ -14,11 +15,13 @@
 //! `docs/architecture/tech-stack.md §2.6`
 
 pub mod ipc_client;
+pub(crate) mod system_tray;
 
 use ipc_client::{
     commands::{
-        add_entry, assign_hotkey, decrypt_vault, delete_entry, encrypt_vault, get_vault_status,
-        list_entries, remove_hotkey, unlock_vault, update_entry,
+        add_entry, assign_hotkey, decrypt_vault, delete_entry, encrypt_vault,
+        get_clipboard_countdown, get_vault_status, list_entries, remove_hotkey, unlock_vault,
+        update_entry,
     },
     AppState, GuiIpcClient,
 };
@@ -34,6 +37,7 @@ use tauri::Manager as _;
 /// Tauri ランタイムの初期化または起動に失敗した場合に `tauri::Error` を返す。
 pub fn run() -> tauri::Result<()> {
     tauri::Builder::default()
+        .plugin(tauri_plugin_shell::init())
         .setup(|app| {
             // AppState を初期化（None = daemon 未接続）
             app.manage::<AppState>(tokio::sync::Mutex::new(None));
@@ -63,6 +67,10 @@ pub fn run() -> tauri::Result<()> {
                 }
             });
 
+            // システムトレイ初期化（Sub-D #97: REQ-TRAY-01〜05）
+            // daemon 接続の前後どちらでも可（countdown タスクは daemon 未接続を None で扱う）
+            system_tray::setup(app)?;
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -76,6 +84,7 @@ pub fn run() -> tauri::Result<()> {
             encrypt_vault,
             decrypt_vault,
             unlock_vault,
+            get_clipboard_countdown,
         ])
         .run(tauri::generate_context!())
 }

--- a/crates/shikomi-gui/src/system_tray/countdown.rs
+++ b/crates/shikomi-gui/src/system_tray/countdown.rs
@@ -190,4 +190,13 @@ mod tests {
         let text = tooltip_text(Some(1));
         assert_eq!(text, "shikomi — クリップボードを自動消去まで 1 秒");
     }
+
+    // TC-TRAY-UT09: calc_remaining — elapsed=29s → Some(1)（最小正値境界）
+    #[test]
+    fn ut09_calc_remaining_one_second_before_timeout() {
+        let now = Instant::now();
+        let started_at = now - Duration::from_secs(29);
+        // elapsed=29 < CLEAR_TIMEOUT_SECS(30) → remaining = 1（最小正値境界）
+        assert_eq!(calc_remaining(started_at, now), Some(1));
+    }
 }

--- a/crates/shikomi-gui/src/system_tray/countdown.rs
+++ b/crates/shikomi-gui/src/system_tray/countdown.rs
@@ -6,10 +6,9 @@
 //! 設計根拠: docs/features/shikomi-gui/system-tray/detailed-design.md §4
 //!          docs/features/shikomi-gui/system-tray/detailed-design.md §9
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use shikomi_core::ipc::{IpcRequest, IpcResponse};
-use shikomi_core::CLEAR_TIMEOUT_SECS;
 use tauri::tray::TrayIconId;
 use tauri::{AppHandle, Manager as _, Runtime};
 
@@ -92,34 +91,12 @@ fn tooltip_text(remaining: Option<u64>) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// calc_remaining — 残秒計算純粋関数（§9、テスト用）
-// ---------------------------------------------------------------------------
-
-/// クリップボード投入開始時刻から残秒を計算する。
-///
-/// `now` を引数注入することで `Instant::now()` 依存を排除しテスト可能にする（§9）。
-///
-/// | 条件 | 戻り値 |
-/// |------|--------|
-/// | `elapsed >= CLEAR_TIMEOUT_SECS` | `None` |
-/// | `elapsed < CLEAR_TIMEOUT_SECS` | `Some(CLEAR_TIMEOUT_SECS - elapsed)` |
-fn calc_remaining(started_at: Instant, now: Instant) -> Option<u64> {
-    let elapsed_secs = now.duration_since(started_at).as_secs();
-    if elapsed_secs >= CLEAR_TIMEOUT_SECS {
-        None
-    } else {
-        Some(CLEAR_TIMEOUT_SECS - elapsed_secs)
-    }
-}
-
-// ---------------------------------------------------------------------------
 // tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
     // TC-TRAY-UT01: tooltip_text — カウントダウン中（残 15 秒）
     #[test]
@@ -142,51 +119,10 @@ mod tests {
         assert_eq!(text, "shikomi");
     }
 
-    // TC-TRAY-UT03: calc_remaining — 残 20 秒
-    #[test]
-    fn ut03_calc_remaining_active() {
-        let now = Instant::now();
-        let started_at = now - Duration::from_secs(10);
-        assert_eq!(calc_remaining(started_at, now), Some(20));
-    }
-
-    // TC-TRAY-UT04: calc_remaining — タイムアウト超過
-    #[test]
-    fn ut04_calc_remaining_expired() {
-        let now = Instant::now();
-        let started_at = now - Duration::from_secs(31);
-        assert_eq!(calc_remaining(started_at, now), None);
-    }
-
-    // TC-TRAY-UT05: calc_remaining — 境界: elapsed == CLEAR_TIMEOUT_SECS（30 秒 = None）
-    #[test]
-    fn ut05_calc_remaining_boundary_exactly_timeout() {
-        let now = Instant::now();
-        let started_at = now - Duration::from_secs(30);
-        assert_eq!(calc_remaining(started_at, now), None);
-    }
-
-    // TC-TRAY-UT06: calc_remaining — 直後（elapsed ≈ 0）
-    #[test]
-    fn ut06_calc_remaining_just_started() {
-        let now = Instant::now();
-        // elapsed = 0 → remaining = 30
-        assert_eq!(calc_remaining(now, now), Some(30));
-    }
-
     // TC-TRAY-UT07: tooltip_text — 境界最小（残 1 秒）
     #[test]
     fn ut07_tooltip_text_one_second_remaining() {
         let text = tooltip_text(Some(1));
         assert_eq!(text, "shikomi — クリップボードを自動消去まで 1 秒");
-    }
-
-    // TC-TRAY-UT09: calc_remaining — elapsed=29s → Some(1)（最小正値境界）
-    #[test]
-    fn ut09_calc_remaining_one_second_before_timeout() {
-        let now = Instant::now();
-        let started_at = now - Duration::from_secs(29);
-        // elapsed=29 < CLEAR_TIMEOUT_SECS(30) → remaining = 1（最小正値境界）
-        assert_eq!(calc_remaining(started_at, now), Some(1));
     }
 }

--- a/crates/shikomi-gui/src/system_tray/countdown.rs
+++ b/crates/shikomi-gui/src/system_tray/countdown.rs
@@ -22,30 +22,20 @@ use crate::ipc_client::{round_trip_checked, AppState};
 /// カウントダウンポーリングタスクのエントリポイント。
 ///
 /// `setup()` から `tauri::async_runtime::spawn` で起動する。
-/// `AppHandle` の weak 参照を使い、ランタイム終了後に安全にループを終了させる。
+/// トレイアイコンが見つからなくなった時点（アプリ終了途中）でループを終了する。
 /// エラーは `tracing::warn!` でログし、タスクは継続する（best-effort）。
 ///
 /// 設計根拠: docs/features/shikomi-gui/system-tray/detailed-design.md §4.3
 pub async fn run<R: Runtime>(app_handle: AppHandle<R>, tray_id: TrayIconId) {
-    let weak = app_handle.downgrade();
-    // 強参照を解放してランタイム終了検知を weak のみに委ねる
-    drop(app_handle);
-
     loop {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        let Some(app) = weak.upgrade() else {
-            // ランタイム終了: ループを安全に終了する（REQ-TRAY-05 §4.3）
-            tracing::debug!("countdown: AppHandle dropped; exiting loop");
+        let remaining = poll_remaining(&app_handle).await;
+
+        let Some(tray) = app_handle.tray_by_id(&tray_id) else {
+            // トレイが破棄されている（アプリ終了途中）→ ループを安全に終了する（REQ-TRAY-05 §4.3）
+            tracing::debug!("countdown: tray icon not found; exiting loop");
             break;
-        };
-
-        let remaining = poll_remaining(&app).await;
-
-        let Some(tray) = app.tray_by_id(&tray_id) else {
-            // トレイが破棄されている（アプリ終了途中）→ best-effort で継続
-            tracing::warn!("countdown: tray icon not found; skipping tooltip update");
-            continue;
         };
 
         let text = tooltip_text(remaining);

--- a/crates/shikomi-gui/src/system_tray/countdown.rs
+++ b/crates/shikomi-gui/src/system_tray/countdown.rs
@@ -98,31 +98,31 @@ fn tooltip_text(remaining: Option<u64>) -> String {
 mod tests {
     use super::*;
 
-    // TC-TRAY-UT01: tooltip_text — カウントダウン中（残 15 秒）
+    // TC-GUI-TRAY-UT01: tooltip_text — カウントダウン中（残 15 秒）
     #[test]
     fn ut01_tooltip_text_countdown_active() {
         let text = tooltip_text(Some(15));
         assert_eq!(text, "shikomi — クリップボードを自動消去まで 15 秒");
     }
 
-    // TC-TRAY-UT02: tooltip_text — 非アクティブ（None）
+    // TC-GUI-TRAY-UT02: tooltip_text — 境界最小（残 1 秒）
     #[test]
-    fn ut02_tooltip_text_inactive_none() {
-        let text = tooltip_text(None);
-        assert_eq!(text, "shikomi");
+    fn ut02_tooltip_text_one_second_remaining() {
+        let text = tooltip_text(Some(1));
+        assert_eq!(text, "shikomi — クリップボードを自動消去まで 1 秒");
     }
 
-    // TC-TRAY-UT02b: tooltip_text — 非アクティブ（0 秒）
+    // TC-GUI-TRAY-UT03: tooltip_text — 非アクティブ（0 秒）
     #[test]
-    fn ut02b_tooltip_text_inactive_zero() {
+    fn ut03_tooltip_text_inactive_zero() {
         let text = tooltip_text(Some(0));
         assert_eq!(text, "shikomi");
     }
 
-    // TC-TRAY-UT07: tooltip_text — 境界最小（残 1 秒）
+    // TC-GUI-TRAY-UT04: tooltip_text — 非アクティブ（None）
     #[test]
-    fn ut07_tooltip_text_one_second_remaining() {
-        let text = tooltip_text(Some(1));
-        assert_eq!(text, "shikomi — クリップボードを自動消去まで 1 秒");
+    fn ut04_tooltip_text_inactive_none() {
+        let text = tooltip_text(None);
+        assert_eq!(text, "shikomi");
     }
 }

--- a/crates/shikomi-gui/src/system_tray/countdown.rs
+++ b/crates/shikomi-gui/src/system_tray/countdown.rs
@@ -1,0 +1,193 @@
+//! クリップボード消去カウントダウンのポーリングタスク（Sub-D #97）。
+//!
+//! `run()` は 1 秒ごとに `get_clipboard_countdown` IPC を呼び出し、残秒に応じて
+//! トレイアイコンのツールチップを更新する。
+//!
+//! 設計根拠: docs/features/shikomi-gui/system-tray/detailed-design.md §4
+//!          docs/features/shikomi-gui/system-tray/detailed-design.md §9
+
+use std::time::{Duration, Instant};
+
+use shikomi_core::ipc::{IpcRequest, IpcResponse};
+use shikomi_core::CLEAR_TIMEOUT_SECS;
+use tauri::tray::TrayIconId;
+use tauri::{AppHandle, Manager as _, Runtime};
+
+use crate::ipc_client::{round_trip_checked, AppState};
+
+// ---------------------------------------------------------------------------
+// run — ポーリングループ（REQ-TRAY-05）
+// ---------------------------------------------------------------------------
+
+/// カウントダウンポーリングタスクのエントリポイント。
+///
+/// `setup()` から `tauri::async_runtime::spawn` で起動する。
+/// `AppHandle` の weak 参照を使い、ランタイム終了後に安全にループを終了させる。
+/// エラーは `tracing::warn!` でログし、タスクは継続する（best-effort）。
+///
+/// 設計根拠: docs/features/shikomi-gui/system-tray/detailed-design.md §4.3
+pub async fn run<R: Runtime>(app_handle: AppHandle<R>, tray_id: TrayIconId) {
+    let weak = app_handle.downgrade();
+    // 強参照を解放してランタイム終了検知を weak のみに委ねる
+    drop(app_handle);
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let Some(app) = weak.upgrade() else {
+            // ランタイム終了: ループを安全に終了する（REQ-TRAY-05 §4.3）
+            tracing::debug!("countdown: AppHandle dropped; exiting loop");
+            break;
+        };
+
+        let remaining = poll_remaining(&app).await;
+
+        let Some(tray) = app.tray_by_id(&tray_id) else {
+            // トレイが破棄されている（アプリ終了途中）→ best-effort で継続
+            tracing::warn!("countdown: tray icon not found; skipping tooltip update");
+            continue;
+        };
+
+        let text = tooltip_text(remaining);
+        if let Err(e) = tray.set_tooltip(Some(text.as_str())) {
+            tracing::warn!(error = %e, "countdown: set_tooltip failed (best-effort)");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// poll_remaining — IPC 呼び出しで残秒を取得（§4.2 エラー方針）
+// ---------------------------------------------------------------------------
+
+/// `AppState` 経由で daemon に `GetClipboardStatus` を問い合わせ、残秒を返す。
+///
+/// - `AppState` が `None`（daemon 未接続）→ `None`（カウントダウン非アクティブ扱い）
+/// - IPC 通信エラー → `tracing::debug!` のみ、前回値の代わりに `None` を返す
+///   （§4.2: ツールチップのリセットより無変化を優先する必要があれば上位で対応）
+async fn poll_remaining<R: Runtime>(app: &AppHandle<R>) -> Option<u64> {
+    let state = app.state::<AppState>();
+    match round_trip_checked(&state, &IpcRequest::GetClipboardStatus).await {
+        Ok(IpcResponse::ClipboardStatus { remaining_secs }) => remaining_secs,
+        Ok(other) => {
+            tracing::debug!(
+                variant = other.variant_name(),
+                "countdown: unexpected IPC response"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "countdown: IPC error (best-effort)");
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// tooltip_text — ツールチップ文字列生成（§9 / §10）
+// ---------------------------------------------------------------------------
+
+/// 残秒から表示するツールチップ文字列を返す。
+///
+/// | 状態 | 文字列 |
+/// |------|--------|
+/// | 非アクティブ（`None` または `0`） | `"shikomi"` |
+/// | カウントダウン中（`Some(n)`, n > 0） | `"shikomi — クリップボードを自動消去まで {n} 秒"` |
+///
+/// 設計根拠: docs/features/shikomi-gui/system-tray/detailed-design.md §10
+fn tooltip_text(remaining: Option<u64>) -> String {
+    match remaining {
+        Some(n) if n > 0 => format!("shikomi — クリップボードを自動消去まで {n} 秒"),
+        _ => "shikomi".to_owned(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// calc_remaining — 残秒計算純粋関数（§9、テスト用）
+// ---------------------------------------------------------------------------
+
+/// クリップボード投入開始時刻から残秒を計算する。
+///
+/// `now` を引数注入することで `Instant::now()` 依存を排除しテスト可能にする（§9）。
+///
+/// | 条件 | 戻り値 |
+/// |------|--------|
+/// | `elapsed >= CLEAR_TIMEOUT_SECS` | `None` |
+/// | `elapsed < CLEAR_TIMEOUT_SECS` | `Some(CLEAR_TIMEOUT_SECS - elapsed)` |
+fn calc_remaining(started_at: Instant, now: Instant) -> Option<u64> {
+    let elapsed_secs = now.duration_since(started_at).as_secs();
+    if elapsed_secs >= CLEAR_TIMEOUT_SECS {
+        None
+    } else {
+        Some(CLEAR_TIMEOUT_SECS - elapsed_secs)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    // TC-TRAY-UT01: tooltip_text — カウントダウン中（残 15 秒）
+    #[test]
+    fn ut01_tooltip_text_countdown_active() {
+        let text = tooltip_text(Some(15));
+        assert_eq!(text, "shikomi — クリップボードを自動消去まで 15 秒");
+    }
+
+    // TC-TRAY-UT02: tooltip_text — 非アクティブ（None）
+    #[test]
+    fn ut02_tooltip_text_inactive_none() {
+        let text = tooltip_text(None);
+        assert_eq!(text, "shikomi");
+    }
+
+    // TC-TRAY-UT02b: tooltip_text — 非アクティブ（0 秒）
+    #[test]
+    fn ut02b_tooltip_text_inactive_zero() {
+        let text = tooltip_text(Some(0));
+        assert_eq!(text, "shikomi");
+    }
+
+    // TC-TRAY-UT03: calc_remaining — 残 20 秒
+    #[test]
+    fn ut03_calc_remaining_active() {
+        let now = Instant::now();
+        let started_at = now - Duration::from_secs(10);
+        assert_eq!(calc_remaining(started_at, now), Some(20));
+    }
+
+    // TC-TRAY-UT04: calc_remaining — タイムアウト超過
+    #[test]
+    fn ut04_calc_remaining_expired() {
+        let now = Instant::now();
+        let started_at = now - Duration::from_secs(31);
+        assert_eq!(calc_remaining(started_at, now), None);
+    }
+
+    // TC-TRAY-UT05: calc_remaining — 境界: elapsed == CLEAR_TIMEOUT_SECS（30 秒 = None）
+    #[test]
+    fn ut05_calc_remaining_boundary_exactly_timeout() {
+        let now = Instant::now();
+        let started_at = now - Duration::from_secs(30);
+        assert_eq!(calc_remaining(started_at, now), None);
+    }
+
+    // TC-TRAY-UT06: calc_remaining — 直後（elapsed ≈ 0）
+    #[test]
+    fn ut06_calc_remaining_just_started() {
+        let now = Instant::now();
+        // elapsed = 0 → remaining = 30
+        assert_eq!(calc_remaining(now, now), Some(30));
+    }
+
+    // TC-TRAY-UT07: tooltip_text — 境界最小（残 1 秒）
+    #[test]
+    fn ut07_tooltip_text_one_second_remaining() {
+        let text = tooltip_text(Some(1));
+        assert_eq!(text, "shikomi — クリップボードを自動消去まで 1 秒");
+    }
+}

--- a/crates/shikomi-gui/src/system_tray/menu.rs
+++ b/crates/shikomi-gui/src/system_tray/menu.rs
@@ -1,0 +1,155 @@
+//! トレイメニュー構築とメニューイベントハンドラ（Sub-D #97）。
+//!
+//! メニュー項目: ウィンドウを開く / セパレータ / shikomi のサービスを再起動する /
+//!             セパレータ / 終了（detailed-design.md §3.1）
+//!
+//! 設計根拠: docs/features/shikomi-gui/system-tray/basic-design.md §2.3
+//!          docs/features/shikomi-gui/system-tray/detailed-design.md §3
+
+use tauri::menu::{Menu, MenuBuilder, MenuItem, MenuItemBuilder, PredefinedMenuItem};
+use tauri::{App, AppHandle, Manager as _, Runtime};
+
+/// トレイメニューを構築する。
+///
+/// | 順序 | ID | ラベル |
+/// |------|-----|--------|
+/// | 1 | `"open_window"` | 「ウィンドウを開く」 |
+/// | 2 | — | セパレータ |
+/// | 3 | `"restart_daemon"` | 「shikomi のサービスを再起動する」 |
+/// | 4 | — | セパレータ |
+/// | 5 | `"quit"` | 「終了」 |
+///
+/// # Errors
+///
+/// メニュー構築失敗時は `tauri::Error` を返す。
+pub fn build_menu(app: &App) -> tauri::Result<Menu<tauri::Wry>> {
+    let open_window = MenuItemBuilder::with_id("open_window", "ウィンドウを開く")
+        .build(app)?;
+    let separator1 = PredefinedMenuItem::separator(app)?;
+    let restart_daemon =
+        MenuItemBuilder::with_id("restart_daemon", "shikomi のサービスを再起動する")
+            .build(app)?;
+    let separator2 = PredefinedMenuItem::separator(app)?;
+    let quit = MenuItemBuilder::with_id("quit", "終了").build(app)?;
+
+    MenuBuilder::new(app)
+        .item(&open_window)
+        .item(&separator1)
+        .item(&restart_daemon)
+        .item(&separator2)
+        .item(&quit)
+        .build()
+}
+
+/// トレイメニューイベントを処理する。
+///
+/// `TrayIconBuilder::on_menu_event` に渡すハンドラ。
+/// `message` フィールドを UI に表示しない（単一責務）。
+///
+/// | ID | 処理 |
+/// |----|------|
+/// | `"open_window"` | メインウィンドウを表示しフォーカス |
+/// | `"restart_daemon"` | daemon を再起動しAppStateをリセット（§3.2） |
+/// | `"quit"` | `AppHandle::exit(0)` で終了 |
+pub fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: tauri::menu::MenuEvent) {
+    match event.id().as_ref() {
+        "open_window" => handle_open_window(app),
+        "restart_daemon" => handle_restart_daemon(app),
+        "quit" => {
+            tracing::info!("system_tray: quit requested via tray menu");
+            app.exit(0);
+        }
+        id => {
+            tracing::warn!(id, "system_tray: unknown menu item id");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// open_window ハンドラ（§3.2）
+// ---------------------------------------------------------------------------
+
+fn handle_open_window<R: Runtime>(app: &AppHandle<R>) {
+    let Some(window) = app.get_webview_window("main") else {
+        tracing::warn!("system_tray: main window not found on open_window");
+        return;
+    };
+
+    if let Err(e) = window.show() {
+        tracing::warn!(error = %e, "system_tray: window.show() failed");
+        return;
+    }
+    if let Err(e) = window.set_focus() {
+        tracing::warn!(error = %e, "system_tray: window.set_focus() failed");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// restart_daemon ハンドラ（§3.2）
+// ---------------------------------------------------------------------------
+
+fn handle_restart_daemon<R: Runtime>(app: &AppHandle<R>) {
+    use tauri_plugin_shell::ShellExt as _;
+
+    // AppState を None にリセット（既存接続を切断）
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn(async move {
+        {
+            let state = app_clone.state::<crate::ipc_client::AppState>();
+            *state.lock().await = None;
+            tracing::info!("system_tray: AppState reset for daemon restart");
+        }
+
+        // shikomi start を spawn（完了を待たない）
+        // shell scope: { "name": "shikomi", "cmd": "shikomi", "args": ["^start$"] }
+        // 設計根拠: basic-design.md §6.1
+        match app_clone.shell().command("shikomi").args(["start"]).spawn() {
+            Ok(_) => {
+                tracing::info!("system_tray: shikomi start spawned");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "system_tray: shikomi start spawn failed");
+            }
+        }
+
+        // 再接続試行（lib.rs の初期接続ロジックを再利用）
+        reconnect_daemon(&app_clone).await;
+    });
+}
+
+/// daemon への再接続を試みる。
+///
+/// 接続成功で `AppState` を `Some(client)` に更新する。
+/// 接続失敗は `tracing::warn!` のみ（`DaemonConnectionPanel` が UI を担当）。
+async fn reconnect_daemon<R: Runtime>(app: &AppHandle<R>) {
+    use shikomi_infra::ipc::IpcEndpoint;
+
+    // daemon 起動を少し待つ（best-effort、接続失敗は UI が通知する）
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let socket_path = match IpcEndpoint::default_for_current_user() {
+        Err(e) => {
+            tracing::warn!("system_tray: failed to resolve daemon socket path: {e}");
+            return;
+        }
+        Ok(p) => p,
+    };
+
+    match crate::ipc_client::GuiIpcClient::connect(&socket_path).await {
+        Ok(client) => {
+            let state = app.state::<crate::ipc_client::AppState>();
+            *state.lock().await = Some(client);
+            tracing::info!(
+                "system_tray: reconnected to daemon at {}",
+                socket_path.display()
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                "system_tray: reconnect failed at {}: {}",
+                socket_path.display(),
+                e
+            );
+        }
+    }
+}

--- a/crates/shikomi-gui/src/system_tray/menu.rs
+++ b/crates/shikomi-gui/src/system_tray/menu.rs
@@ -23,12 +23,10 @@ use tauri::{App, AppHandle, Manager as _, Runtime};
 ///
 /// メニュー構築失敗時は `tauri::Error` を返す。
 pub fn build_menu(app: &App) -> tauri::Result<Menu<tauri::Wry>> {
-    let open_window = MenuItemBuilder::with_id("open_window", "ウィンドウを開く")
-        .build(app)?;
+    let open_window = MenuItemBuilder::with_id("open_window", "ウィンドウを開く").build(app)?;
     let separator1 = PredefinedMenuItem::separator(app)?;
     let restart_daemon =
-        MenuItemBuilder::with_id("restart_daemon", "shikomi のサービスを再起動する")
-            .build(app)?;
+        MenuItemBuilder::with_id("restart_daemon", "shikomi のサービスを再起動する").build(app)?;
     let separator2 = PredefinedMenuItem::separator(app)?;
     let quit = MenuItemBuilder::with_id("quit", "終了").build(app)?;
 

--- a/crates/shikomi-gui/src/system_tray/mod.rs
+++ b/crates/shikomi-gui/src/system_tray/mod.rs
@@ -54,9 +54,7 @@ pub fn setup(app: &mut App) -> tauri::Result<()> {
 /// `AppHandle::exit(0)` はトレイメニューの「終了」のみが呼ぶ唯一の終了経路（§2.2）。
 fn register_close_to_tray_handler(app: &App) {
     let Some(window) = app.get_webview_window("main") else {
-        tracing::warn!(
-            "system_tray::setup: main window not found; close-to-tray not registered"
-        );
+        tracing::warn!("system_tray::setup: main window not found; close-to-tray not registered");
         return;
     };
 

--- a/crates/shikomi-gui/src/system_tray/mod.rs
+++ b/crates/shikomi-gui/src/system_tray/mod.rs
@@ -50,7 +50,7 @@ pub fn setup(app: &mut App) -> tauri::Result<()> {
 
 /// ウィンドウ「×」ボタンをトレイ常駐にリダイレクトするハンドラを登録する（REQ-TRAY-02）。
 ///
-/// `CloseRequested` を `prevent_default()` して `hide()` する。
+/// `CloseRequested` を `prevent_close()` して `hide()` する。
 /// `AppHandle::exit(0)` はトレイメニューの「終了」のみが呼ぶ唯一の終了経路（§2.2）。
 fn register_close_to_tray_handler(app: &App) {
     let Some(window) = app.get_webview_window("main") else {
@@ -61,7 +61,7 @@ fn register_close_to_tray_handler(app: &App) {
     let window_clone = window.clone();
     window.on_window_event(move |event| {
         if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-            api.prevent_default();
+            api.prevent_close();
             if let Err(e) = window_clone.hide() {
                 tracing::warn!(error = %e, "system_tray: window.hide() failed");
             }

--- a/crates/shikomi-gui/src/system_tray/mod.rs
+++ b/crates/shikomi-gui/src/system_tray/mod.rs
@@ -1,0 +1,72 @@
+//! システムトレイ初期化（Sub-D #97）。
+//!
+//! `setup()` はアプリ起動時に一度だけ呼ばれ、以下を行う:
+//! - `TrayIconBuilder` でトレイアイコン + ツールチップ + メニューを生成（REQ-TRAY-01）
+//! - ウィンドウ close-to-tray ハンドラを登録（REQ-TRAY-02）
+//! - `countdown::run` タスクを spawn（REQ-TRAY-05）
+//!
+//! 設計根拠: docs/features/shikomi-gui/system-tray/basic-design.md §2.1
+//!          docs/features/shikomi-gui/system-tray/detailed-design.md §1
+
+pub(crate) mod countdown;
+pub(crate) mod menu;
+
+use tauri::tray::TrayIconBuilder;
+use tauri::{App, Manager as _};
+
+/// システムトレイをセットアップする。
+///
+/// `lib.rs::run()` の `.setup()` フック内から呼び出す。
+///
+/// # Errors
+///
+/// `TrayIconBuilder::build` 失敗時に `tauri::Error` を返す（Fail Fast）。
+/// トレイアイコン生成失敗はアプリ起動を中断する（REQ-TRAY-01）。
+pub fn setup(app: &mut App) -> tauri::Result<()> {
+    let icon = app
+        .default_window_icon()
+        .cloned()
+        .ok_or_else(|| tauri::Error::AssetNotFound("default window icon".to_owned()))?;
+
+    let tray_menu = menu::build_menu(app)?;
+
+    let tray = TrayIconBuilder::new()
+        .icon(icon)
+        .tooltip("shikomi")
+        .menu(&tray_menu)
+        .on_menu_event(menu::handle_menu_event)
+        .build(app)?;
+
+    // close-to-tray ハンドラ登録（REQ-TRAY-02）
+    register_close_to_tray_handler(app);
+
+    // countdown ポーリングタスク起動（REQ-TRAY-05）
+    let app_handle = app.handle().clone();
+    let tray_id = tray.id().clone();
+    tauri::async_runtime::spawn(countdown::run(app_handle, tray_id));
+
+    Ok(())
+}
+
+/// ウィンドウ「×」ボタンをトレイ常駐にリダイレクトするハンドラを登録する（REQ-TRAY-02）。
+///
+/// `CloseRequested` を `prevent_default()` して `hide()` する。
+/// `AppHandle::exit(0)` はトレイメニューの「終了」のみが呼ぶ唯一の終了経路（§2.2）。
+fn register_close_to_tray_handler(app: &App) {
+    let Some(window) = app.get_webview_window("main") else {
+        tracing::warn!(
+            "system_tray::setup: main window not found; close-to-tray not registered"
+        );
+        return;
+    };
+
+    let window_clone = window.clone();
+    window.on_window_event(move |event| {
+        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+            api.prevent_default();
+            if let Err(e) = window_clone.hide() {
+                tracing::warn!(error = %e, "system_tray: window.hide() failed");
+            }
+        }
+    });
+}

--- a/crates/shikomi-gui/tauri.conf.json
+++ b/crates/shikomi-gui/tauri.conf.json
@@ -22,6 +22,17 @@
       }
     ]
   },
+  "plugins": {
+    "shell": {
+      "scope": [
+        {
+          "name": "shikomi",
+          "cmd": "shikomi",
+          "args": [{ "validator": "^start$" }]
+        }
+      ]
+    }
+  },
   "bundle": {
     "active": true,
     "targets": ["deb", "rpm", "appimage", "nsis", "msi", "dmg"],

--- a/crates/shikomi-gui/tests/it_system_tray.rs
+++ b/crates/shikomi-gui/tests/it_system_tray.rs
@@ -1,0 +1,190 @@
+//! 結合テスト — system-tray get_clipboard_countdown（TC-TRAY-IT01〜IT06）。
+//!
+//! 設計根拠: docs/features/shikomi-gui/system-tray/test-design.md §6
+//!          docs/features/shikomi-gui/system-tray/basic-design.md §3.3
+//!          docs/features/shikomi-gui/system-tray/detailed-design.md §5
+//!
+//! ## テストケース一覧
+//!
+//! | TC | 内容 |
+//! |---|---|
+//! | IT01 | AppState=None → Ok(remaining_secs: None)（daemon 未接続サイレントフォールバック） |
+//! | IT02 | MockDaemon ClipboardStatus { Some(20) } → Ok(remaining_secs: Some(20)) |
+//! | IT03 | MockDaemon ClipboardStatus { None } → Ok(remaining_secs: None) |
+//! | IT04 | MockDaemon 接続切断（IPC エラー）→ Ok(remaining_secs: None)（エラー非伝搬） |
+//! | IT05 | remaining_secs: Some(15) → JSON シリアライズ `{ "remaining_secs": 15 }`（数値） |
+//! | IT06 | remaining_secs: None → JSON シリアライズ `{ "remaining_secs": null }` |
+
+mod common;
+
+use shikomi_core::ipc::IpcResponse;
+use shikomi_gui::ipc_client::{commands::tray::get_clipboard_countdown, AppState, GuiIpcClient};
+use tauri::test::{mock_builder, mock_context, noop_assets};
+use tauri::Manager;
+use tokio::sync::Mutex;
+
+// ---------------------------------------------------------------------------
+// ヘルパ
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+fn build_none_app() -> tauri::App<tauri::test::MockRuntime> {
+    mock_builder()
+        .manage(Mutex::new(None::<GuiIpcClient>) as AppState)
+        .build(mock_context(noop_assets()))
+        .expect("failed to build mock app with None AppState")
+}
+
+#[cfg(unix)]
+async fn build_connected_app(
+    socket_path: &std::path::Path,
+) -> tauri::App<tauri::test::MockRuntime> {
+    let client = GuiIpcClient::connect(socket_path)
+        .await
+        .expect("GuiIpcClient::connect failed in test setup");
+    mock_builder()
+        .manage(Mutex::new(Some(client)) as AppState)
+        .build(mock_context(noop_assets()))
+        .expect("failed to build mock app with connected client")
+}
+
+// ---------------------------------------------------------------------------
+// TC-TRAY-IT01: AppState=None → Ok(remaining_secs: None)（サイレントフォールバック）
+// ---------------------------------------------------------------------------
+
+/// daemon 未接続（`AppState = None`）の場合、`get_clipboard_countdown` は
+/// `GUIError` を返さず `Ok(remaining_secs: None)` を返す。
+///
+/// 設計根拠: detailed-design.md §5.2（countdown polling がエラーパネルを誘発しない）
+#[cfg(unix)]
+#[tokio::test]
+async fn it01_get_clipboard_countdown_not_connected_returns_none() {
+    let app = build_none_app();
+    let state = app.state::<AppState>();
+    let result = get_clipboard_countdown(state).await;
+
+    // GUIError を返さない（Ok の確認）
+    let output =
+        result.expect("get_clipboard_countdown should return Ok even when not connected");
+    // remaining_secs は None（カウントダウン非アクティブ扱い）
+    assert_eq!(output.remaining_secs, None);
+}
+
+// ---------------------------------------------------------------------------
+// TC-TRAY-IT02: MockDaemon ClipboardStatus { Some(20) } → Ok(remaining_secs: Some(20))
+// ---------------------------------------------------------------------------
+
+/// MockDaemon が `ClipboardStatus { remaining_secs: Some(20) }` を返すとき、
+/// `get_clipboard_countdown` は `Ok(ClipboardCountdownResult { remaining_secs: Some(20) })` を返す。
+#[cfg(unix)]
+#[tokio::test]
+async fn it02_get_clipboard_countdown_active_remaining_20() {
+    let daemon = common::mock_daemon::MockDaemon::spawn(IpcResponse::ClipboardStatus {
+        remaining_secs: Some(20),
+    })
+    .await;
+    let app = build_connected_app(&daemon.socket_path).await;
+    let state = app.state::<AppState>();
+
+    let result = get_clipboard_countdown(state).await;
+
+    let output = result.expect("get_clipboard_countdown should succeed");
+    assert_eq!(output.remaining_secs, Some(20));
+}
+
+// ---------------------------------------------------------------------------
+// TC-TRAY-IT03: MockDaemon ClipboardStatus { None } → Ok(remaining_secs: None)
+// ---------------------------------------------------------------------------
+
+/// MockDaemon が `ClipboardStatus { remaining_secs: None }` を返すとき、
+/// `get_clipboard_countdown` は `Ok(ClipboardCountdownResult { remaining_secs: None })` を返す。
+#[cfg(unix)]
+#[tokio::test]
+async fn it03_get_clipboard_countdown_inactive_none() {
+    let daemon = common::mock_daemon::MockDaemon::spawn(IpcResponse::ClipboardStatus {
+        remaining_secs: None,
+    })
+    .await;
+    let app = build_connected_app(&daemon.socket_path).await;
+    let state = app.state::<AppState>();
+
+    let result = get_clipboard_countdown(state).await;
+
+    let output = result.expect("get_clipboard_countdown should succeed");
+    assert_eq!(output.remaining_secs, None);
+}
+
+// ---------------------------------------------------------------------------
+// TC-TRAY-IT04: IPC エラー（接続切断）→ Ok(remaining_secs: None)（エラー非伝搬）
+// ---------------------------------------------------------------------------
+
+/// MockDaemon が Handshake 後に接続を強制切断した場合、
+/// `get_clipboard_countdown` は `Err` を返さず `Ok(remaining_secs: None)` を返す。
+///
+/// 設計根拠: detailed-design.md §4.2（IPC エラー時は `tracing::debug!` のみ、エラー非伝搬）
+#[cfg(unix)]
+#[tokio::test]
+async fn it04_get_clipboard_countdown_ipc_error_silent_fallback() {
+    let daemon = common::mock_daemon::MockDaemon::spawn_disconnect_after_handshake().await;
+    let app = build_connected_app(&daemon.socket_path).await;
+    let state = app.state::<AppState>();
+
+    let result = get_clipboard_countdown(state).await;
+
+    // IPC エラーでも Ok を返す（countdown ポーリングがエラーパネルを誘発しない）
+    let output =
+        result.expect("get_clipboard_countdown should return Ok even on IPC error");
+    assert_eq!(output.remaining_secs, None);
+}
+
+// ---------------------------------------------------------------------------
+// TC-TRAY-IT05: remaining_secs: Some(15) → JSON `{ "remaining_secs": 15 }`
+// ---------------------------------------------------------------------------
+
+/// `remaining_secs: Some(15)` の場合、JSON シリアライズで `{ "remaining_secs": 15 }`（数値）となる。
+///
+/// 設計根拠: detailed-design.md §5.1 シリアライズ契約 / §9 SolidJS ペイロード型凍結
+#[cfg(unix)]
+#[tokio::test]
+async fn it05_serialize_remaining_secs_some_is_number() {
+    let daemon = common::mock_daemon::MockDaemon::spawn(IpcResponse::ClipboardStatus {
+        remaining_secs: Some(15),
+    })
+    .await;
+    let app = build_connected_app(&daemon.socket_path).await;
+    let state = app.state::<AppState>();
+
+    let output = get_clipboard_countdown(state)
+        .await
+        .expect("get_clipboard_countdown should succeed");
+
+    let json = serde_json::to_value(&output).expect("serialization should succeed");
+    // SolidJS 側が受け取る型: `remaining_secs` は number（null ではない）
+    assert_eq!(json["remaining_secs"], serde_json::json!(15u64));
+}
+
+// ---------------------------------------------------------------------------
+// TC-TRAY-IT06: remaining_secs: None → JSON `{ "remaining_secs": null }`
+// ---------------------------------------------------------------------------
+
+/// `remaining_secs: None` の場合、JSON シリアライズで `{ "remaining_secs": null }` となる。
+///
+/// 設計根拠: detailed-design.md §5.1 シリアライズ契約 / §9 SolidJS ペイロード型凍結
+#[cfg(unix)]
+#[tokio::test]
+async fn it06_serialize_remaining_secs_none_is_null() {
+    let daemon = common::mock_daemon::MockDaemon::spawn(IpcResponse::ClipboardStatus {
+        remaining_secs: None,
+    })
+    .await;
+    let app = build_connected_app(&daemon.socket_path).await;
+    let state = app.state::<AppState>();
+
+    let output = get_clipboard_countdown(state)
+        .await
+        .expect("get_clipboard_countdown should succeed");
+
+    let json = serde_json::to_value(&output).expect("serialization should succeed");
+    // SolidJS 側が受け取る型: `remaining_secs` は null（数値ではない）
+    assert_eq!(json["remaining_secs"], serde_json::Value::Null);
+}

--- a/crates/shikomi-gui/tests/it_system_tray.rs
+++ b/crates/shikomi-gui/tests/it_system_tray.rs
@@ -64,8 +64,7 @@ async fn it01_get_clipboard_countdown_not_connected_returns_none() {
     let result = get_clipboard_countdown(state).await;
 
     // GUIError を返さない（Ok の確認）
-    let output =
-        result.expect("get_clipboard_countdown should return Ok even when not connected");
+    let output = result.expect("get_clipboard_countdown should return Ok even when not connected");
     // remaining_secs は None（カウントダウン非アクティブ扱い）
     assert_eq!(output.remaining_secs, None);
 }
@@ -132,8 +131,7 @@ async fn it04_get_clipboard_countdown_ipc_error_silent_fallback() {
     let result = get_clipboard_countdown(state).await;
 
     // IPC エラーでも Ok を返す（countdown ポーリングがエラーパネルを誘発しない）
-    let output =
-        result.expect("get_clipboard_countdown should return Ok even on IPC error");
+    let output = result.expect("get_clipboard_countdown should return Ok even on IPC error");
     assert_eq!(output.remaining_secs, None);
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -193,6 +193,10 @@ skip = [
     { name = "windows_x86_64_gnullvm", version = "0.52" },
     { name = "windows_x86_64_msvc", version = "0.42" },
     { name = "windows_x86_64_msvc", version = "0.52" },
+    # tauri-plugin-shell v2.3.5 → shared_child → windows-sys 0.60 → windows-targets 0.53 が
+    # 既存依存と windows_i686_gnullvm 0.53.1 の重複を生じさせる。Issue #97 で導入。
+    # tauri-plugin-shell が windows-sys 0.61 系に追従次第、本エントリを削除して重複解消する。
+    { name = "windows_i686_gnullvm", version = "0.53" },
 ]
 skip-tree = []
 

--- a/docs/features/shikomi-gui/system-tray/basic-design.md
+++ b/docs/features/shikomi-gui/system-tray/basic-design.md
@@ -35,7 +35,7 @@ crates/shikomi-gui/src/
       tray.rs       ← get_clipboard_countdown Tauri Command（REQ-TRAY-04）
 ```
 
-**モジュール可視性規則**: `tooltip_text()` / `calc_remaining()` は `countdown.rs` 内のモジュールプライベート関数（`pub` なし）とする。`system_tray::setup()` のみ `pub fn` として `lib.rs` に公開する。
+**モジュール可視性規則**: `tooltip_text()` は `countdown.rs` 内のモジュールプライベート関数（`pub` なし）とする。`system_tray::setup()` のみ `pub fn` として `lib.rs` に公開する。`calc_remaining()` は A案適用により削除済み（残秒計算は daemon 側 `get_clipboard_status.rs` に一元化）。
 
 **追加依存パッケージ**:
 
@@ -83,7 +83,7 @@ flowchart TB
 |------|------|
 | トレイアイコン生成 | `TrayIconBuilder::new()` でアイコン・ツールチップ・メニューを設定し `build(app)` |
 | ウィンドウ close-to-tray 設定 | `app.get_webview_window("main")` に `on_window_event` ハンドラを登録 |
-| countdown タスク起動 | `tauri::async_runtime::spawn` で `countdown::run(app_handle)` を起動 |
+| countdown タスク起動 | `tauri::async_runtime::spawn` で `countdown::run(app_handle, tray_id)` を起動 |
 
 **アイコンリソース**: 既存の `icons/32x32.png`（`tauri.conf.json` の `bundle.icon` で定義済み）を使用する。OS 別アイコン解決は `tauri::image::Image::from_path` で行い、プラットフォーム差異を吸収する。
 

--- a/docs/features/shikomi-gui/system-tray/detailed-design.md
+++ b/docs/features/shikomi-gui/system-tray/detailed-design.md
@@ -129,21 +129,26 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    participant Task as countdown::run(app_handle)
-    participant Cmd as get_clipboard_countdown Command
+    participant Task as countdown::run(app_handle, tray_id)
+    participant Cmd as poll_remaining()
     participant Daemon as shikomi-daemon
+    participant App as AppHandle
     participant Tray as TrayIcon
+
     loop 1 秒ごと
         Task->>Task: tokio::time::sleep(1s)
-        Task->>Cmd: AppState.lock() → IpcRequest::GetClipboardStatus
-        Cmd->>Daemon: IPC round_trip
+        Task->>Cmd: poll_remaining(&app_handle)
+        Cmd->>Daemon: IpcRequest::GetClipboardStatus
         Daemon-->>Cmd: ClipboardStatus { remaining_secs }
-        Cmd-->>Task: ClipboardCountdownResult
+        Cmd-->>Task: Option<u64>
 
-        alt remaining_secs == Some(n), n > 0
-            Task->>Tray: set_tooltip("shikomi — クリップボードを自動消去まで {n} 秒")
-        else remaining_secs == None または 0
-            Task->>Tray: set_tooltip("shikomi")
+        Task->>App: tray_by_id(&tray_id)
+        alt TrayIcon 取得成功
+            App-->>Task: Some(tray)
+            Task->>Tray: tray.set_tooltip(tooltip_text(remaining))
+        else TrayIcon 消失（アプリ終了中）
+            App-->>Task: None
+            Task->>Task: break（ループ終了）
         end
     end
 ```
@@ -152,13 +157,16 @@ sequenceDiagram
 
 | ケース | 処理 |
 |--------|------|
-| `AppState` が `None`（daemon 未接続） | `ClipboardCountdownResult { remaining_secs: None }` とみなす（エラー伝搬なし）|
-| IPC 通信エラー | `tracing::debug!` でログのみ。ツールチップは前回状態を維持（polling failure = 非アクティブ扱いは過剰 reset のリスクがある）|
-| タスク panic | Tauri ランタイムが spawn タスクの panic を検知しないため、`catch_unwind` で囲み panic をログして継続する（countdown タスクの死がアプリ全体を止めない）|
+| `AppState` が `None`（daemon 未接続） | `poll_remaining()` が `None` を返す（エラー伝搬なし）。ツールチップは「shikomi」非アクティブ表示 |
+| IPC 通信エラー | `poll_remaining()` が `tracing::debug!` でログのみ、`None` を返す。ツールチップは「shikomi」に更新（過剰 reset のリスクより一貫性を優先）|
+| 予期しない IPC レスポンス variant | `tracing::debug!` でバリアント名をログ、`None` 返却 |
+| `set_tooltip` 失敗 | `tracing::warn!` でログしループ継続（best-effort。Linux Wayland 等の環境差異を吸収）|
+| `tray_by_id()` が `None`（トレイ消失） | ループを `break` で終了。アプリ終了中を示す。panic しない |
+| タスク panic | Tokio の spawn タスクは panic 発生時に当該タスクのみ終了し、アプリ全体を止めない（Tokio ランタイム保証）。`catch_unwind` は不要 |
 
 ### 4.3 タスクライフサイクル
 
-`countdown::run()` は `setup()` から spawn された後、アプリ終了まで継続するインフィニットループ。`AppHandle` の weak 参照を使い、ランタイム終了後も `set_tooltip` 呼び出しが panic しないよう安全にループを終了させる。エラーは `tracing::warn!` で記録しタスクを継続する。
+`countdown::run(app_handle, tray_id)` は `setup()` から `tauri::async_runtime::spawn` で起動する。`AppHandle` の strong 参照を保持し、毎ループで `app_handle.tray_by_id(&tray_id)` を呼ぶ。`None` が返った場合（トレイ破棄＝アプリ終了途中）は `break` でループを自然終了する。weak 参照を使わない理由: Tauri v2 の `tray_by_id()` が `Option` を返すことで生存確認が完結するため、weak 参照による二重管理は不要（KISS）。
 
 ---
 

--- a/docs/features/shikomi-gui/system-tray/detailed-design.md
+++ b/docs/features/shikomi-gui/system-tray/detailed-design.md
@@ -26,7 +26,7 @@ sequenceDiagram
     SetupFn->>SetupFn: tray.on_tray_icon_event(右クリック → popup)
     SetupFn->>SetupFn: menu.on_menu_event(id 分岐)
     SetupFn->>Window: on_window_event(CloseRequested → prevent_default + hide)
-    SetupFn->>CountdownTask: tauri::async_runtime::spawn(countdown::run(app_handle))
+    SetupFn->>CountdownTask: tauri::async_runtime::spawn(countdown::run(app_handle, tray_id))
     CountdownTask-->>SetupFn: JoinHandle（drop 時 abort）
 ```
 
@@ -245,7 +245,7 @@ daemon 未接続（`AppState == None`）の場合、IPC 呼び出しをスキッ
 | 関数名 | 可視性 | 役割 |
 |--------|--------|------|
 | `tooltip_text(remaining: Option<u64>) -> String` | `fn`（モジュールプライベート） | ツールチップ文字列を生成する純粋関数。`countdown.rs` 内でのみ呼ぶ |
-| `calc_remaining(started_at: Instant, now: Instant) -> Option<u64>` | `fn`（モジュールプライベート） | 経過時間から残秒を計算する純粋関数。`now` を引数注入することで `Instant::now()` 依存を排除しテスト可能にする |
+
 
 どちらも `pub fn` にしない。呼び出し元は `countdown::run()` のみ。
 

--- a/docs/features/shikomi-gui/system-tray/detailed-design.md
+++ b/docs/features/shikomi-gui/system-tray/detailed-design.md
@@ -247,7 +247,7 @@ daemon 未接続（`AppState == None`）の場合、IPC 呼び出しをスキッ
 | `tooltip_text(remaining: Option<u64>) -> String` | `fn`（モジュールプライベート） | ツールチップ文字列を生成する純粋関数。`countdown.rs` 内でのみ呼ぶ |
 
 
-どちらも `pub fn` にしない。呼び出し元は `countdown::run()` のみ。
+この関数も `pub fn` にしない。呼び出し元は `countdown::run()` のみ。
 
 ---
 

--- a/docs/features/shikomi-gui/system-tray/test-design.md
+++ b/docs/features/shikomi-gui/system-tray/test-design.md
@@ -13,9 +13,11 @@
 
 `TrayIcon`・`AppHandle`・`WebviewWindow` などの Tauri ランタイム API は、UT/IT レベルでの完全モックが困難なため、次の方針を取る:
 
-1. **純粋ロジックを関数として分離**し UT で検証する（ツールチップ文字列生成・残秒計算）
+1. **純粋ロジックを関数として分離**し UT で検証する（ツールチップ文字列生成）
 2. **Tauri Command (`get_clipboard_countdown`)** は `AppState` + MockDaemon で IT 検証する
 3. **Tauri ランタイム操作（`window.show()`・`app.exit()`・`tray.set_tooltip()`）** は Tauri フレームワーク動作として信頼し、IT/UT 対象外とする。tracing ログを証跡として残す
+
+> **残秒計算の責務分離**: `remaining_secs` の計算（`countdown_started_at` → 経過秒 → 残秒）は `shikomi-daemon` 側 `get_clipboard_status.rs` の責務。GUI 側 `countdown.rs` は IPC レスポンスの `remaining_secs: Option<u64>` をそのまま `tooltip_text()` に渡す（DRY: daemon 側に一元化）。
 
 ---
 
@@ -24,7 +26,6 @@
 | テスト | 外部 I/O | 依存対象 | 対処 | Fixture 状態 |
 |-------|---------|---------|------|------------|
 | IT（`get_clipboard_countdown`） | UDS / Named Pipe（daemon 接続） | `GuiIpcClient`（`IpcRequest::GetClipboardStatus`） | `MockDaemon`（Sub-B 実装済み `tests/common/mock_daemon.rs`）で差し替え | 流用可（Sub-B の MockDaemon は `shikomi-core::ipc` 実フォーマット準拠済み） |
-| UT（残秒計算） | `Instant::now()` | 時刻 | テスト内で `Instant` を固定値として引数渡し（依存注入。`countdown_started_at` + `now` を引数で受け取る純粋関数として設計） | 不要 |
 | UT（ツールチップ文字列） | なし | 純粋計算（文字列フォーマット） | モック不要 | 不要 |
 | IT（`get_clipboard_countdown` — IPC エラー） | UDS | MockDaemon が接続切断 | `MockDaemon` が接続拒否するよう設定 | 流用可 |
 
@@ -38,7 +39,6 @@
 | テストレベル | 配置先 | 実行コマンド |
 |------------|--------|------------|
 | UT（ツールチップ文字列生成） | `crates/shikomi-gui/src/system_tray/countdown.rs` 内 `#[cfg(test)]` | `cargo test -p shikomi-gui` |
-| UT（残秒計算ロジック） | `crates/shikomi-gui/src/system_tray/countdown.rs` 内 `#[cfg(test)]` | `cargo test -p shikomi-gui` |
 | IT（`get_clipboard_countdown` Command） | `crates/shikomi-gui/tests/it_system_tray.rs` | `cargo test -p shikomi-gui` |
 
 ---
@@ -64,10 +64,6 @@ Sub-B と同様。Tauri Command ハンドラは `tauri::State<AppState>` を受�
 | daemon 接続済み | `Arc::new(tokio::sync::Mutex::new(Some(client)))` |
 | daemon 未接続 | `Arc::new(tokio::sync::Mutex::new(None))` |
 
-### 3.3 時刻固定（残秒計算 UT）
-
-`remaining_secs` 計算ロジックは `fn calc_remaining(started_at: Option<Instant>, now: Instant) -> Option<u64>` として純粋関数に分離する（詳細設計 §6.2 の計算をテスト容易な形に実装する）。テストでは `Instant` を固定値として渡すことで `Instant::now()` への依存をなくす。
-
 ---
 
 ## 4. テストマトリクス（トレーサビリティ）
@@ -80,11 +76,6 @@ Sub-B と同様。Tauri Command ハンドラは `tauri::State<AppState>` を受�
 | TC-GUI-TRAY-UT02 | REQ-TRAY-05 | `detailed-design.md §10` 文言一覧 | `remaining_secs=Some(1)` → `"shikomi — クリップボードを自動消去まで 1 秒"`（最小正値） | 正常系（境界値） |
 | TC-GUI-TRAY-UT03 | REQ-TRAY-05 | `detailed-design.md §4.1`（`n > 0` 条件） | `remaining_secs=Some(0)` → `"shikomi"`（0秒は非アクティブ扱い） | 正常系（境界値） |
 | TC-GUI-TRAY-UT04 | REQ-TRAY-05 | `detailed-design.md §10` 文言一覧 | `remaining_secs=None` → `"shikomi"` | 正常系 |
-| TC-GUI-TRAY-UT05 | REQ-TRAY-04 | `detailed-design.md §6.2` | `countdown_started_at=None` → `calc_remaining(None, now)` → `None` | 正常系 |
-| TC-GUI-TRAY-UT06 | REQ-TRAY-04 | `detailed-design.md §6.2` | `elapsed=10s`（`CLEAR_TIMEOUT_SECS=30`）→ `calc_remaining(...)` → `Some(20)` | 正常系 |
-| TC-GUI-TRAY-UT07 | REQ-TRAY-04 | `detailed-design.md §6.2` | `elapsed=30s`（境界: 丁度タイムアウト）→ `calc_remaining(...)` → `None` | 正常系（境界値） |
-| TC-GUI-TRAY-UT08 | REQ-TRAY-04 | `detailed-design.md §6.2` | `elapsed=31s`（超過）→ `calc_remaining(...)` → `None` | 正常系（境界値） |
-| TC-GUI-TRAY-UT09 | REQ-TRAY-04 | `detailed-design.md §6.2` | `elapsed=29s` → `calc_remaining(...)` → `Some(1)`（最小正値境界） | 正常系（境界値） |
 
 ### 4.2 結合テスト
 
@@ -108,7 +99,7 @@ Sub-B と同様。Tauri Command ハンドラは `tauri::State<AppState>` を受�
 | 対応する要件ID | REQ-TRAY-05（R1-GUI-15） |
 | 対応する工程 | 階層 3 詳細設計（`detailed-design.md §10` 文言一覧） |
 | 種別 | 正常系・境界値 |
-| テスト対象関数 | `tooltip_text(remaining_secs: Option<u64>) -> &'static str / String` |
+| テスト対象関数 | `tooltip_text(remaining_secs: Option<u64>) -> String` |
 | 前提条件 | 純粋関数呼び出し。外部依存なし |
 | 操作・期待結果 | 下表参照 |
 
@@ -121,26 +112,7 @@ Sub-B と同様。Tauri Command ハンドラは `tauri::State<AppState>` を受�
 
 **設計根拠**: `detailed-design.md §4.1` の分岐条件「`remaining_secs == Some(n), n > 0`」と `§10` 文言テーブルの完全一致を検証する。ツールチップ文字列はこの関数が単一責務を持ち、`countdown::run()` と `tray.set_tooltip()` 呼び出し側で生成しない（DRY）。
 
----
-
-### TC-GUI-TRAY-UT05〜UT09: 残秒計算ロジック（REQ-TRAY-04）
-
-| 項目 | 内容 |
-|------|------|
-| 対応する要件ID | REQ-TRAY-04（R1-GUI-15） |
-| 対応する工程 | 階層 3 詳細設計（`detailed-design.md §6.2`） |
-| テスト対象関数 | `calc_remaining(started_at: Option<Instant>, now: Instant) -> Option<u64>` |
-| 前提条件 | `CLEAR_TIMEOUT_SECS = 30`（定数）。`now` と `started_at` を引数で渡す（時刻依存注入） |
-
-| テスト ID | `started_at` | `now - started_at` | 期待 `remaining_secs` | 種別 |
-|---------|------------|---------|------|------|
-| TC-GUI-TRAY-UT05 | `None` | — | `None`（非アクティブ） | 正常系 |
-| TC-GUI-TRAY-UT06 | `Some(t)` | 10秒 | `Some(20)` | 正常系 |
-| TC-GUI-TRAY-UT07 | `Some(t)` | 30秒（境界: 丁度タイムアウト） | `None` | 境界値 |
-| TC-GUI-TRAY-UT08 | `Some(t)` | 31秒（超過） | `None` | 境界値 |
-| TC-GUI-TRAY-UT09 | `Some(t)` | 29秒 | `Some(1)`（最小正値） | 境界値 |
-
-**設計根拠**: `detailed-design.md §6.2` の 3 条件分岐（`None` / `elapsed >= CLEAR_TIMEOUT_SECS` / `elapsed < CLEAR_TIMEOUT_SECS`）を全て網羅する。`Instant::now()` を引数として外から渡すことでテスト時の時刻固定を実現し、assumed mock 禁止を守る。
+> **残秒計算 UT は daemon 側で実施**: `calc_remaining` は `shikomi-daemon/src/ipc/v2_handler/get_clipboard_status.rs` の責務。境界値（elapsed=0/1/29/30/31 秒）は daemon UT で網羅する（§8 参照表）。GUI 側に残秒計算ロジックを持たせない（DRY 原則）。
 
 ---
 
@@ -239,15 +211,17 @@ Sub-B と同様。Tauri Command ハンドラは `tauri::State<AppState>` を受�
 
 ## 8. daemon 側テスト設計（参照）
 
-`GetClipboardStatus` ハンドラ・`countdown_started_at` 状態機械は `shikomi-daemon` crate のスコープ。以下は本設計書の参照情報として記載するが、実装・テストは `crates/shikomi-daemon/` 内で行う。
+`GetClipboardStatus` ハンドラ・`countdown_started_at` 状態機械は `shikomi-daemon` crate のスコープ。**残秒計算ロジック（`calc_remaining`）は `crates/shikomi-daemon/src/ipc/v2_handler/get_clipboard_status.rs` に一元化**されており、境界値を含む全 UT はそこで実施する。
 
-| daemon 側テスト | 対応する要件 | 配置先 |
-|--------------|-----------|--------|
-| `countdown_started_at=None` → `GetClipboardStatus` → `remaining_secs: None` | `basic-design.md §3.2` | daemon UT |
-| Secret 投入 → `countdown_started_at = Some(Instant::now())` | `detailed-design.md §6.1` | daemon IT |
-| ClearTimer 完了 → `countdown_started_at = None` | `detailed-design.md §6.1` | daemon IT |
-| `elapsed < CLEAR_TIMEOUT_SECS` → `remaining_secs: Some(n)` | `detailed-design.md §6.2` | daemon UT |
-| `elapsed >= CLEAR_TIMEOUT_SECS` → `remaining_secs: None` | `detailed-design.md §6.2` | daemon UT |
+| daemon 側テスト関数名 | 入力（elapsed） | 期待 `remaining_secs` | 配置先 |
+|---------------------|--------------|---------------------|--------|
+| `returns_none_when_not_started` | `countdown_started_at=None` | `None` | `get_clipboard_status.rs` UT |
+| `returns_some_when_active` | 10秒 | `Some(20)` | `get_clipboard_status.rs` UT |
+| `returns_none_when_elapsed_exceeds_timeout` | 31秒（超過） | `None` | `get_clipboard_status.rs` UT |
+| `returns_none_when_elapsed_equals_timeout` | 30秒（境界: 丁度タイムアウト） | `None` | `get_clipboard_status.rs` UT |
+| `returns_one_when_29_seconds_elapsed` | 29秒（最小正値境界） | `Some(1)` | `get_clipboard_status.rs` UT |
+
+> これら 5 件の daemon UT が `CLEAR_TIMEOUT_SECS=30` 前後の境界値を網羅する。GUI 側に残秒計算ロジックを複製しない（DRY 原則）。
 
 ---
 
@@ -256,7 +230,6 @@ Sub-B と同様。Tauri Command ハンドラは `tauri::State<AppState>` を受�
 | テスト対象 | モック要否 | 実装方法 |
 |----------|---------|---------|
 | UDS / Named Pipe（daemon 接続） | **IT で差し替え** | Sub-B 実装済み `tests/common/mock_daemon.rs` に `ClipboardStatus` レスポンス追加 |
-| `Instant::now()` | **UT で依存注入** | `calc_remaining(started_at, now: Instant)` に `now` を引数で渡す |
 | `TrayIcon`・`AppHandle`・`WebviewWindow` | **UT/IT 対象外** | 純粋ロジック分離で回避。残りはシステムテスト |
 | `AppState` | **IT で直接構築** | `Arc::new(Mutex::new(Some(client)))` / `None` |
 | `ClipboardCountdownResult` シリアライズ | **モック不要** | 純粋計算。実 `serde_json` を通す |
@@ -269,7 +242,7 @@ Sub-B と同様。Tauri Command ハンドラは `tauri::State<AppState>` を受�
 
 | テスト | ワークフロー | 備考 |
 |-------|------------|------|
-| TC-GUI-TRAY-UT01〜UT09（9件） | `lint.yml` + 既存 `test-gui.yml` | UDS 不使用のためヘッドレス OK |
+| TC-GUI-TRAY-UT01〜UT04（4件） | `lint.yml` + 既存 `test-gui.yml` | UDS 不使用のためヘッドレス OK |
 | TC-GUI-TRAY-IT01〜IT06（6件） | 既存 `test-gui.yml` | tempfile + UDS 使用。Linux/macOS で実行 |
 | Windows IT | `windows.yml` | Named Pipe 経路で TC-TRAY-IT01〜IT04 相当を実行（Sub-B `it_ipc_client.rs` と同パターン）|
 
@@ -282,10 +255,12 @@ Sub-B と同様。Tauri Command ハンドラは `tauri::State<AppState>` を受�
 | REQ-TRAY 全件網羅 | REQ-TRAY-04, 05 が IT または UT でカバーされること（REQ-TRAY-01〜03, 06 は Tauri ランタイム依存のためシステムテスト担当）|
 | 正常系 | `get_clipboard_countdown` の全パス（未接続 / カウントダウン中 / 非アクティブ）必須 |
 | 異常系 | IPC 通信エラー時の非伝搬を必ず検証 |
-| 境界値 | 残秒 0・1・29・30・31 秒を必ず含む（`CLEAR_TIMEOUT_SECS=30` 前後の挙動） |
+| 境界値（ツールチップ） | `tooltip_text` への入力: `Some(1)`（最小正値）・`Some(0)`（非アクティブ境界）・`None` を必ず含む |
+| 境界値（残秒計算） | `calc_remaining` の elapsed 0/1/29/30/31 秒は daemon UT（`get_clipboard_status.rs`）で担保（§8 参照） |
 | シリアライズ | `remaining_secs: Some(n)` → `number`、`None` → `null` の JSON 型契約を IT で検証 |
 
 ---
 
 *作成: 涅マユリ（テスト担当）/ 2026-05-11*
 *設計根拠: `docs/features/shikomi-gui/system-tray/basic-design.md` §モジュール契約 / `detailed-design.md` §1〜9 / Issue #97*
+*A案適用 (2026-05-11): `calc_remaining` を GUI 側から削除。残秒計算 UT は daemon 側 `get_clipboard_status.rs` に一元化。GUI UT は `tooltip_text` 境界値 4 件のみ。*


### PR DESCRIPTION
## Summary

Closes #97

- **shikomi-core**: `IpcRequest::GetClipboardStatus` / `IpcResponse::ClipboardStatus { remaining_secs }` 追加（non-exhaustive 非破壊変更）
- **shikomi-daemon**: `HotkeyEventLoop` に `countdown_started_at: Arc<Mutex<Option<Instant>>>` 追加、`GetClipboardStatus` IPC ハンドラ新規実装（`get_clipboard_status.rs`）、`IpcServer` / `V2Context` に共有状態を配線
- **shikomi-gui**: `system_tray/mod.rs`（setup + close-to-tray）/ `menu.rs`（3 項目 + メニューハンドラ）/ `countdown.rs`（1 秒ポーリングタスク）を新規作成。`ipc_client/commands/tray.rs` に `get_clipboard_countdown` Tauri Command 追加。`tauri-plugin-shell` 統合（`shikomi start` 再起動）。

## Test plan

- [ ] `cargo test -p shikomi-daemon --lib` — 77 件通過確認
- [ ] `cargo test -p shikomi-core --lib` — 224 件通過確認
- [ ] countdown.rs 内ユニットテスト（TC-TRAY-UT01〜07）: `tooltip_text` / `calc_remaining` の境界値
- [ ] get_clipboard_status.rs 内ユニットテスト: elapsed 計算ロジック境界値
- [ ] テスト担当: `docs/features/shikomi-gui/system-tray/test-design.md` 記載のテストケースを確認