### PR TITLE
[#78] Sub-F アクセシビリティ出力 結合テスト設計（TC-F-A01〜A05）

### DIFF
--- a/docs/features/cli-vault-commands/test-design/index.md
+++ b/docs/features/cli-vault-commands/test-design/index.md
@@ -22,7 +22,7 @@
 |----------|------|-----------|
 | `index.md`（本書） | 概要、レベル戦略、トレーサビリティマトリクス、モック方針、カバレッジ基準 | — |
 | `e2e.md` | E2E テスト設計（`assert_cmd` + `tempfile`）と証跡 | TC-E2E-001〜102 |
-| `integration.md` | UseCase 単位 結合テスト（実 SQLite + `tempfile`）/ §10 Sub-F vault サブコマンド 結合テスト（CLI→IPC V2、`DaemonSpawn` + `expectrl` PTY）/ §10.4.8 インジェクション境界値 / §11 Sub-F アクセシビリティ出力 結合テスト（PDF / BRF / Audio、`#![cfg(unix)]`）| TC-IT-001〜050 / TC-F-I01〜I12（I11a/I11b 含む）/ TC-F-A01〜A05 |
+| `integration.md` | UseCase 単位 結合テスト（実 SQLite + `tempfile`）/ §10 Sub-F vault サブコマンド 結合テスト（CLI→IPC V2、`DaemonSpawn` + `expectrl` PTY）/ §10.4.8 インジェクション境界値 / §11 Sub-F アクセシビリティ出力 結合テスト（PDF / BRF / Audio、`#![cfg(unix)]`）| TC-IT-001〜050 / TC-F-I01〜I12（I11a/I11b 含む）/ TC-F-A01〜A06 |
 | `unit.md` | pure function ユニットテスト + 実装担当への引き継ぎ事項 | TC-UT-001〜091 |
 | `ci.md` | CI 検証ケース、ファイル配置、証跡提出方針、実行コマンド | TC-CI-001〜015 |
 

--- a/docs/features/cli-vault-commands/test-design/index.md
+++ b/docs/features/cli-vault-commands/test-design/index.md
@@ -22,7 +22,7 @@
 |----------|------|-----------|
 | `index.md`（本書） | 概要、レベル戦略、トレーサビリティマトリクス、モック方針、カバレッジ基準 | — |
 | `e2e.md` | E2E テスト設計（`assert_cmd` + `tempfile`）と証跡 | TC-E2E-001〜102 |
-| `integration.md` | UseCase 単位 結合テスト（実 SQLite + `tempfile`）/ §10 Sub-F vault サブコマンド 結合テスト（CLI→IPC V2、`DaemonSpawn` + `expectrl` PTY）/ §10.4.8 インジェクション境界値 | TC-IT-001〜050 / TC-F-I01〜I12（I11a/I11b 含む）|
+| `integration.md` | UseCase 単位 結合テスト（実 SQLite + `tempfile`）/ §10 Sub-F vault サブコマンド 結合テスト（CLI→IPC V2、`DaemonSpawn` + `expectrl` PTY）/ §10.4.8 インジェクション境界値 / §11 Sub-F アクセシビリティ出力 結合テスト（PDF / BRF / Audio、`#![cfg(unix)]`）| TC-IT-001〜050 / TC-F-I01〜I12（I11a/I11b 含む）/ TC-F-A01〜A05 |
 | `unit.md` | pure function ユニットテスト + 実装担当への引き継ぎ事項 | TC-UT-001〜091 |
 | `ci.md` | CI 検証ケース、ファイル配置、証跡提出方針、実行コマンド | TC-CI-001〜015 |
 

--- a/docs/features/cli-vault-commands/test-design/integration.md
+++ b/docs/features/cli-vault-commands/test-design/integration.md
@@ -389,4 +389,74 @@ TC-F-I10a〜d のうち Windows で skip するものおよび TC-F-I11b も同�
 
 ---
 
+## 11. Sub-F vault アクセシビリティ出力 結合テスト（TC-F-A01〜A05）
+
+> Issue #78 / #74-D。  
+> SSoT: `vault-encryption/test-design/sub-f-cli-subcommands/index.md §15.7`（Rev1）
+
+### 11.1 設計方針
+
+- **テスト対象**: `shikomi vault encrypt --output {print,braille,audio}` のアクセシビリティ出力経路 + `SHIKOMI_ACCESSIBILITY=1` 自動切替 + umask 077 ファイル権限
+- **エントリポイント**: §10 同様、`assert_cmd::Command::cargo_bin("shikomi")` で実バイナリ呼び出し（clap パース込み）
+- **daemon 依存**: `vault encrypt` は IPC V2 経由で daemon が暗号化処理を担うため、全 TC で `DaemonSpawn` を使用（§10.2 と同一セットアップ）
+- **TTY 入力**: C-38 stdin パイプ拒否により、パスフレーズは `expectrl` PTY 経由で入力する
+- **ファイルガード**: `crates/shikomi-cli/tests/accessibility_paths.rs` の先頭に `#![cfg(unix)]` を付与。`expectrl` PTY は Unix 専用かつ `umask` が Unix 固有であるため、Windows CI はファイル全体がコンパイル対象外となる（3-OS matrix のうち ubuntu + macOS でのみ実行）
+- **stdout バイナリキャプチャ**: `--output print`（PDF）/ `--output braille`（BRF）はバイナリ出力のため、`assert_cmd::Output.stdout: Vec<u8>` を直接参照してバイト列でアサートする（`predicates::str::contains` ではない）
+- **liblouis FFI 不採用**: braille 変換は `shikomi-daemon` 内の自前 wordlist テーブルで実装（SSoT §15.2 確定。FFI 依存・外部共有ライブラリ不要）
+
+### 11.2 外部 I/O 依存マップ
+
+| 外部 I/O | 方針 | characterization 状態 |
+|---|---|---|
+| **`shikomi-daemon` プロセス** | §10.2 と同一: `DaemonSpawn` で実子プロセス起動 + socket 親 `0700` + `Drop` で `kill()`→`wait()` | 既存資産再利用 |
+| **TTY（passphrase）** | `expectrl` PTY 経由で passphrase を入力（C-38 前提、§10.3 TTY 行と同じ dev-dep 再利用）| 既存資産再利用 |
+| **PDF 出力（--output print）** | `assert_cmd::Output.stdout` の `Vec<u8>` でキャプチャ。magic byte / EOF marker をバイト列 assert | 不要（stdout キャプチャ）|
+| **BRF 出力（--output braille）** | 同上。Unicode braille 範囲（U+2800..U+28FF）または ASCII `.brf` 行末でアサート。liblouis FFI なし（自前 wordlist）| 不要（stdout キャプチャ）|
+| **Audio 出力（--output audio）** | CI では fake `say` / `espeak` バイナリを `PATH` 先頭に配置して spawn を観測。実スピーカー出力は要求しない | fake バイナリ用フィクスチャ要整備 |
+| **umask（TC-F-A05）** | `Command::new` 等で `0o077` を設定した子プロセス内で CLI 実行。出力一時ファイルの mode を `metadata().permissions().mode()` で assert | Unix 専用（ファイルガードで保護）|
+
+### 11.3 CI スキップ条件と `#[ignore]` reason 文字列規約
+
+**ファイルレベルガード（全 TC）**: `#![cfg(unix)]` により Windows CI では全 TC が自動的にコンパイル対象外となる（`#[ignore]` 個別付与不要）。
+
+**TC-F-A03 個別スキップ**: CI 環境に `say`（macOS）/ `espeak`（Linux）が PATH 未登録の場合、fake バイナリフィクスチャが未整備として skip。reason 文字列（v8.4 規約 §10.3 準拠）:
+
+```
+"requires fake TTS binary in PATH (audio spawn gate,
+ test-design integration.md §11.3,
+ unlock condition: add fake_say fixture to tests/helpers/ and register in CI workflow)"
+```
+
+**TC-F-A04 スキップ候補**: `SHIKOMI_ACCESSIBILITY=1` の自動切替先が OS オーディオパスに依存する場合、CI 環境によってはスキップが必要。実装担当（銀時）が確定後、同規約で reason 文字列を追加する（実装の責務）。
+
+### 11.4 テストケース一覧（TC-F-A01〜A05 / SSoT §15.7 1:1 対応）
+
+> **共通前提条件**: `DaemonSpawn::new()` によるセキュリティ契約（socket 親 `0700` + stat fail fast）が全 TC に適用される（§10.4 冒頭と同一）。
+
+| TC-ID | SSoT 受入基準 | 前提条件 | 操作 | 期待結果 |
+|-------|-------------|---------|------|---------|
+| TC-F-A01 | EC-F1 / SSoT §15.7 A01 | plaintext vault + `DaemonSpawn` | `shikomi vault encrypt --output print`（`expectrl` PTY 経由 passphrase）| exit 0 + `stdout` バイト列が `%PDF-1.7`（magic byte）および `%%EOF`（終端 marker）を含む。24 語ニーモニックが 36pt 相当のコンテンツとして PDF 本文に埋め込まれている（テキスト抽出 / 構造解析で確認）|
+| TC-F-A02 | EC-F1 / SSoT §15.7 A02 | plaintext vault + `DaemonSpawn` | `shikomi vault encrypt --output braille`（`expectrl` PTY 経由）| exit 0 + `stdout` バイト列が U+2800..U+28FF Unicode braille 範囲のコードポイントを含む（または ASCII BRF 行末 `\r\n` 形式）。Grade 2 短縮形エンコード（例: "the" → `⠮`）が自前 wordlist テーブルで正しく生成されている |
+| TC-F-A03 | SSoT §15.7 A03 | plaintext vault + `DaemonSpawn` + fake `say`/`espeak` を `PATH` 先頭配置（`#[ignore]` 付き）| `shikomi vault encrypt --output audio`（`expectrl` PTY 経由）| exit 0 + fake TTS バイナリが spawn された証跡（fake バイナリが受信した引数を一時ファイルに記録し、テストで読み取り確認）|
+| TC-F-A04 | SSoT §15.7 A04 | plaintext vault + `DaemonSpawn` + `SHIKOMI_ACCESSIBILITY=1` env | `shikomi vault encrypt`（`--output` フラグなし、`expectrl` PTY 経由）| exit 0。stdout / stderr に print / braille / audio いずれかの出力形式が現れること。レコード内容が平文で stdout / stderr に露出しないこと（grep 0 件）|
+| TC-F-A05 | SSoT §15.7 A05 | plaintext vault + `DaemonSpawn` + プロセス umask `0o077` 設定 | `shikomi vault encrypt --output print`（`expectrl` PTY 経由）| exit 0。出力先一時ファイルの mode が `0o600`（owner read/write のみ）。`/tmp` 以下に vault.db 関連の中間ファイルが生成されない（`/tmp` の mtime 変化なし、または stat で確認）|
+
+### 11.5 `accessibility_paths.rs` 責務分割
+
+| テストファイル | TC | 責務 |
+|-------------|-----|------|
+| `crates/shikomi-cli/tests/accessibility_paths.rs` | TC-F-A01〜A05 | vault encrypt アクセシビリティ出力（PDF / BRF / Audio）+ `SHIKOMI_ACCESSIBILITY=1` 自動切替 + umask 077 権限検証。`#![cfg(unix)]` ファイルガード |
+
+**共通インフラ**: §10.6 と同一（`DaemonSpawn` / `common/mod.rs` / `common/fixtures.rs`）。TC-F-A03 用の fake TTS バイナリフィクスチャは `tests/helpers/fake_tts.rs` として工程3（銀時実装）で追加する（`#[ignore]` 解除条件）。
+
+### 11.6 カバレッジ対象（Sub-F アクセシビリティ、SSoT §15.3 対応）
+
+| 受入基準 / 契約 | カバー TC |
+|--------------|----------|
+| EC-F1（encrypt）アクセシビリティ出力 3 形式（PDF / BRF / Audio）| TC-F-A01, TC-F-A02, TC-F-A03 |
+| `SHIKOMI_ACCESSIBILITY=1` 自動切替 + exit 0 + 情報漏洩なし | TC-F-A04 |
+| umask 077 出力権限 `0o600` + `/tmp` 中間ファイル生成禁止 | TC-F-A05 |
+
+---
+
 *この文書は `index.md` の分割成果。ユニットテストは `unit.md`、E2E は `e2e.md`、CI は `ci.md` を参照*

--- a/docs/features/cli-vault-commands/test-design/integration.md
+++ b/docs/features/cli-vault-commands/test-design/integration.md
@@ -403,6 +403,7 @@ TC-F-I10a〜d のうち Windows で skip するものおよび TC-F-I11b も同�
 - **ファイルガード**: `crates/shikomi-cli/tests/accessibility_paths.rs` の先頭に `#![cfg(unix)]` を付与。`expectrl` PTY は Unix 専用かつ `umask` が Unix 固有であるため、Windows CI はファイル全体がコンパイル対象外となる（3-OS matrix のうち ubuntu + macOS でのみ実行）
 - **stdout バイナリキャプチャ**: `--output print`（PDF）/ `--output braille`（BRF）はバイナリ出力のため、`assert_cmd::Output.stdout: Vec<u8>` を直接参照してバイト列でアサートする（`predicates::str::contains` ではない）
 - **liblouis FFI 不採用**: braille 変換は `shikomi-daemon` 内の自前 wordlist テーブルで実装（SSoT §15.2 確定。FFI 依存・外部共有ライブラリ不要）
+- **出力キャプチャ方式の使い分け**: TC-F-A01 / A02 は `assert_cmd::Output.stdout: Vec<u8>` でバイト列キャプチャ（ファイル未生成）。TC-F-A05 は `> out.pdf` シェルリダイレクト + `std::fs::metadata` で mode 検証（stdout キャプチャ不使用）
 
 ### 11.2 外部 I/O 依存マップ
 
@@ -413,7 +414,7 @@ TC-F-I10a〜d のうち Windows で skip するものおよび TC-F-I11b も同�
 | **PDF 出力（--output print）** | `assert_cmd::Output.stdout` の `Vec<u8>` でキャプチャ。magic byte / EOF marker をバイト列 assert | 不要（stdout キャプチャ）|
 | **BRF 出力（--output braille）** | 同上。Unicode braille 範囲（U+2800..U+28FF）または ASCII `.brf` 行末でアサート。liblouis FFI なし（自前 wordlist）| 不要（stdout キャプチャ）|
 | **Audio 出力（--output audio）** | CI では fake `say` / `espeak` バイナリを `PATH` 先頭に配置して spawn を観測。実スピーカー出力は要求しない | fake バイナリ用フィクスチャ要整備 |
-| **umask（TC-F-A05）** | `Command::new` 等で `0o077` を設定した子プロセス内で CLI 実行。出力一時ファイルの mode を `metadata().permissions().mode()` で assert | Unix 専用（ファイルガードで保護）|
+| **umask（TC-F-A05）** | `unix::process::CommandExt::pre_exec(|| { unsafe { libc::umask(0o077); Ok(()) } })` で子プロセス前に umask 設定し、`shikomi vault encrypt --output print > out.pdf` をシェルリダイレクト付きで実行。`std::fs::metadata("out.pdf").permissions().mode() & 0o777` で `0o600` を assert（stdout キャプチャ不使用）| Unix 専用（ファイルガードで保護）|
 
 ### 11.3 CI スキップ条件と `#[ignore]` reason 文字列規約
 
@@ -427,7 +428,15 @@ TC-F-I10a〜d のうち Windows で skip するものおよび TC-F-I11b も同�
  unlock condition: add fake_say fixture to tests/helpers/ and register in CI workflow)"
 ```
 
-**TC-F-A04 スキップ候補**: `SHIKOMI_ACCESSIBILITY=1` の自動切替先が OS オーディオパスに依存する場合、CI 環境によってはスキップが必要。実装担当（銀時）が確定後、同規約で reason 文字列を追加する（実装の責務）。
+**TC-F-A03 実装注意**: fake TTS バイナリへのニーモニックテキスト渡しを tempfile に平文記録することは**禁止**（vault secret 漏洩リスク、OWASP A02）。spawn 確認は CLI の `stdout pid: N` 形式出力で行う（§11.4 TC-F-A03 参照）。
+
+**TC-F-A04 個別スキップ**: `SHIKOMI_ACCESSIBILITY=1` の自動切替先が OS オーディオパスに依存し、fake TTS が PATH 未登録の場合に skip。reason 文字列（v8.4 規約 §10.3 準拠）:
+
+```
+"SHIKOMI_ACCESSIBILITY=1 auto-select may trigger audio path requiring TTS binary (audio auto-select gate,
+ test-design integration.md §11.3,
+ unlock condition: implementation guarantees print/braille fallback when TTS unavailable, or fake TTS registered in CI)"
+```
 
 ### 11.4 テストケース一覧（TC-F-A01〜A05 / SSoT §15.7 1:1 対応）
 
@@ -435,17 +444,18 @@ TC-F-I10a〜d のうち Windows で skip するものおよび TC-F-I11b も同�
 
 | TC-ID | SSoT 受入基準 | 前提条件 | 操作 | 期待結果 |
 |-------|-------------|---------|------|---------|
-| TC-F-A01 | EC-F1 / SSoT §15.7 A01 | plaintext vault + `DaemonSpawn` | `shikomi vault encrypt --output print`（`expectrl` PTY 経由 passphrase）| exit 0 + `stdout` バイト列が `%PDF-1.7`（magic byte）および `%%EOF`（終端 marker）を含む。24 語ニーモニックが 36pt 相当のコンテンツとして PDF 本文に埋め込まれている（テキスト抽出 / 構造解析で確認）|
-| TC-F-A02 | EC-F1 / SSoT §15.7 A02 | plaintext vault + `DaemonSpawn` | `shikomi vault encrypt --output braille`（`expectrl` PTY 経由）| exit 0 + `stdout` バイト列が U+2800..U+28FF Unicode braille 範囲のコードポイントを含む（または ASCII BRF 行末 `\r\n` 形式）。Grade 2 短縮形エンコード（例: "the" → `⠮`）が自前 wordlist テーブルで正しく生成されている |
-| TC-F-A03 | SSoT §15.7 A03 | plaintext vault + `DaemonSpawn` + fake `say`/`espeak` を `PATH` 先頭配置（`#[ignore]` 付き）| `shikomi vault encrypt --output audio`（`expectrl` PTY 経由）| exit 0 + fake TTS バイナリが spawn された証跡（fake バイナリが受信した引数を一時ファイルに記録し、テストで読み取り確認）|
-| TC-F-A04 | SSoT §15.7 A04 | plaintext vault + `DaemonSpawn` + `SHIKOMI_ACCESSIBILITY=1` env | `shikomi vault encrypt`（`--output` フラグなし、`expectrl` PTY 経由）| exit 0。stdout / stderr に print / braille / audio いずれかの出力形式が現れること。レコード内容が平文で stdout / stderr に露出しないこと（grep 0 件）|
-| TC-F-A05 | SSoT §15.7 A05 | plaintext vault + `DaemonSpawn` + プロセス umask `0o077` 設定 | `shikomi vault encrypt --output print`（`expectrl` PTY 経由）| exit 0。出力先一時ファイルの mode が `0o600`（owner read/write のみ）。`/tmp` 以下に vault.db 関連の中間ファイルが生成されない（`/tmp` の mtime 変化なし、または stat で確認）|
+| TC-F-A01 | EC-F1 / SSoT §15.7 A01 | plaintext vault + `DaemonSpawn` | `shikomi vault encrypt --output print`（`expectrl` PTY 経由 passphrase）| exit 0 + `stdout` バイト列が `%PDF-1.7`（magic byte）および `%%EOF`（終端 marker）を含む。24 語ニーモニックが 36pt 相当のコンテンツとして PDF 本文に埋め込まれている（テキスト抽出 / 構造解析で確認）。vault secret 値（`SECRET_TEST_VALUE` 相当のバイト列）が `stdout` に含まれない（OWASP A02 情報漏洩防衛）|
+| TC-F-A02 | EC-F1 / SSoT §15.7 A02 | plaintext vault + `DaemonSpawn` | `shikomi vault encrypt --output braille`（`expectrl` PTY 経由）| exit 0 + `stdout` バイト列が U+2800..U+28FF Unicode braille 範囲のコードポイントを含む（または ASCII BRF 行末 `\r\n` 形式）。Grade 2 短縮形エンコード（例: "the" → `⠮`）が自前 wordlist テーブルで正しく生成されている。vault secret 値のバイト列が BRF `stdout` に含まれない（OWASP A02 情報漏洩防衛）|
+| TC-F-A03 | SSoT §15.7 A03 | plaintext vault + `DaemonSpawn` + fake `say`/`espeak` を `PATH` 先頭配置（`#[ignore]` 付き）| `shikomi vault encrypt --output audio`（`expectrl` PTY 経由）| exit 0 + `stdout` に `pid: N`（整数）形式で TTS サブプロセス ID が出力される（CLI が spawn した証跡）。env allowlist 通過確認（許可 env のみ TTS に渡されることを stderr / stdout で確認）。fake TTS は受け取った引数を tempfile に平文記録しない（OWASP A02、dictation 学習 prefs 汚染なし）|
+| TC-F-A04 | SSoT §15.7 A04 | plaintext vault + `DaemonSpawn` + `SHIKOMI_ACCESSIBILITY=1` env（`#[ignore]` 候補: §11.3 reason 文字列参照）| `shikomi vault encrypt`（`--output` フラグなし、`expectrl` PTY 経由）| exit 0。stdout / stderr に print / braille / audio いずれかの出力形式が現れること。レコード内容が平文で stdout / stderr に露出しないこと（grep 0 件）|
+| TC-F-A05 | SSoT §15.7 A05 | plaintext vault + `DaemonSpawn` + `CommandExt::pre_exec` unsafe ブロックで umask `0o077` 設定 | `shikomi vault encrypt --output print > out.pdf`（`expectrl` PTY 経由、`>` リダイレクトでファイル生成）| exit 0。`std::fs::metadata("out.pdf").permissions().mode() & 0o777 == 0o600`（owner read/write のみ、umask `0o077` の反映確認）。`/tmp` 以下に vault.db 関連の中間ファイルが生成されない（`/tmp` mtime 変化なし）|
+| TC-F-A06 | OWASP A01 / SSoT §15.7 A01-guard | 暗号化 vault（**Locked**）+ `DaemonSpawn` | `shikomi vault encrypt --output print`（`expectrl` PTY 経由）| exit 1 以上 + `CliError::AlreadyEncrypted` または `VaultLocked` 由来エラー文言。`stdout` に `%PDF-1.7` バイト列が含まれない（Locked vault でアクセシビリティ出力が生成されない、OWASP A01 認可バイパス防衛確認）|
 
 ### 11.5 `accessibility_paths.rs` 責務分割
 
 | テストファイル | TC | 責務 |
 |-------------|-----|------|
-| `crates/shikomi-cli/tests/accessibility_paths.rs` | TC-F-A01〜A05 | vault encrypt アクセシビリティ出力（PDF / BRF / Audio）+ `SHIKOMI_ACCESSIBILITY=1` 自動切替 + umask 077 権限検証。`#![cfg(unix)]` ファイルガード |
+| `crates/shikomi-cli/tests/accessibility_paths.rs` | TC-F-A01〜A06 | vault encrypt アクセシビリティ出力（PDF / BRF / Audio）+ `SHIKOMI_ACCESSIBILITY=1` 自動切替 + umask 077 権限検証 + Locked vault 認可バイパス防衛（OWASP A01）。`#![cfg(unix)]` ファイルガード |
 
 **共通インフラ**: §10.6 と同一（`DaemonSpawn` / `common/mod.rs` / `common/fixtures.rs`）。TC-F-A03 用の fake TTS バイナリフィクスチャは `tests/helpers/fake_tts.rs` として工程3（銀時実装）で追加する（`#[ignore]` 解除条件）。
 
@@ -456,6 +466,8 @@ TC-F-I10a〜d のうち Windows で skip するものおよび TC-F-I11b も同�
 | EC-F1（encrypt）アクセシビリティ出力 3 形式（PDF / BRF / Audio）| TC-F-A01, TC-F-A02, TC-F-A03 |
 | `SHIKOMI_ACCESSIBILITY=1` 自動切替 + exit 0 + 情報漏洩なし | TC-F-A04 |
 | umask 077 出力権限 `0o600` + `/tmp` 中間ファイル生成禁止 | TC-F-A05 |
+| OWASP A02 PDF / BRF バイナリへの vault secret 混入防衛（情報漏洩陰性確認）| TC-F-A01, TC-F-A02 |
+| OWASP A01 Locked vault + `--output` 認可バイパス防衛 | TC-F-A06 |
 
 ---
 

--- a/docs/features/cli-vault-commands/test-design/integration.md
+++ b/docs/features/cli-vault-commands/test-design/integration.md
@@ -389,7 +389,7 @@ TC-F-I10a〜d のうち Windows で skip するものおよび TC-F-I11b も同�
 
 ---
 
-## 11. Sub-F vault アクセシビリティ出力 結合テスト（TC-F-A01〜A05）
+## 11. Sub-F vault アクセシビリティ出力 結合テスト（TC-F-A01〜A06）
 
 > Issue #78 / #74-D。  
 > SSoT: `vault-encryption/test-design/sub-f-cli-subcommands/index.md §15.7`（Rev1）
@@ -438,7 +438,7 @@ TC-F-I10a〜d のうち Windows で skip するものおよび TC-F-I11b も同�
  unlock condition: implementation guarantees print/braille fallback when TTS unavailable, or fake TTS registered in CI)"
 ```
 
-### 11.4 テストケース一覧（TC-F-A01〜A05 / SSoT §15.7 1:1 対応）
+### 11.4 テストケース一覧（TC-F-A01〜A06 / SSoT §15.7 1:1 対応）
 
 > **共通前提条件**: `DaemonSpawn::new()` によるセキュリティ契約（socket 親 `0700` + stat fail fast）が全 TC に適用される（§10.4 冒頭と同一）。
 


### PR DESCRIPTION
## Summary

- `integration.md §11` 新設: `vault encrypt --output {print,braille,audio}` / `SHIKOMI_ACCESSIBILITY=1` / umask 077 のアクセシビリティ出力結合テスト TC-F-A01〜A05（SSoT §15.7 1:1 対応）
- `index.md §2` 更新: 索引テーブルの `integration.md` 行に TC-F-A01〜A05 を追記
- 行数 462（500 行制限内）

## 設計決定サマリ

| 決定 | 内容 |
|------|------|
| ファイルガード | `#![cfg(unix)]` でファイル全体を Unix 限定。Windows CI は全 TC がコンパイル対象外（`#[ignore]` 個別付与不要）|
| stdout バイナリキャプチャ | PDF/BRF は `assert_cmd::Output.stdout: Vec<u8>` で magic byte / unicode braille 範囲をバイト列 assert |
| liblouis FFI | **不採用**。自前 wordlist テーブル（SSoT §15.2 確定）|
| TC-F-A03 `#[ignore]` | fake TTS フィクスチャ未整備 CI 向け、v8.4 規約準拠の 4 要素 reason 文字列を明記 |
| DaemonSpawn | 全 TC 共通。§10.2 の実装を再利用（socket 親 `0700` セキュリティ契約継承）|

## 対応 SSoT

- `vault-encryption/test-design/sub-f-cli-subcommands/index.md §15.7`

## Closes

Closes #78

## Test plan

- [ ] `integration.md §11` 内容が SSoT §15.7 TC-F-A01〜A05 と 1:1 対応しているか確認
- [ ] `index.md §2` 索引テーブルが更新されているか確認
- [ ] 462 行（500 行制限以内）
- [ ] `#[ignore]` reason 文字列が v8.4 規約（4 要素）準拠か確認
- [ ] `#![cfg(unix)]` ファイルガードの記述が §11.1 / §11.3 に明記されているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)