### PR TITLE
fix(windows-ci): normalize_tempdir_dacl — TempDir DACL 継承を遮断（Issue #86）

### DIFF
--- a/crates/shikomi-cli/Cargo.toml
+++ b/crates/shikomi-cli/Cargo.toml
@@ -75,6 +75,11 @@ serial_test   = { workspace = true }
 # 暗号化 vault フィクスチャ helper (tests/common/fixtures.rs) で SQLite を直接書き出すため。
 # CLI 本体は rusqlite を参照しない（`shikomi-infra` 経由）。本依存はテスト限定。
 rusqlite      = { workspace = true }
+# Windows テスト: normalize_tempdir_dacl（test-fixtures feature gate）を CLI テストヘルパ
+# （tests/common/mod.rs）から参照するため dev-dependencies で明示的に feature を有効化する。
+# justfile/CI のフラグに依存せず `cargo test -p shikomi-cli` 単体でも Windows でコンパイル可能。
+# 設計根拠: docs/features/vault-persistence/test-design/integration/index.md
+shikomi-infra = { path = "../shikomi-infra", features = ["test-fixtures"] }
 
 [lints]
 workspace = true

--- a/crates/shikomi-cli/tests/common/mod.rs
+++ b/crates/shikomi-cli/tests/common/mod.rs
@@ -52,8 +52,10 @@ pub fn tighten_perms_unix(path: &Path) {
 
 #[cfg(windows)]
 pub fn tighten_perms_unix(path: &Path) {
-    shikomi_infra::persistence::ensure_vault_dir(path)
-        .expect("ensure_vault_dir (Windows DACL) failed");
+    // TempDir::new() は %TEMP% から DACL を継承するため、
+    // PermissionGuard::verify_dir の不変条件④（EXPECTED_DIR_MASK 完全一致）が通らない。
+    // normalize_tempdir_dacl で DACL を正規化してから load() を呼ぶ（Issue #86）。
+    shikomi_infra::persistence::normalize_tempdir_dacl(path);
 }
 
 #[cfg(not(any(unix, windows)))]

--- a/crates/shikomi-infra/src/persistence/mod.rs
+++ b/crates/shikomi-infra/src/persistence/mod.rs
@@ -71,6 +71,20 @@ pub fn ensure_vault_file(path: &std::path::Path) -> Result<(), PersistenceError>
     permission::PermissionGuard::ensure_file(path)
 }
 
+/// テスト専用（Windows）: TempDir の継承 DACL を正規化する。
+///
+/// `TempDir::new()` は `%TEMP%` から DACL を継承するため、
+/// `PermissionGuard::verify_dir` の不変条件④（`EXPECTED_DIR_MASK` 完全一致）が通らない。
+/// 本関数を `load()` / `prepare_dir()` の前に呼ぶことで `verify_dir` を確実に通過させる。
+///
+/// `test-fixtures` feature または `cfg(test)` でのみ利用可能（本番バイナリへの混入防止）。
+#[cfg(any(test, feature = "test-fixtures"))]
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn normalize_tempdir_dacl(path: &std::path::Path) {
+    permission::normalize_tempdir_dacl(path)
+}
+
 // -------------------------------------------------------------------
 // VaultRepository trait
 // -------------------------------------------------------------------

--- a/crates/shikomi-infra/src/persistence/permission/mod.rs
+++ b/crates/shikomi-infra/src/persistence/permission/mod.rs
@@ -13,6 +13,15 @@ use super::error::PersistenceError;
 // PermissionGuard
 // -------------------------------------------------------------------
 
+/// テスト専用（Windows）: TempDir の継承 DACL を正規化する。
+///
+/// `test-fixtures` feature または `cfg(test)` でのみ利用可能。
+#[cfg(any(test, feature = "test-fixtures"))]
+#[cfg(windows)]
+pub(crate) fn normalize_tempdir_dacl(path: &std::path::Path) {
+    windows::normalize_tempdir_dacl(path)
+}
+
 /// パーミッション操作を提供するゼロサイズ型。
 pub(crate) struct PermissionGuard;
 

--- a/crates/shikomi-infra/src/persistence/permission/windows/ensure.rs
+++ b/crates/shikomi-infra/src/persistence/permission/windows/ensure.rs
@@ -85,7 +85,7 @@ pub(in crate::persistence::permission) fn verify_dir(path: &Path) -> Result<(), 
 /// Win32 API 失敗時は `expect()` でパニックする（Fail Fast 原則、テストセットアップ失敗は即断）。
 /// `SE_SECURITY_PRIVILEGE` 不要（DACL 変更は所有者権限で動作）。
 #[cfg(any(test, feature = "test-fixtures"))]
-pub(super) fn normalize_tempdir_dacl(path: &Path) {
+pub(crate) fn normalize_tempdir_dacl(path: &Path) {
     // Step 1: GetNamedSecurityInfoW — 現在の所有者 SID を取得
     let (_sd_guard, owner_sid) = fetch_owner_sid_from_path(path)
         .expect("normalize_tempdir_dacl: fetch_owner_sid_from_path failed");

--- a/crates/shikomi-infra/src/persistence/permission/windows/ensure.rs
+++ b/crates/shikomi-infra/src/persistence/permission/windows/ensure.rs
@@ -68,6 +68,38 @@ pub(in crate::persistence::permission) fn verify_dir(path: &Path) -> Result<(), 
     )
 }
 
+/// Windows テスト環境専用: TempDir の継承 DACL を正規化する。
+///
+/// `TempDir::new()` は `%TEMP%` から DACL を継承するため、
+/// `PermissionGuard::verify_dir` の不変条件④（`EXPECTED_DIR_MASK` 完全一致）が通らない。
+/// 本関数を `load()` / `prepare_dir()` の前に呼ぶことで `verify_dir` を確実に通過させる。
+///
+/// 内部実装:
+/// - Step 1: `GetNamedSecurityInfoW` — 現在の所有者 SID を取得
+/// - Step 2: `SetEntriesInAclW` — `EXPECTED_DIR_MASK` で新 DACL を構築
+/// - Step 3: `SetNamedSecurityInfoW(PROTECTED_DACL_SECURITY_INFORMATION)` — 適用
+///           `PROTECTED_DACL_SECURITY_INFORMATION` を使い親からの継承を遮断する
+///
+/// # Panics
+///
+/// Win32 API 失敗時は `expect()` でパニックする（Fail Fast 原則、テストセットアップ失敗は即断）。
+/// `SE_SECURITY_PRIVILEGE` 不要（DACL 変更は所有者権限で動作）。
+#[cfg(any(test, feature = "test-fixtures"))]
+pub(super) fn normalize_tempdir_dacl(path: &Path) {
+    // Step 1: GetNamedSecurityInfoW — 現在の所有者 SID を取得
+    let (_sd_guard, owner_sid) = fetch_owner_sid_from_path(path)
+        .expect("normalize_tempdir_dacl: fetch_owner_sid_from_path failed");
+
+    // Step 2: SetEntriesInAclW — EXPECTED_DIR_MASK で新 DACL を構築
+    let acl_guard = build_owner_only_dacl(owner_sid, EXPECTED_DIR_MASK, path, EXPECTED_DIR_STR)
+        .expect("normalize_tempdir_dacl: build_owner_only_dacl failed");
+
+    // Step 3: SetNamedSecurityInfoW(PROTECTED_DACL_SECURITY_INFORMATION) — 適用
+    //         親からの ACE 継承を遮断する
+    apply_protected_dacl(path, &acl_guard)
+        .expect("normalize_tempdir_dacl: apply_protected_dacl failed");
+}
+
 /// ファイルの DACL が 4 不変条件をすべて満たすか検証する。
 ///
 /// # Errors

--- a/crates/shikomi-infra/src/persistence/permission/windows/mod.rs
+++ b/crates/shikomi-infra/src/persistence/permission/windows/mod.rs
@@ -14,6 +14,9 @@ mod verify;
 
 pub(super) use ensure::{ensure_dir, ensure_file, verify_dir, verify_file};
 
+#[cfg(any(test, feature = "test-fixtures"))]
+pub(crate) use ensure::normalize_tempdir_dacl;
+
 // ---------------------------------------------------------------------------
 // 定数
 // ---------------------------------------------------------------------------

--- a/crates/shikomi-infra/tests/helpers/mod.rs
+++ b/crates/shikomi-infra/tests/helpers/mod.rs
@@ -26,7 +26,17 @@ pub static ENV_MUTEX: Mutex<()> = Mutex::new(());
 ///
 /// `SHIKOMI_VAULT_DIR` 環境変数経由で `SqliteVaultRepository::new()` を呼び出す。
 /// `ENV_MUTEX` でプロセス内アクセスを直列化し、並列テストでの env 競合を防ぐ。
+///
+/// Windows: `TempDir::new()` は `%TEMP%` から DACL を継承するため、
+/// `PermissionGuard::verify_dir` の不変条件④（`EXPECTED_DIR_MASK` 完全一致）が通らない。
+/// `normalize_tempdir_dacl` で DACL を正規化して `load()` を確実に通過させる（Issue #86）。
 pub fn make_repo(dir: &Path) -> SqliteVaultRepository {
+    // Windows: load() 前に TempDir の継承 DACL を正規化する（Issue #86）。
+    // save() 経由の場合は ensure_dir が自動設定するため不要だが、
+    // load() を直接呼ぶケースで verify_dir が通らないことを防ぐ。
+    #[cfg(all(windows, feature = "test-fixtures"))]
+    shikomi_infra::persistence::normalize_tempdir_dacl(dir);
+
     let _guard = ENV_MUTEX.lock().unwrap();
     std::env::set_var("SHIKOMI_VAULT_DIR", dir);
     let repo = SqliteVaultRepository::new().unwrap();


### PR DESCRIPTION
## Summary

- `shikomi-infra` に `normalize_tempdir_dacl` ヘルパを実装（`#[cfg(any(test, feature = "test-fixtures"))]` + `#[cfg(windows)]`）
- `GetNamedSecurityInfoW` → `SetEntriesInAclW(EXPECTED_DIR_MASK)` → `SetNamedSecurityInfoW(PROTECTED_DACL_SECURITY_INFORMATION)` の 3 ステップで DACL 継承を遮断
- `EXPECTED_DIR_MASK` は既存定数を再利用（DRY、重複なし）
- CLI / infra 両テストから `shikomi_infra::persistence::normalize_tempdir_dacl` を呼び出し（Win32 コード重複なし）
- `test-fixtures` feature がデフォルトに含まれないことを確認済み

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `shikomi-infra/src/persistence/permission/windows/ensure.rs` | `normalize_tempdir_dacl` を追加（3 ステップ実装） |
| `shikomi-infra/src/persistence/permission/windows/mod.rs` | `pub(crate)` 再エクスポートを追加 |
| `shikomi-infra/src/persistence/permission/mod.rs` | `pub(crate)` ラッパ関数を追加 |
| `shikomi-infra/src/persistence/mod.rs` | `pub` 再エクスポートを追加 |
| `shikomi-cli/tests/common/mod.rs` | `tighten_perms_unix`(Windows) を `normalize_tempdir_dacl` に更新 |
| `shikomi-infra/tests/helpers/mod.rs` | `make_repo` に `normalize_tempdir_dacl` 呼び出しを追加 |

Closes #86

## Test plan

- [ ] Windows CI (`windows.yml`) で DACL 関連テスト（TC-I24〜I27、TC-U17〜U26）が全件 PASS すること
- [ ] Linux/macOS CI への影響なし（`#[cfg(windows)]` でゲート済み）
- [ ] `cargo fmt --all -- --check` PASS（実施済み）
- [ ] `cargo clippy -p shikomi-infra -p shikomi-cli --all-targets --features shikomi-infra/test-fixtures` PASS（実施済み、既存 warning のみ）
- [ ] `cargo deny` / `cargo audit` PASS（依存追加なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)