### PR TITLE
docs(vault-persistence): Phase 8 リファクタ設計確定 — AtomicWriteSession / RetryPolicy / DACL / dir-fd

### DIFF
--- a/docs/features/vault-persistence/basic-design/index.md
+++ b/docs/features/vault-persistence/basic-design/index.md
@@ -31,7 +31,7 @@
 | REQ-P02, P03, P04, P05, P11, P12 | `shikomi_infra::persistence::sqlite` | `crates/shikomi-infra/src/persistence/sqlite/mod.rs` | `SqliteVaultRepository` 実装の入口、トランザクション制御 |
 | REQ-P03 | 〃 `::schema` | `crates/shikomi-infra/src/persistence/sqlite/schema.rs` | `CREATE TABLE`・`CHECK` 制約・`PRAGMA` の SQL 定数 |
 | REQ-P03, P09 | 〃 `::mapping` | `crates/shikomi-infra/src/persistence/sqlite/mapping.rs` | ドメイン型 ↔ SQLite 行の写像（シリアライズ / 検証付きデシリアライズ） |
-| REQ-P04, P05 | 〃 `::atomic` | `crates/shikomi-infra/src/persistence/sqlite/atomic.rs` | atomic write（`.new` への SQLite 書込 → **DB ハンドル明示クローズ + WAL/journal サイドカー解放** → fsync → rename → Win 限定 rename リトライ補強）、`.new` 残存検出。**ハンドル解放順序は契約**（OS 別 file-handle semantics の差を吸収する責務、`./error.md` §Windows rename PermissionDenied 経路 / `../detailed-design/flows.md` §`save` step 6-7） |
+| REQ-P04, P05 | 〃 `::atomic` | `crates/shikomi-infra/src/persistence/sqlite/atomic.rs` | `AtomicWriteSession { conn, new_path }` セッション型（Phase 8 実装）: `new(paths, vault)` で SQLite 書込 → COMMIT まで実行し `conn` 保持、`finalize(self, retry_policy)` の所有権消費で checkpoint / journal_mode / **DB ハンドル明示クローズ** / サイドカー DACL / fsync / rename（Win retry）を型レベル順序保証で完結。`AtomicWriter` ZST は `detect_orphan` / `cleanup_new` / `write_new_only(#[cfg(test)])` の名前空間として残存。`RetryPolicy` trait + `ExponentialBackoffRetryPolicy` で retry 振る舞いをテスト注入可能（`../detailed-design/classes.md` §3.2 / §3.4）。`.new` 残存検出は `detect_orphan` が担う |
 | REQ-P06, P07 | `shikomi_infra::persistence::permission` | `crates/shikomi-infra/src/persistence/permission/mod.rs` | OS 非依存の検証 API。内部で `cfg_if!` により `unix.rs` / `windows.rs` へ委譲 |
 | REQ-P06 | 〃 `::unix` | `crates/shikomi-infra/src/persistence/permission/unix.rs` | `cfg(unix)` のみ有効。`0o700` / `0o600` 設定・検証 |
 | REQ-P07 | 〃 `::windows` | `crates/shikomi-infra/src/persistence/permission/windows.rs` | `cfg(windows)` のみ有効。NTFS owner-only DACL 設定・検証（`SetNamedSecurityInfoW` / `GetNamedSecurityInfoW`）。**本モジュールは本 Issue で スタブ → 本実装に置換**、関連ヘルパは `pub(super)` で同ファイル内に閉じる。unsafe boundary は**本ファイル内のみ**（`./security.md` §unsafe_code 整合方針 / §Windows owner-only DACL の適用戦略 と詳細設計 `detailed-design/classes.md` §13 を参照） |
@@ -141,11 +141,21 @@ classDiagram
         +rows_to_vault responsibility
     }
 
+    class AtomicWriteSession {
+        +new responsibility
+        +finalize responsibility
+    }
+
     class AtomicWriter {
-        +write_new responsibility
-        +fsync_and_rename responsibility
         +detect_orphan responsibility
         +cleanup_new responsibility
+    }
+
+    class RetryPolicy {
+        <<trait>>
+        +max_attempts responsibility
+        +sleep_duration responsibility
+        +should_retry responsibility
     }
 
     class PermissionGuard {
@@ -164,8 +174,10 @@ classDiagram
     SqliteVaultRepository --> VaultPaths : owns
     SqliteVaultRepository --> Schema : uses
     SqliteVaultRepository --> Mapping : uses
-    SqliteVaultRepository --> AtomicWriter : uses
+    SqliteVaultRepository --> AtomicWriteSession : write + finalize (save)
+    SqliteVaultRepository --> AtomicWriter : detect_orphan / cleanup_new
     SqliteVaultRepository --> PermissionGuard : uses
+    AtomicWriteSession --> RetryPolicy : cfg(windows) rename retry
     SqliteVaultRepository ..> VaultLock : acquire on load/save
     SqliteVaultRepository ..> Audit : emits events
     SqliteVaultRepository ..> Vault_core : load returns / save receives
@@ -217,23 +229,25 @@ classDiagram
 ### REQ-P01 / REQ-P02 / REQ-P04 / REQ-P11 / REQ-P13 / REQ-P14: `SqliteVaultRepository::save(vault)`
 
 1. `audit::entry_save(&self.paths, vault.record_count())` を発行（REQ-P14、開始ログ）
-2. `vault.protection_mode()` が `Encrypted` なら **`UnsupportedYet` を即 return**（REQ-P11、Fail Fast）
+2. **（Sub-D Rev で削除）** 旧: `protection_mode == Encrypted` で `UnsupportedYet` 即 return。新: 暗号化モードも通常経路で進行
 3. `PermissionGuard::ensure_dir(paths.dir)` でディレクトリ作成（既存なら `0o700` を強制、Windows は ACL 強制）
 4. **`VaultLock::acquire_exclusive(&self.paths)?`** で排他ロック取得（REQ-P13）。別プロセスが排他/共有ロックを保持中なら `Locked` で即 return（非ブロッキング、待機・再試行しない）。取得した `VaultLock` は step 7 までスコープに生存し、drop 時に自動解放（RAII）
 5. `AtomicWriter::detect_orphan(paths.vault_db_new)` で `.new` 残存検出（残っていれば `OrphanNewFile` を返し中断、ユーザ明示操作を待つ、AC-14 の save 側検証）
-6. `AtomicWriter::write_new(paths.vault_db_new)` のスコープで一時 SQLite DB を作成:
+6. `let session = AtomicWriteSession::new(&self.paths, &vault)?` で一時 SQLite DB を作成しセッションを開く（`../detailed-design/classes.md` §3.2 参照）:
    - `Connection::open_with_flags(OpenFlags::SQLITE_OPEN_CREATE \| SQLITE_OPEN_READ_WRITE \| SQLITE_OPEN_NO_MUTEX)`
-   - **作成直後**にファイルパーミッションを `0o600` に設定（Unix） / 所有者 ACL 設定（Windows）
-   - `PRAGMA application_id = 0x73686B6D`、`PRAGMA user_version = 1`、`PRAGMA journal_mode = DELETE` を発行
+   - `PermissionGuard::ensure_file(new_path)` で `0o600` 設定（Unix） / owner-only DACL 設定（Windows、**rename 前 DACL 適用戦略確定**、`../detailed-design/classes.md` §3.3）
+   - `PRAGMA application_id`、`PRAGMA user_version`、`PRAGMA journal_mode = DELETE` を発行
    - `Schema::CREATE_VAULT_HEADER` / `Schema::CREATE_RECORDS` で DDL 適用
    - **単一トランザクション**で `vault_header` に 1 行 insert、`records` に全レコード insert（`tx.execute_batch` ではなく `params!` バインドで個別 insert）
-   - COMMIT
-   - `Connection` drop（SQLite 内部 flush）
-7. `AtomicWriter::fsync_and_rename`:
-   - `.new` を再 open し `File::sync_all()`
-   - 親ディレクトリを open し `File::sync_all()`（Unix で rename メタデータの永続化に必要、POSIX 2008）
-   - `std::fs::rename(paths.vault_db_new, paths.vault_db)`（Unix）または `windows::Win32::Storage::FileSystem::ReplaceFileW`（Windows）
-   - rename 失敗時は `.new` を削除し `AtomicWriteFailed { stage: Rename, ... }` を返す
+   - COMMIT。`conn` は `AtomicWriteSession` が保持し続ける
+7. `session.finalize(&ExponentialBackoffRetryPolicy::default())?` — `AtomicWriteSession` を所有権消費し以下を順序固定で実行（`../detailed-design/classes.md` §3.2 参照）:
+   - `PRAGMA wal_checkpoint(TRUNCATE)` + `PRAGMA journal_mode = DELETE` でサイドカー物理消去契約を固定
+   - `conn.close()` 明示呼出（`Drop` 任せ禁止）。失敗時は `Sqlite` エラーで return + `.new` best-effort 削除
+   - サイドカー候補（`.new-journal` / `.new-wal` / `.new-shm`）に `ensure_file` を適用（存在するもののみ）
+   - `.new` を再 open し `File::sync_all()`（FsyncTemp）
+   - 親ディレクトリを open し `File::sync_all()`（FsyncDir、Unix のみ。POSIX 2008 rename メタデータ永続化）
+   - `std::fs::rename`（Unix / Windows 共通。**`ReplaceFileW` 直接呼出は不採用**、`../detailed-design/flows.md` §`save` step 7.7 参照）。Win 限定で `ExponentialBackoffRetryPolicy` に従う指数バックオフ retry + symlink 再検証
+   - rename 失敗時は `.new` を best-effort 削除し `AtomicWriteFailed { stage: Rename, ... }` を返す
 8. `audit::exit_ok_save(record_count, bytes_written, elapsed_ms)` を発行（REQ-P14、成功ログ）
 9. `VaultLock` が drop され排他ロックが自動解放される
 10. `Ok(())`

--- a/docs/features/vault-persistence/basic-design/security.md
+++ b/docs/features/vault-persistence/basic-design/security.md
@@ -132,7 +132,11 @@ Unix `0600` / `0700` に相当する「所有者のみ read/write」を NTFS で
 
 1. **retry 直前の symlink 再検証**: 各 retry 試行の `sleep` 後、rename 再実行**直前**に `fs::symlink_metadata(vault.db)` と `fs::symlink_metadata(new_path)` を呼び、`is_symlink()` が true なら retry 打ち切り、`InvalidVaultDir { reason: SymlinkNotAllowed }` で fail fast
 2. **junction（NTFS reparse point）検出**: Windows では `is_symlink()` だけでなく `MetadataExt::file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0` も検査（`std::os::windows::fs::MetadataExt`、Microsoft Learn "File Attributes" https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants）。`mklink /J` で作られた junction も拒否
-3. **dir-fd 化（次段）**: 完全な TOCTOU 排除には親ディレクトリを open しっぱなしにして相対パスで操作する dir-fd パターンが望ましいが、Windows の `O_DIRECTORY` 相当は `FILE_FLAG_BACKUP_SEMANTICS` 経由で煩雑。本 Issue では symlink 再検証で実用的に絞り、dir-fd 化は **Phase 8 リファクタ PR**（`AtomicWriteSession` 構造体化と同時）で再評価する
+3. **dir-fd 化（Phase 8 決定: 不採用）**: 完全な TOCTOU 排除には親ディレクトリを open しっぱなしにして相対パスで操作する dir-fd パターンが望ましいが、Phase 8 で再評価した結果**不採用**とする。採否根拠:
+   - `AtomicWriteSession.finalize(self)` の所有権消費パターンにより Connection クローズとサイドカー解放が型レベルで強制され、書込操作の構造的安全性が確立された
+   - Unix: `VaultPaths::new` の 7 段階バリデーション（シンボリックリンク全面禁止 + `canonicalize` + 保護領域チェック）+ retry 直前の symlink 再検証で TOCTOU の攻撃面は実用的に十分絞られている
+   - Windows: `FILE_FLAG_BACKUP_SEMANTICS` 経由の dir-fd 相当 API（`NtCreateFile` 等）は公開ドキュメントが乏しく undocumented 依存のリスクがある
+   - YAGNI: 現行の多層防御（パス検証 + DACL設定 + symlink再検証 + atomic rename）で要件を満たしており、dir-fd 追加による実用的な攻撃面縮小は限定的
 
 #### retry 監査ログ（A09）
 
@@ -167,7 +171,7 @@ Unix `0600` / `0700` に相当する「所有者のみ read/write」を NTFS で
    - **線形 50ms × 5 では Defender / Search Indexer (~250ms+ 保持) を吸収不可**（Bug-G-001 §3 CI 観測）
    - **Defender 解放までの待機を attempt 3 (~350ms 累積) で完了**でき、典型 race を救う
    - 攻撃者制御の長期 lock（>1675ms）に対しては `outcome=exhausted` で fail fast し DoS 兆候を上位通報（責務分離、KISS）
-   - Phase 8 リファクタで envelope encryption / I/O 統計連携が入る時に retry policy も `RetryPolicy` trait に切り出す予定（YAGNI、本 Issue では定数 + 指数固定で十分）
+   - **Phase 8 で `RetryPolicy` trait を実装済み**: retry 振る舞い（`max_attempts` / `sleep_duration(attempt)` / `should_retry(raw_os_error)`）を `RetryPolicy` trait に切り出し、`AtomicWriteSession::finalize(self, retry_policy: &dyn RetryPolicy)` でテスト注入可能にした（`../detailed-design/classes.md` §3.4 参照）。production default は `ExponentialBackoffRetryPolicy`、CI テスト用に `NoSleepRetryPolicy` を `#[cfg(test)]` で提供
 
 #### `Connection::close()` 失敗時の `.new` クリーンアップ
 

--- a/docs/features/vault-persistence/detailed-design/classes.md
+++ b/docs/features/vault-persistence/detailed-design/classes.md
@@ -212,21 +212,21 @@ classDiagram
 - **`AtomicWriteSession { conn, new_path }`**: SQLite 書込中の状態（開いた `Connection` + `.new` のパス）を保持するセッション型。`new(paths, vault)` でセッション開始、`finalize(self, retry_policy)` の所有権消費で全工程（クローズ → サイドカー DACL → fsync → rename）を順序固定で完結（Tell, Don't Ask、型レベルでクローズ順序を強制）
 - **`AtomicWriter`（ZST 残存）**: `detect_orphan` / `cleanup_new` / `#[cfg(test)] write_new_only` の 3 静的メソッドの名前空間として機能。`write_new` は `AtomicWriteSession::new` に昇格した
 
-**3.1 `AtomicWriter` のクローズ順序契約**（Issue #65 由来、Win file-handle semantics 対応）: `write_new` 内で SQLite `Connection` を扱う際、以下の順序を**契約**として固定する。順序逸脱は `AtomicWriteFailed { stage: WriteTemp }` で fail fast し、本契約は型では強制できないため doc コメント（`atomic.rs`）と本設計書 SSoT で二重管理する（`./flows.md` §`save` step 6.10〜6.13 と整合）:
+**3.1 クローズ順序契約**（Issue #65 由来、Win file-handle semantics 対応）: `AtomicWriteSession::new` 内で SQLite `Connection` を取得し、以下の順序を**契約**として固定する。Phase 8 で `AtomicWriteSession::finalize(self, ...)` の所有権消費パターンにより**型レベルで強制**できるようになった（§3.2 参照）。各ステップは `./flows.md` §`save` step 7.1〜7.3 に対応し、順序逸脱は `AtomicWriteFailed { stage: WriteTemp }` で fail fast する:
 
-1. 全 `INSERT` を含むトランザクションを `tx.commit()` で締める
-2. **`PRAGMA wal_checkpoint(TRUNCATE)`** を発行（WAL 採用時のサイドカー強制空化、DELETE 採用時は no-op で害なし）
-3. **`PRAGMA journal_mode = DELETE`** を発行（残存サイドカーを close 時に物理削除する契約に切替）
-4. **`Connection::close()` を明示呼出**（`Drop` 任せ禁止）。失敗は `WriteTemp` stage で fail fast
-5. 以降 `fsync_and_rename` 段で `.new` を再 open してフラッシュ → rename
+1. 全 `INSERT` を含むトランザクションを `tx.commit()` で締める（`AtomicWriteSession::new` 最終処理）
+2. **`PRAGMA wal_checkpoint(TRUNCATE)`** を発行（WAL 採用時のサイドカー強制空化、DELETE 採用時は no-op で害なし）— `finalize` step 7.1
+3. **`PRAGMA journal_mode = DELETE`** を発行（残存サイドカーを close 時に物理削除する契約に切替）— `finalize` step 7.2
+4. **`Connection::close()` を明示呼出**（`Drop` 任せ禁止）。失敗は `WriteTemp` stage で fail fast — `finalize` step 7.3
+5. 以降 `finalize` 内の FsyncTemp / FsyncDir / rename 段（`./flows.md` §`save` step 7.5〜7.7）で `.new` を再 open してフラッシュ → rename
 
 **契約違反例**（PR レビューで却下対象、`../basic-design/error.md` §禁止事項 §Windows rename retry の盲目採用は禁止 と整合）:
 
 - `tx.commit()` 後に `drop(conn)` のみで `Connection::close()` 明示呼出を省く（`sqlite3_close_v2` の遅延クローズ semantics で Win rename が race する温床、rusqlite docs https://docs.rs/rusqlite/latest/rusqlite/struct.Connection.html#method.close 参照）
 - `PRAGMA wal_checkpoint(TRUNCATE)` / `journal_mode = DELETE` を省く（`-wal` / `-shm` / `-journal` サイドカー残存で Win Indexer が触りに行き rename 競合の温床）
-- `cfg(windows)` rename retry を「根本対策なし」で挿入する（`./flows.md` §`save` step 7.3 / `../basic-design/error.md` §Windows rename PermissionDenied 行で禁止）
+- `cfg(windows)` rename retry を「根本対策なし」で挿入する（`../basic-design/error.md` §禁止事項 §Windows rename retry の盲目採用は禁止 で明記）
 
-**3.2 `AtomicWriteSession` 構造体化（Phase 8 実装済）**: クローズ順序契約（§3.1）を型レベルで強制するため、`AtomicWriteSession { conn: rusqlite::Connection, new_path: PathBuf }` セッション型を実装した。`paths: &VaultPaths` は参照として `new` / `finalize` に渡す（所有権を持たない）。
+**3.2 `AtomicWriteSession` 構造体化（Phase 8 実装済）**: クローズ順序契約（§3.1）を型レベルで強制するため、`AtomicWriteSession { conn: rusqlite::Connection, new_path: PathBuf }` セッション型を実装した。`paths: &VaultPaths` は `new` のみに渡す（`finalize` は `self` と `retry_policy` のみを受け取る。`new_path` は `new` 内で `paths.vault_db_new()` から `PathBuf` としてコピーし `AtomicWriteSession` フィールドに格納、`finalize` はそこを参照する）。
 
 - `AtomicWriteSession::new(paths: &VaultPaths, vault: &Vault) -> Result<AtomicWriteSession>`: `.new` 作成 → パーミッション設定 → `Connection::open` → PRAGMA/DDL → `vault_header` + `records` を 1 トランザクションで INSERT → `COMMIT` までを実行し、**`conn` を保持したまま** `AtomicWriteSession` を返す
 - `AtomicWriteSession::finalize(self, retry_policy: &dyn RetryPolicy) -> Result<()>`: 所有権を消費する形で以下を順序固定で実行する

--- a/docs/features/vault-persistence/detailed-design/classes.md
+++ b/docs/features/vault-persistence/detailed-design/classes.md
@@ -63,11 +63,27 @@ classDiagram
         +verify_file(path) Result
     }
 
+    class AtomicWriteSession {
+        -conn Connection
+        -new_path PathBuf
+        +new(paths, vault) Result_Self
+        +finalize(self, retry_policy) Result
+    }
+
     class AtomicWriter {
         +detect_orphan(new_path) Result
-        +write_new(new_path, vault) Result
-        +fsync_and_rename(new_path, final_path) Result
         +cleanup_new(new_path) Result
+    }
+
+    class RetryPolicy {
+        <<trait>>
+        +max_attempts() u32
+        +sleep_duration(attempt) Duration
+        +should_retry(raw_os_error) bool
+    }
+
+    class ExponentialBackoffRetryPolicy {
+        +default() Self
     }
 
     class SchemaSql {
@@ -156,7 +172,8 @@ classDiagram
     SqliteVaultRepository ..> VaultLock : acquire on load/save
     SqliteVaultRepository ..> Audit : emits events
     SqliteVaultRepository ..> PermissionGuard : uses
-    SqliteVaultRepository ..> AtomicWriter : uses
+    SqliteVaultRepository ..> AtomicWriter : detect_orphan / cleanup_new
+    SqliteVaultRepository ..> AtomicWriteSession : write + finalize (save)
     SqliteVaultRepository ..> Mapping : uses
     SqliteVaultRepository ..> SchemaSql : uses
     SqliteVaultRepository ..> PersistenceError
@@ -165,10 +182,13 @@ classDiagram
     VaultLock ..> VaultPaths : uses lock path
     VaultLock ..> PersistenceError : Locked
     Audit ..> PersistenceError : read only
-    AtomicWriter ..> Mapping
-    AtomicWriter ..> SchemaSql
-    AtomicWriter ..> PermissionGuard : set 0600
-    AtomicWriter ..> AtomicWriteStage
+    AtomicWriteSession ..> Mapping
+    AtomicWriteSession ..> SchemaSql
+    AtomicWriteSession ..> PermissionGuard : ensure_file(.new / sidecars)
+    AtomicWriteSession ..> AtomicWriteStage
+    AtomicWriteSession ..> PersistenceError
+    AtomicWriteSession ..> RetryPolicy : cfg(windows) rename retry
+    ExponentialBackoffRetryPolicy ..|> RetryPolicy
     AtomicWriter ..> PersistenceError
     Mapping ..> Vault_core
     Mapping ..> VaultHeader_core
@@ -187,7 +207,10 @@ classDiagram
 
 **2. なぜ `VaultPaths` は不変の値オブジェクトにするか**: `dir` から `vault.db` / `vault.db.new` / `vault.db.lock` のパスを派生させるロジックを**1 箇所**に閉じ込めるため。文字列結合を各所で書くと typo（`vault.dbnew` 等）の温床になる（DRY）。不変にすることで save 中の状態変化を防ぐ（Fail Fast）。`new` は 7 段階バリデーション（`../basic-design/security.md` §vault ディレクトリ検証）を通す公開 API。`new_unchecked` は `pub(crate)` の内部 API で `with_dir` 専用（検証スキップ、明示名で危険性を可視化）。
 
-**3. なぜ `AtomicWriter` を別クラスに分離するか**: atomic write は「`.new` への書き込み」「fsync」「rename」「cleanup」の 4 段階があり、各段階で失敗時の責務が異なる。`SqliteVaultRepository::save` に直接書くと関数が 100 行超えになり SRP 違反。`AtomicWriter` は**状態を持たない**（メソッドはいずれも引数の `&VaultPaths` と `&Vault` から計算）、`impl AtomicWriter` の関連関数のみで構成（実質 modulized namespace）。
+**3. `AtomicWriter` / `AtomicWriteSession` の分離設計（Phase 8 完了）**: atomic write は「`.new` への SQLite 書込」「クローズ順序固定 + サイドカー解放」「fsync」「rename（Win: retry）」「cleanup」の 5 段階があり、各段階で失敗時の責務が異なる。`SqliteVaultRepository::save` に直接書くと関数が 100 行超えになり SRP 違反。Phase 8 リファクタで旧 `AtomicWriter` ZST + 静的メソッドを次の 2 型に分解した:
+
+- **`AtomicWriteSession { conn, new_path }`**: SQLite 書込中の状態（開いた `Connection` + `.new` のパス）を保持するセッション型。`new(paths, vault)` でセッション開始、`finalize(self, retry_policy)` の所有権消費で全工程（クローズ → サイドカー DACL → fsync → rename）を順序固定で完結（Tell, Don't Ask、型レベルでクローズ順序を強制）
+- **`AtomicWriter`（ZST 残存）**: `detect_orphan` / `cleanup_new` / `#[cfg(test)] write_new_only` の 3 静的メソッドの名前空間として機能。`write_new` は `AtomicWriteSession::new` に昇格した
 
 **3.1 `AtomicWriter` のクローズ順序契約**（Issue #65 由来、Win file-handle semantics 対応）: `write_new` 内で SQLite `Connection` を扱う際、以下の順序を**契約**として固定する。順序逸脱は `AtomicWriteFailed { stage: WriteTemp }` で fail fast し、本契約は型では強制できないため doc コメント（`atomic.rs`）と本設計書 SSoT で二重管理する（`./flows.md` §`save` step 6.10〜6.13 と整合）:
 
@@ -203,9 +226,53 @@ classDiagram
 - `PRAGMA wal_checkpoint(TRUNCATE)` / `journal_mode = DELETE` を省く（`-wal` / `-shm` / `-journal` サイドカー残存で Win Indexer が触りに行き rename 競合の温床）
 - `cfg(windows)` rename retry を「根本対策なし」で挿入する（`./flows.md` §`save` step 7.3 / `../basic-design/error.md` §Windows rename PermissionDenied 行で禁止）
 
-**3.2 `AtomicWriteSession` への構造体化リファクタは Phase 8 別 PR に分離**: 上記クローズ順序契約は理想的には `AtomicWriteSession { conn, paths, new_path }` のようなセッション型を作り、`finalize(self) -> Result<()>` の所有権消費メソッドに集約することで**型レベル強制**できる（Tell, Don't Ask）。本 Issue では既存 `AtomicWriter` ZST + 静的メソッド連鎖の構造を維持し、本 PR スコープを「Issue #65 バグ修正 + 契約 SSoT 化」に絞る（KISS、本 PR 肥大化回避）。構造体化は Phase 8 リファクタ専用 PR で実施する（外部レビューでキャプテン決定、合意済）。
+**3.2 `AtomicWriteSession` 構造体化（Phase 8 実装済）**: クローズ順序契約（§3.1）を型レベルで強制するため、`AtomicWriteSession { conn: rusqlite::Connection, new_path: PathBuf }` セッション型を実装した。`paths: &VaultPaths` は参照として `new` / `finalize` に渡す（所有権を持たない）。
 
-**3.3 `permission/windows/*.rs` DACL 適用順序の再点検は本 PR スコープ外（deferred 判断）**: Issue #65 本文と現行 `atomic.rs:177-188` のコメントは「rename 後に DACL 適用」と明記し、test failure（`vault_migration_integration` 5 件）は **rename 段で発火**しているため DACL 適用順序とは独立した経路（DB ハンドル / サイドカー / Win file-handle semantics 由来）と切り分けられる。本 PR の rename retry 補強と DACL 適用順序の再評価は**論点が独立**しており、本 PR で同時に弄ると変更原因が混在しレビュー不能になる。**結論**: DACL 適用順序の再点検は本 PR では行わず、Phase 8 リファクタ PR（`AtomicWriteSession` 構造体化）と同タイミングで「rename 前 DACL 設定 + rename 後の所有者保持検証」を再評価するスコープに含める。本判断を SSoT として本箇所に記録し、レビュー時の沈黙を「Boy Scout 違反」と誤認されないよう明文化する（ペテルギウス工程1指摘 §4 への応答）。
+- `AtomicWriteSession::new(paths: &VaultPaths, vault: &Vault) -> Result<AtomicWriteSession>`: `.new` 作成 → パーミッション設定 → `Connection::open` → PRAGMA/DDL → `vault_header` + `records` を 1 トランザクションで INSERT → `COMMIT` までを実行し、**`conn` を保持したまま** `AtomicWriteSession` を返す
+- `AtomicWriteSession::finalize(self, retry_policy: &dyn RetryPolicy) -> Result<()>`: 所有権を消費する形で以下を順序固定で実行する
+  1. `execute("PRAGMA wal_checkpoint(TRUNCATE)")` — WAL サイドカー物理空化
+  2. `execute("PRAGMA journal_mode = DELETE")` — close 時サイドカー物理消去契約の再強制
+  3. `conn.close()` 明示呼出。失敗時は `PersistenceError::Sqlite` で伝播し `cleanup_new(new_path)` を best-effort 実行
+  4. サイドカー候補（`".new-journal"` / `".new-wal"` / `".new-shm"`）の `PermissionGuard::ensure_file` 適用（存在するもののみ）
+  5. `File::open(new_path)?.sync_all()?` — FsyncTemp
+  6. `File::open(dir)?.sync_all()?` — FsyncDir（Unix のみ、POSIX 2008 rename メタデータ永続化）
+  7. rename（`std::fs::rename`、Win 限定で `retry_policy` に従う指数バックオフ retry + symlink 再検証、§3.4 `RetryPolicy` 参照）
+
+**型レベルの保証**: `AtomicWriteSession` を消費しなければ（= `finalize` を呼ばなければ）その後の処理に進めない。`Drop` 実装で「`finalize` 未呼出のまま drop された場合は `cleanup_new` を best-effort 実行し panic しない」とし、安全な失敗を保証する（Fail Safe）。
+
+**3.3 Windows DACL 適用順序の確定（Phase 8 決定）**: Phase 8 で調査した結果、`MoveFileExW(MOVEFILE_REPLACE_EXISTING)` を**同一ボリューム内**で使用した場合、ソースファイル（`.new`）のファイルオブジェクトが宛先パス（`vault.db`）に移動するため、**ソースのセキュリティ記述子がそのまま保持される**。旧 `vault.db` のファイルオブジェクト（SD を含む）は破棄される。`std::fs::rename`（内部的に `MoveFileExW` へ展開）を採用している本設計において、DACL 適用タイミングの確定判断は以下の通り:
+
+**確定: rename 前に `.new` へ DACL 設定**
+
+- `AtomicWriteSession::new` 内で `PermissionGuard::ensure_file(new_path)` を呼び、owner-only DACL（ACE 1 個・`SE_DACL_PROTECTED`・`ACCESS_ALLOWED_ACE_TYPE`・完全マスク）を設定する（`./flows.md` §`save` step 6.4 と整合）
+- `MoveFileExW` が同一ボリューム内でソース SD を保持するため、rename 後の `vault.db` は `.new` の DACL を引き継ぐ（別ボリューム / ネットワークドライブは vault ディレクトリとして `VaultPaths::new` の `canonicalize` + 保護領域チェックで実用上排除されるため考慮外）
+- `load` 冒頭の `verify_file(vault.db)` が 4 不変条件（`SE_DACL_PROTECTED` / ACE 数 1 / トラスティ SID 一致 / AccessMask 完全一致）を検証し、DACL の保持を確認する（`./flows.md` §`verify_file` 制御フロー）
+- **所有者 SID を touch しない方針は維持**: `ensure_file` の `SetNamedSecurityInfoW` は `OWNER_SECURITY_INFORMATION` を落とし DACL のみ書換（`../basic-design/security.md` §Windows owner-only DACL の適用戦略 と整合）
+
+一次情報出典: Microsoft Learn "MoveFileExW" https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw
+
+**3.4 `RetryPolicy` trait の切り出し（Phase 8 実装済）**: Win rename retry の振る舞いを trait に切り出すことで、テスト時に「実際の sleep なし・即時 fail の注入」が可能になる（旧設計は定数 `MAX_RETRIES = 5` / `base_ms = 50` をハードコードしており、CI で retry 発火テストが実際の wait を伴っていた）。
+
+`RetryPolicy` trait の定義:
+
+| メソッド | シグネチャ | 責務 |
+|---------|-----------|------|
+| `max_attempts` | `fn max_attempts(&self) -> u32` | 最大 retry 回数（超えたら `AtomicWriteFailed { stage: Rename }` で return） |
+| `sleep_duration` | `fn sleep_duration(&self, attempt: u32) -> std::time::Duration` | `attempt` 番目（1〜）の retry 前 sleep 量を返す。jitter を内部で生成してよい |
+| `should_retry` | `fn should_retry(&self, raw_os_error: i32) -> bool` | OS エラーコードが一過性エラーか否かを判定。`cfg(windows)` の `ERROR_ACCESS_DENIED (5)` / `ERROR_SHARING_VIOLATION (32)` / `ERROR_LOCK_VIOLATION (33)` → true、その他 → false |
+
+`ExponentialBackoffRetryPolicy` (production default):
+
+- `max_attempts = 5`、`base_ms = 50`、`jitter_ms = 25`（`OsRng` で `±25ms` 一様乱数）
+- `sleep_duration(attempt)` = `50ms × 2^(attempt-1) ± 25ms`（指数バックオフ、`../basic-design/security.md` §jitter テーブルと整合）
+- `should_retry` は上記 3 エラーコードのみ true
+- `Default` impl で構築可（`ExponentialBackoffRetryPolicy::default()`）
+
+**設計判断**:
+
+- `RetryPolicy` は `Send + Sync` 境界を要求しない（`AtomicWriteSession::finalize` の呼出はシングルスレッド内で完結する、`&dyn RetryPolicy` で渡す）
+- `cfg(windows)` のみ `should_retry` が意味を持つ。Unix では `RetryPolicy` を渡しても `sleep_duration` / `should_retry` は呼ばれない（`cfg(unix)` のリネームは即 fail fast、retry なし）
+- テスト用 `NoSleepRetryPolicy { max_attempts: 1 }` を `#[cfg(test)]` で定義し、TC-I29 / TC-I29-B の retry 発火テストで実際の sleep を排除する（CI 高速化、Non-Functional: テスト完了時間の削減）
 
 **4. なぜ `PermissionGuard` を別クラスに分離するか**: OS 別実装（Unix / Windows）を `cfg(unix)` / `cfg(windows)` で切り分けるが、`SqliteVaultRepository` の制御フローを OS 依存にしたくない。`PermissionGuard` が OS 非依存の 4 メソッド（`ensure_dir` / `ensure_file` / `verify_dir` / `verify_file`）を公開し、内部で `cfg_if!` で実装選択（Dependency Inversion の OS レベル適用）。
 

--- a/docs/features/vault-persistence/detailed-design/classes.md
+++ b/docs/features/vault-persistence/detailed-design/classes.md
@@ -212,7 +212,7 @@ classDiagram
 - **`AtomicWriteSession { conn, new_path }`**: SQLite 書込中の状態（開いた `Connection` + `.new` のパス）を保持するセッション型。`new(paths, vault)` でセッション開始、`finalize(self, retry_policy)` の所有権消費で全工程（クローズ → サイドカー DACL → fsync → rename）を順序固定で完結（Tell, Don't Ask、型レベルでクローズ順序を強制）
 - **`AtomicWriter`（ZST 残存）**: `detect_orphan` / `cleanup_new` / `#[cfg(test)] write_new_only` の 3 静的メソッドの名前空間として機能。`write_new` は `AtomicWriteSession::new` に昇格した
 
-**3.1 クローズ順序契約**（Issue #65 由来、Win file-handle semantics 対応）: `AtomicWriteSession::new` 内で SQLite `Connection` を取得し、以下の順序を**契約**として固定する。Phase 8 で `AtomicWriteSession::finalize(self, ...)` の所有権消費パターンにより**型レベルで強制**できるようになった（§3.2 参照）。各ステップは `./flows.md` §`save` step 7.1〜7.3 に対応し、順序逸脱は `AtomicWriteFailed { stage: WriteTemp }` で fail fast する:
+**3.1 クローズ順序契約**（Issue #65 由来、Win file-handle semantics 対応）: `AtomicWriteSession::new` 内で SQLite `Connection` を取得し、以下の順序を**契約**として固定する。Phase 8 で `AtomicWriteSession::finalize(self, ...)` の所有権消費パターンにより**型レベルで強制**できるようになった（§3.2 参照）。各ステップの `./flows.md` 対応番号は末尾に記す。順序逸脱は `AtomicWriteFailed { stage: WriteTemp }` で fail fast する:
 
 1. 全 `INSERT` を含むトランザクションを `tx.commit()` で締める（`AtomicWriteSession::new` 最終処理）
 2. **`PRAGMA wal_checkpoint(TRUNCATE)`** を発行（WAL 採用時のサイドカー強制空化、DELETE 採用時は no-op で害なし）— `finalize` step 7.1

--- a/docs/features/vault-persistence/detailed-design/data.md
+++ b/docs/features/vault-persistence/detailed-design/data.md
@@ -105,13 +105,41 @@ RetryOutcome
 - `fn verify_dir(path: &Path) -> Result<()>` — 既存ディレクトリの mode / ACL を検証
 - `fn verify_file(path: &Path) -> Result<()>` — 既存ファイルの mode / ACL を検証
 
-### `AtomicWriter`（`pub(crate)`、関連関数の集合、状態なし）
+### `AtomicWriteSession`（`pub(crate)`、セッション型、Phase 8 新設）
 
-- `fn detect_orphan(new_path: &Path) -> Result<()>` — `.new` が存在したら `Err(OrphanNewFile)`
-- `fn write_new(paths: &VaultPaths, vault: &Vault) -> Result<()>` — `.new` 作成 → PRAGMA → DDL → Tx 内 insert → COMMIT → close。OS パーミッション設定を作成直後に行う
-- `#[cfg(test)] fn write_new_only(paths: &VaultPaths, vault: &Vault) -> Result<()>` — **テスト専用フック**（AC-06 対応）。`write_new` と同一だが、`fsync_and_rename` を呼ばずに `.new` を残したまま return する。atomic write の中断状態を決定的に再現するため
-- `fn fsync_and_rename(paths: &VaultPaths) -> Result<()>` — `.new` を open し `sync_all`、親ディレクトリを open し `sync_all`、rename / ReplaceFileW
-- `fn cleanup_new(new_path: &Path) -> Result<()>` — best-effort 削除。失敗時は `tracing::warn!` でログ、上位には伝播しない（呼出側のエラーを上書きしない）
+SQLite 書込中の `rusqlite::Connection` を保持するセッション型。`finalize(self, ...)` の所有権消費でクローズ順序契約を型レベルで強制する（`./classes.md` §3.1 / §3.2 参照）。
+
+- `pub(crate) fn new(paths: &VaultPaths, vault: &Vault) -> Result<AtomicWriteSession>` — `.new` 作成 → OS パーミッション設定 → `Connection::open` → PRAGMA / DDL → 単一 Tx 内 insert → COMMIT までを実行し `conn` を保持したセッションを返す
+- `pub(crate) fn finalize(self, retry_policy: &dyn RetryPolicy) -> Result<()>` — 所有権を消費して以下を順序固定で実行: `PRAGMA wal_checkpoint(TRUNCATE)` → `PRAGMA journal_mode = DELETE` → `conn.close()`（失敗時は `Sqlite` エラー + best-effort `.new` 削除）→ サイドカー DACL 適用 → FsyncTemp → FsyncDir（Unix） → rename（Win: `retry_policy` に従う retry + symlink 再検証）
+- `Drop` 実装: `finalize` 未呼出のまま drop された場合は `AtomicWriter::cleanup_new` を best-effort 実行し panic しない（Fail Safe）
+
+### `AtomicWriter`（`pub(crate)`、ZST 名前空間、静的ヘルパのみ）
+
+`write_new` / `fsync_and_rename` は `AtomicWriteSession` に昇格。残存する静的メソッドのみ:
+
+- `pub(crate) fn detect_orphan(new_path: &Path) -> Result<()>` — `.new` が存在したら `Err(OrphanNewFile)`
+- `pub(crate) fn cleanup_new(new_path: &Path) -> Result<()>` — best-effort 削除。失敗時は `tracing::warn!` でログ、上位には伝播しない（呼出側のエラーを上書きしない）
+- `#[cfg(test)] pub(crate) fn write_new_only(paths: &VaultPaths, vault: &Vault) -> Result<()>` — **テスト専用フック**（AC-06 対応）。`AtomicWriteSession::new` と同一ロジックで `.new` を書き込むが `finalize` を呼ばずに return し `.new` を残す。atomic write 中断状態を決定的に再現するため
+
+### `RetryPolicy`（`pub(crate)` trait）
+
+Win rename retry の振る舞いを抽象化し、テスト注入を可能にする（`./classes.md` §3.4 参照）。
+
+| メソッド | シグネチャ | 責務 |
+|---------|-----------|------|
+| `max_attempts` | `fn max_attempts(&self) -> u32` | 最大 retry 回数 |
+| `sleep_duration` | `fn sleep_duration(&self, attempt: u32) -> std::time::Duration` | attempt 番目の sleep 量（jitter 込み）|
+| `should_retry` | `fn should_retry(&self, raw_os_error: i32) -> bool` | OS エラーが一過性か否かを判定 |
+
+### `ExponentialBackoffRetryPolicy`（`pub(crate)`、`RetryPolicy` の production default 実装）
+
+- `Default::default()` で構築: `max_attempts = 5`、`base_ms = 50`、`jitter_ms = 25`（`OsRng` `±25ms` 一様乱数）
+- `sleep_duration(attempt)` = `50ms × 2^(attempt-1) ± 25ms`（最悪 ~1675ms / 平均 ~1550ms、`../basic-design/security.md` §jitter テーブルと整合）
+- `should_retry(raw_os_error)`: `cfg(windows)` で `ERROR_ACCESS_DENIED (5)` / `ERROR_SHARING_VIOLATION (32)` / `ERROR_LOCK_VIOLATION (33)` → `true`、他 → `false`。`cfg(not(windows))` では常に `false`（Unix では rename を retry しない）
+
+**テスト用実装**（`#[cfg(test)]` のみ）:
+
+- `NoSleepRetryPolicy { max_attempts: 1 }` — `sleep_duration` は `Duration::ZERO` を返す。TC-I29 / TC-I29-B の retry 発火テストで実際の sleep を排除し CI 高速化
 
 ### `Mapping`（`pub(crate)`、関連関数の集合、状態なし）
 

--- a/docs/features/vault-persistence/detailed-design/flows.md
+++ b/docs/features/vault-persistence/detailed-design/flows.md
@@ -89,27 +89,28 @@
 3. `PermissionGuard::ensure_dir(self.paths.dir())` — 作成 or 既存強制
 4. `VaultLock::acquire_exclusive(&self.paths)?` — 排他ロック取得。別プロセスが排他/共有ロックを保持中なら `Locked { path, holder_hint }` を即 return（Fail Fast、待機・再試行しない）。以降 step 7 完了まで `VaultLock` がスコープに生存し drop 時に自動解放（RAII）
 5. `AtomicWriter::detect_orphan(self.paths.vault_db_new())` — 残存なら `OrphanNewFile` を return（ユーザ操作待ち、AC-14 の save 側検証）
-6. `AtomicWriter::write_new(self.paths, vault)`:
+6. `let session = AtomicWriteSession::new(self.paths, vault)?` — `.new` ファイル作成から SQLite COMMIT まで実行し、`conn` を保持したセッションを返す（`./classes.md` §3.2 参照）:
    1. `File::create(new_path)` 相当の mode 指定 open（Unix: `OpenOptions::mode(0o600)`、Windows: 作成後に ACL 設定）
    2. file handle を drop（SQLite が同じパスを再 open できるようにする）
    3. `Connection::open_with_flags(new_path, SQLITE_OPEN_CREATE | SQLITE_OPEN_READ_WRITE | SQLITE_OPEN_NO_MUTEX)`
-   4. `PermissionGuard::ensure_file(new_path)` — SQLite が open 時に mode を変えた場合の再強制
+   4. `PermissionGuard::ensure_file(new_path)` — SQLite が open 時に mode を変えた場合の再強制。Windows では owner-only DACL を設定（rename 前 DACL 適用戦略確定、`./classes.md` §3.3 参照）
    5. `execute(PRAGMA_APPLICATION_ID_SET)`、`execute(PRAGMA_USER_VERSION_SET)`、`execute(PRAGMA_JOURNAL_MODE)`
    6. `execute(CREATE_VAULT_HEADER)`、`execute(CREATE_RECORDS)`
    7. `let tx = conn.transaction()?`
    8. `Mapping::vault_header_to_params(vault.header())` で params 取得、`tx.execute(INSERT_VAULT_HEADER, params)` 実行
    9. `for record in vault.records()`: `Mapping::record_to_params(record)` → `tx.execute(INSERT_RECORD, params)`
-   10. `tx.commit()?`
-   11. **`execute("PRAGMA wal_checkpoint(TRUNCATE)")`** — WAL モード採用時に `-wal` / `-shm` サイドカーをチェックポイント+truncate で物理空にする（DELETE モード採用時は no-op だが副作用なし、SQLite "Write-Ahead Logging" §`PRAGMA wal_checkpoint` https://www.sqlite.org/pragma.html#pragma_wal_checkpoint 参照）
-   12. **`execute("PRAGMA journal_mode = DELETE")`** — 残存の `-journal` / `-wal` / `-shm` サイドカーを削除モードに切替し、close 時にサイドカーが物理消去されることを契約として固定（Issue #65 由来、Win file-handle semantics 対応の根本対策）。**defense-in-depth の意図**: `schema.rs::PRAGMA_JOURNAL_MODE` で初期 DELETE 設定済（`atomic.rs:70-71`）の冗長 issue だが、将来 WAL モードへ切り替える設計判断（パフォーマンス改善 / 並行 read 性能）が入った時に **本 step を消し忘れて Win rename race を再導入する罠を構造的に塞ぐ**。`PRAGMA_JOURNAL_MODE` 定数の値変更時、本 step が「DELETE への明示的な強制切替」として動き、`.new` 書込中だけは確実に DELETE モードで close される（Boy Scout / Fail Safe）
-   13. **`conn.close()` を明示呼出**。`Result<(), (Connection, rusqlite::Error)>` を握り、失敗時は **`PersistenceError::Sqlite { source: rusqlite::Error }` を直接返す**（`io::Error::other` 等で型情報を失う変換を行わない、`../basic-design/error.md` §禁止事項 §エラー情報を失う型の公開 API 使用 と整合）。`drop(conn)` 任せで Win file-handle 解放遅延を許容しない（rusqlite Drop は `sqlite3_close_v2` を呼ぶが pending stmt cache があると close を遅延する semantics — `rusqlite::Connection::close` doc https://docs.rs/rusqlite/latest/rusqlite/struct.Connection.html#method.close 参照）。close 失敗時は `AtomicWriter::cleanup_new(new_path)` を呼んで `.new` を best-effort 削除し、元の `Sqlite` エラーを伝播（`../basic-design/security.md` §atomic write の二次防衛線 §`Connection::close()` 失敗時の `.new` クリーンアップ）
-7. `AtomicWriter::fsync_and_rename(self.paths)`:
-   1. `File::open(new_path)?.sync_all()?`（`FsyncTemp`、Win では `read(true).write(true)` で開く — `FlushFileBuffers` が書込権限を要求するため）
-   2. `File::open(dir)?.sync_all()?`（`FsyncDir`、Unix のみ。Windows では no-op）
-   3. **rename 段（共通実装、Win のみ retry 補強）**: `fs::rename(new_path, final_path)` を呼ぶ。Rust `std::fs::rename` は OS 抽象を内部で行い、Unix では `rename(2)`（POSIX atomic）、Windows では `MoveFileExW(MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)` 相当に展開される（`std::fs::rename` Win 挙動 https://doc.rust-lang.org/std/fs/fn.rename.html#platform-specific-behavior 参照）。**`ReplaceFileW` 直接呼出は採用しない**（採否根拠: ① `std::fs::rename` で十分な atomicity を得られる、② `ReplaceFileW` 直接採用は `shikomi-infra` に新たな unsafe FFI 境界を追加し本 PR スコープを越える、③ メタデータ preserve は本 vault では不要 — `.new` を `vault.db` で完全置換する一方向で、attribute / ADS / timestamp を保つ必要がない、④ `MOVEFILE_WRITE_THROUGH` で書込貫通も `std::fs::rename` 経路で達成。Microsoft Learn "MoveFileExW" https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw / "ReplaceFileW" https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-replacefilew 参照）。
+   10. `tx.commit()?` — COMMIT 完了。`conn` は `AtomicWriteSession` が保持し続ける（クローズ順序の型レベル強制は `finalize` の責務、`./classes.md` §3.1 / §3.2 参照）
+7. `session.finalize(&ExponentialBackoffRetryPolicy::default())?` — `AtomicWriteSession` を所有権消費し、クローズ順序固定 → サイドカー DACL → fsync → rename を一連で実行（`./classes.md` §3.2 / §3.4 参照）:
+   1. **`execute("PRAGMA wal_checkpoint(TRUNCATE)")`** — WAL モード採用時に `-wal` / `-shm` サイドカーをチェックポイント+truncate で物理空にする（DELETE モード採用時は no-op だが副作用なし、SQLite "Write-Ahead Logging" §`PRAGMA wal_checkpoint` https://www.sqlite.org/pragma.html#pragma_wal_checkpoint 参照）
+   2. **`execute("PRAGMA journal_mode = DELETE")`** — 残存の `-journal` / `-wal` / `-shm` サイドカーを削除モードに切替し、close 時にサイドカーが物理消去されることを契約として固定（Issue #65 由来、Win file-handle semantics 対応の根本対策）。**defense-in-depth の意図**: `schema.rs::PRAGMA_JOURNAL_MODE` で初期 DELETE 設定済の冗長 step だが、将来 WAL モードへ切り替える設計判断が入った時に **本 step を消し忘れて Win rename race を再導入する罠を構造的に塞ぐ**（Boy Scout / Fail Safe）
+   3. **`conn.close()` を明示呼出**。`Result<(), (Connection, rusqlite::Error)>` を握り、失敗時は **`PersistenceError::Sqlite { source: rusqlite::Error }` を直接返す**（`io::Error::other` 等で型情報を失う変換を行わない、`../basic-design/error.md` §禁止事項と整合）。`drop(conn)` 任せで Win file-handle 解放遅延を許容しない（rusqlite Drop は `sqlite3_close_v2` を呼ぶが pending stmt cache があると close を遅延する semantics — `rusqlite::Connection::close` doc https://docs.rs/rusqlite/latest/rusqlite/struct.Connection.html#method.close 参照）。close 失敗時は `AtomicWriter::cleanup_new(new_path)` を呼んで `.new` を best-effort 削除し、元の `Sqlite` エラーを伝播（`../basic-design/security.md` §atomic write の二次防衛線 §`Connection::close()` 失敗時の `.new` クリーンアップ）
+   4. **サイドカー DACL 適用**: `[".new-journal", ".new-wal", ".new-shm"]` の各候補パスを `try_exists()` で確認し、存在するものに `PermissionGuard::ensure_file` を適用（`0o600` / Win owner-only DACL）。存在しなければスキップ（`../basic-design/security.md` §サイドカーの DACL 適用 参照）
+   5. `File::open(new_path)?.sync_all()?`（`FsyncTemp`、Win では `read(true).write(true)` で開く — `FlushFileBuffers` が書込権限を要求するため）
+   6. `File::open(dir)?.sync_all()?`（`FsyncDir`、Unix のみ。Windows では no-op）
+   7. **rename 段（共通実装、Win のみ retry 補強）**: `fs::rename(new_path, final_path)` を呼ぶ。Rust `std::fs::rename` は OS 抽象を内部で行い、Unix では `rename(2)`（POSIX atomic）、Windows では `MoveFileExW(MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)` 相当に展開される（`std::fs::rename` Win 挙動 https://doc.rust-lang.org/std/fs/fn.rename.html#platform-specific-behavior 参照）。**`ReplaceFileW` 直接呼出は採用しない**（`std::fs::rename` で十分な atomicity を得られる、unsafe FFI 境界の追加回避、`MoveFileExW` がソース SD を保持するため rename 前 DACL 設定のみで二段階検証が成立する、`./classes.md` §3.3 参照。Microsoft Learn "MoveFileExW" https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw 参照）。
    - **Unix**: 失敗即 `AtomicWriteFailed { stage: Rename, source }`
-   - **Windows (`cfg(windows)` 限定 retry 補強)**: `Err` の場合、`io::Error::raw_os_error()` を読み、`ERROR_ACCESS_DENIED (5)` / `ERROR_SHARING_VIOLATION (32)` / `ERROR_LOCK_VIOLATION (33)` を**一過性エラー**として識別。これらは Win Indexer / Defender / バックアップソフトの一過性ハンドル / SQLite Drop 順序の残響等で発生するため、**指数バックオフ retry**（attempt n の sleep ≒ `50ms × 2^(n-1)` ± `25ms`、`MAX_RETRIES = 5`、**最悪 ~1675ms / 平均 ~1550ms**、jitter は `±25ms` 一様乱数で固定タイミングを timing oracle 化させない、`../basic-design/security.md` §atomic write の二次防衛線 §jitter）を挿入する。retry 直前に `VaultPaths` の **シンボリックリンク再検証**（`fs::symlink_metadata` で `vault.db` / `.new` 双方の `is_symlink` を再確認）を行う（retry 窓中の TOCTOU 差替え攻撃対策、`../basic-design/security.md` §atomic write の二次防衛線 §Win retry 中 TOCTOU）。再検証で symlink が検出されたら retry を打ち切り `InvalidVaultDir { reason: SymlinkNotAllowed }` で fail fast。**それ以外のエラーコード**（`ERROR_DISK_FULL (112)` / `ERROR_PATH_NOT_FOUND (3)` 等）は即 fail fast、retry しない。retry 全敗で `AtomicWriteFailed { stage: Rename, source }` を返す。retry 発火・完了は `audit::retry_event(stage, attempt, raw_os_error, elapsed_ms, outcome)` で監査ログに記録（`outcome: RetryOutcome` enum、各 retry 試行直前 `Pending` → 成功時 `Succeeded` → 5 回全敗時 `Exhausted`、文字列 switch を排除した型安全実装、`../basic-design/security.md` §atomic write の二次防衛線 §retry 監査ログ / `./data.md` §`RetryOutcome`）。**指数バックオフ採用根拠**は同 §jitter §指数バックオフ採否根拠（Bug-G-001 で線形 50ms × 5 が CI Defender 250ms+ 保持を吸収不能と判明）
-   4. 各段階で失敗したら `AtomicWriter::cleanup_new(new_path)` を呼び、best-effort で `.new` を削除。元のエラーを `AtomicWriteFailed { stage, source }`（または `Sqlite { source }` for close 失敗、`InvalidVaultDir { reason }` for retry 中 symlink 検知）にラップして return
+   - **Windows (`cfg(windows)` 限定 retry 補強)**: `Err` の場合、`io::Error::raw_os_error()` を読み、`retry_policy.should_retry(raw_os_error)` が true な**一過性エラー**（`ERROR_ACCESS_DENIED (5)` / `ERROR_SHARING_VIOLATION (32)` / `ERROR_LOCK_VIOLATION (33)`）を識別。**`retry_policy.sleep_duration(attempt)` の sleep** を挿入する（`ExponentialBackoffRetryPolicy` のデフォルト: `50ms × 2^(n-1) ± 25ms`、**最悪 ~1675ms / 平均 ~1550ms**、`../basic-design/security.md` §jitter）。retry 直前に `VaultPaths` の **シンボリックリンク再検証**（`fs::symlink_metadata` で `vault.db` / `.new` 双方の `is_symlink` を再確認）を行う（`../basic-design/security.md` §Win retry 中 TOCTOU）。再検証で symlink が検出されたら retry 打ち切り `InvalidVaultDir { reason: SymlinkNotAllowed }` で fail fast。**それ以外のエラーコード**（`ERROR_DISK_FULL (112)` 等）は即 fail fast。retry 全敗で `AtomicWriteFailed { stage: Rename, source }` を返す。retry 発火・完了は `audit::retry_event(stage, attempt, raw_os_error, elapsed_ms, outcome)` で監査ログに記録（`./data.md` §`RetryOutcome`、`../basic-design/security.md` §retry 監査ログ）
+   8. 各段階で失敗したら `AtomicWriter::cleanup_new(new_path)` を呼び、best-effort で `.new` を削除。元のエラーを `AtomicWriteFailed { stage, source }`（または `Sqlite { source }` for close 失敗、`InvalidVaultDir { reason }` for retry 中 symlink 検知）にラップして return
 8. `audit::exit_ok_save(record_count, bytes_written, elapsed_ms)` を発行、`VaultLock` が drop され排他ロックが解放される
 9. `Ok(())` を返却
 
@@ -188,10 +189,6 @@
 | `verify_dir` | `fetch_dacl_and_owner` → `verify_dacl_owner_only(_, _, _, EXPECTED_DIR_MASK)` | 検証 | 検証 | 検証 |
 | `verify_file` | 同上、`EXPECTED_FILE_MASK` | 検証 | 検証 | 検証 |
 
-#### `ReplaceFileW` の設定（REQ-P04 Windows 経路、変更なし）
-
-- `windows::Win32::Storage::FileSystem::ReplaceFileW`
-- `lpReplacementFileName = .new`, `lpReplacedFileName = vault.db`, `dwReplaceFlags = REPLACEFILE_WRITE_THROUGH`（内部で fsync 相当が走る）, `lpBackupFileName = null_ptr`（バックアップ不要）
 
 ## 具体的な SQL の要点（定数値の抜粋）
 


### PR DESCRIPTION
Closes #73

## Summary

Issue #65 外部レビューで「Phase 8 別PR」として先送りした 4 件の deferred 事項を全て設計確定。

- **AtomicWriteSession 構造体化**: `AtomicWriter` ZST + 静的メソッド連鎖 → `AtomicWriteSession { conn, new_path }` セッション型に移行。`finalize(self, retry_policy)` の所有権消費でクローズ順序契約を型レベルで強制（Tell, Don't Ask）。`AtomicWriter` ZST は `detect_orphan` / `cleanup_new` の名前空間として残存
- **RetryPolicy trait 切り出し**: `max_attempts` / `sleep_duration(attempt)` / `should_retry(os_error)` を trait 化。`ExponentialBackoffRetryPolicy`（production default）+ `NoSleepRetryPolicy`（`#[cfg(test)]`）でテスト sleep を排除可能に
- **Windows DACL 適用順序確定**: rename 前に `.new` へ `ensure_file`（owner-only DACL）設定、`MoveFileExW` がソースファイルオブジェクトの SD を保持するため rename 後も DACL 維持。stale な `ReplaceFileW` セクションを `flows.md` から削除
- **dir-fd 化 不採用確定**: `AtomicWriteSession` 所有権モデル + symlink 再検証の多層防御で要件充足。Windows の `FILE_FLAG_BACKUP_SEMANTICS` 経由 dir-fd は undocumented 依存リスクあり

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `detailed-design/classes.md` | §3.2 AtomicWriteSession 設計確定、§3.3 DACL タイミング確定、§3.4 RetryPolicy trait 新設。classDiagram に AtomicWriteSession / RetryPolicy / ExponentialBackoffRetryPolicy を追加 |
| `detailed-design/flows.md` | §save step 6 → `AtomicWriteSession::new`、step 7 → `session.finalize()` に再構成。stale `ReplaceFileW` セクション削除 |
| `detailed-design/data.md` | AtomicWriter → AtomicWriteSession + AtomicWriter に分割。RetryPolicy trait / ExponentialBackoffRetryPolicy / NoSleepRetryPolicy シグネチャ追加 |
| `basic-design/security.md` | dir-fd 不採用確定（理由明記）。RetryPolicy trait Phase 8 実装済みに更新 |
| `basic-design/index.md` | atomic.rs モジュール説明を AtomicWriteSession 構造体に更新。classDiagram / 処理フロー §save を整合 |

## Test plan

- [ ] 設計書に疑似コード・言語コードブロックがないことを確認
- [ ] 全ての「Phase 8 別PR」「次段」表記が消去されていることを確認
- [ ] `classes.md` classDiagram の Mermaid 構文が正しいことを確認
- [ ] `basic-design/index.md` の Mermaid classDiagram が整合していることを確認
- [ ] `AtomicWriteSession.finalize` が steps 7.1〜7.8 を網羅していることを `flows.md` で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)