### PR TITLE
feat(vault-persistence): Phase 8 AtomicWriteSession / RetryPolicy 実装

### DIFF
--- a/crates/shikomi-infra/src/persistence/repository.rs
+++ b/crates/shikomi-infra/src/persistence/repository.rs
@@ -12,7 +12,11 @@ use super::{
     lock::VaultLock,
     paths::{self, VaultPaths},
     permission::PermissionGuard,
-    sqlite::{atomic::AtomicWriter, mapping::Mapping, schema::SchemaSql},
+    sqlite::{
+        atomic::{AtomicWriteSession, AtomicWriter, ExponentialBackoffRetryPolicy},
+        mapping::Mapping,
+        schema::SchemaSql,
+    },
     VaultRepository,
 };
 
@@ -361,11 +365,11 @@ impl SqliteVaultRepository {
         // Step 5: 孤立 `.new` ファイルの検出
         AtomicWriter::detect_orphan(self.paths.vault_db_new())?;
 
-        // Step 6: `.new` ファイルに書き込む
-        AtomicWriter::write_new(&self.paths, vault)?;
+        // Step 6: `.new` 作成から SQLite COMMIT まで実行しセッションを取得
+        let session = AtomicWriteSession::new(&self.paths, vault)?;
 
-        // Step 7: fsync + リネーム
-        AtomicWriter::fsync_and_rename(&self.paths)?;
+        // Step 7: クローズ順序固定 → sidecar DACL → fsync → rename（Win: retry 補強）
+        session.finalize(&ExponentialBackoffRetryPolicy)?;
 
         // 書き込みバイト数を取得（監査ログ用）
         let bytes_written = self

--- a/crates/shikomi-infra/src/persistence/sqlite/atomic.rs
+++ b/crates/shikomi-infra/src/persistence/sqlite/atomic.rs
@@ -1,29 +1,27 @@
 //! アトミック書き込みユーティリティ。
 //!
-//! `.new` ファイルへの書き込み → fsync → rename によるアトミック更新を提供する。
+//! Phase 8 リファクタ（Issue #73）: `AtomicWriter` ZST + 静的メソッド連鎖から
+//! セッション型 `AtomicWriteSession { conn, new_path }` に移行。
+//! `finalize(self, retry_policy)` の所有権消費でクローズ順序契約を型レベルで強制。
 //!
-//! Issue #65 補強: `write_new` の終端で WAL チェックポイント+`journal_mode=DELETE`+
-//! `Connection::close()` を明示実施し、サイドカー（`-journal` / `-wal` / `-shm`）の
-//! 物理消去を契約として固定する。残存サイドカーには owner-only DACL を best-effort で
-//! 適用する。`fsync_and_rename` の rename 段は Windows のみ一過性エラー
-//! （`ERROR_ACCESS_DENIED` / `ERROR_SHARING_VIOLATION` / `ERROR_LOCK_VIOLATION`）に対し
-//! **指数バックオフ retry（`50ms × 2^(n-1)` ± `25ms` jitter × 最大 5 回、
-//! 最悪 ~1675ms / 平均 ~1550ms）** を行い、retry 直前に symlink / reparse point を
-//! 再検証して TOCTOU 差替えを fail fast する。詳細は `docs/features/vault-persistence/`
-//! の各設計書を参照。
+//! - **`AtomicWriteSession`**: `.new` 書込から `conn.close()` + fsync + rename まで一連で完結。
+//! - **`AtomicWriter`** (ZST): `detect_orphan` / `cleanup_new` の名前空間として残存。
+//! - **`RetryPolicy`** trait: Win rename retry の振る舞いをテスト注入可能に抽象化。
 //!
-//! Bug-G-001 反映（2026-04-27）: 当初 `50ms × 5 = 最悪 ~375ms` の線形 retry だったが、
-//! Win CI ランナー (windows-latest) で Defender / Search Indexer が `vault.db` ハンドルを
-//! `drop` 後も `~250ms+` 保持し続け、`AtomicWriteFailed { code: 5 }` が継続発生したため、
-//! retry budget を指数バックオフへ拡張した（`security.md §jitter` `SSoT` も連動更新）。
+//! Bug-G-001 反映（2026-04-27）: Win CI ランナーで Defender / Search Indexer が
+//! ハンドルを `drop` 後も `~250ms+` 保持し続けるため、retry を指数バックオフへ拡張
+//! （`50ms × 2^(n-1)` ± `25ms` jitter × 最大 5 回、最悪 ~1675ms / 平均 ~1550ms）。
+//!
+//! Windows DACL 適用順序確定（Phase 8、`./classes.md` §3.3）: rename 前に `.new` に
+//! `ensure_file` を適用し、`MoveFileExW` がソース SD を保持することで `vault.db` に引継。
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use rusqlite::OpenFlags;
 use shikomi_core::Vault;
 
 // `Audit::retry_event` は cfg(windows) rename retry でのみ呼出される。
-// 非 Windows ビルドの unused import 警告を避けるため import 自体を cfg gate する。
 #[cfg(windows)]
 use crate::persistence::audit::{Audit, RetryOutcome};
 use crate::persistence::error::{AtomicWriteStage, PersistenceError};
@@ -34,118 +32,214 @@ use super::mapping::Mapping;
 use super::schema::SchemaSql;
 
 // -------------------------------------------------------------------
-// 内部定数（Issue #65）
+// 内部定数
 // -------------------------------------------------------------------
 
-/// `SQLite` サイドカーファイル名のサフィックス（rusqlite が `<db>` の隣接に作成する）。
-///
-/// `PRAGMA wal_checkpoint(TRUNCATE)` + `PRAGMA journal_mode = DELETE` + `Connection::close()`
-/// により原則消去される（`docs/features/vault-persistence/basic-design/security.md`
-/// §atomic write の二次防衛線 §サイドカーの DACL 適用）。本定数は残存時の DACL 強制で参照する。
+/// `SQLite` サイドカーファイル名のサフィックス。
 const SQLITE_SIDECAR_SUFFIXES: &[&str] = &["-journal", "-wal", "-shm"];
 
-/// `cfg(windows)` 限定 rename retry の上限回数。
-///
-/// 5 回。指数バックオフ `50ms × 2^(n-1)` ± `25ms` jitter:
-///
-/// | n | 中央値 | range | 累積中央値 |
-/// |---|------|-------|----------|
-/// | 1 | 50ms | 25–75ms | 50ms |
-/// | 2 | 100ms | 75–125ms | 150ms |
-/// | 3 | 200ms | 175–225ms | 350ms |
-/// | 4 | 400ms | 375–425ms | 750ms |
-/// | 5 | 800ms | 775–825ms | 1550ms |
-///
-/// = 最悪 ~1675ms / 平均 ~1550ms。SSoT 上限値は
-/// `docs/features/vault-persistence/basic-design/security.md` §jitter（同期参照先 4 ファイル列挙）。
-#[cfg(windows)]
-const RENAME_MAX_RETRIES: u32 = 5;
-
-/// 1 回目 retry 間隔の中央値（ミリ秒）。各 retry n では `BASE × 2^(n-1)` を中央値として使用。
-#[cfg(windows)]
-const RENAME_BASE_DELAY_MS: u64 = 50;
-
-/// retry 間隔の jitter 半幅（±N ミリ秒、timing oracle 防止）。
-///
-/// 指数バックオフでも jitter 半幅は固定（中央値の比率ではなく絶対 ms）で十分。
-/// 大きい retry 間隔（800ms）に対する ±25ms は約 3% で外部観測者からの分布推定を狭めない。
-#[cfg(windows)]
-const RENAME_JITTER_HALF_RANGE_MS: u64 = 25;
-
-/// jitter 抽選範囲（`OsRng` 1 byte の `% N` 値、`0..=2*HALF_RANGE` を網羅）。
-///
-/// `HALF_RANGE_MS` から導出する（マジックナンバー禁止、Boy Scout）。
-/// `HALF_RANGE_MS = 25` のとき `2 * 25 + 1 = 51`（`0..=50` を一様抽選後 `-25` シフトで `[-25, +25]`）。
-/// `HALF_RANGE_MS` を弄った時に独立進化して整合崩壊する罠を構造的に塞ぐ。
-/// `u8` への as 変換は `HALF_RANGE_MS ≤ 127` の範囲内で安全（u8 max = 255）。
-#[cfg(windows)]
-const RENAME_JITTER_RANGE: u8 = (RENAME_JITTER_HALF_RANGE_MS * 2 + 1) as u8;
-
-/// 監査ログに記録する rename stage 名（`Audit::retry_event` の `stage` 引数）。
-#[cfg(windows)]
-const RENAME_STAGE_LABEL: &str = "rename";
-
 // -------------------------------------------------------------------
-// AtomicWriter
+// RetryPolicy trait
 // -------------------------------------------------------------------
 
-/// アトミック書き込み操作を提供するゼロサイズ型。
-pub(crate) struct AtomicWriter;
+/// rename retry の振る舞いを抽象化する trait（Phase 8、Issue #73）。
+///
+/// `cfg(windows)` 限定 rename retry で使用する。`NoSleepRetryPolicy` を差し込むことで
+/// テスト時の実際の sleep を排除し CI を高速化する（`./classes.md` §3.4 参照）。
+///
+/// Unix では `finalize` 内で `should_retry` / `sleep_duration` は一切呼ばれない
+/// （Unix の rename は即 fail fast、retry なし）。
+///
+/// `cfg(windows)` 限定ロジックで使用するため非 Windows ビルドでは dead_code になるが意図的。
+#[allow(dead_code)]
+pub(crate) trait RetryPolicy {
+    /// 最大 retry 回数。超過したら `AtomicWriteFailed { stage: Rename }` で return。
+    fn max_attempts(&self) -> u32;
 
-impl AtomicWriter {
-    /// `vault.db.new` が存在する場合に孤立ファイルエラーを返す。
+    /// `attempt` 番目（1-indexed）の retry 前 sleep 量を返す。jitter を内部で生成してよい。
+    fn sleep_duration(&self, attempt: u32) -> Duration;
+
+    /// OS エラーコードが一過性エラーか否かを判定する。
     ///
-    /// # Errors
+    /// `cfg(windows)`:
+    /// - `ERROR_ACCESS_DENIED (5)` / `ERROR_SHARING_VIOLATION (32)` /
+    ///   `ERROR_LOCK_VIOLATION (33)` → `true`、それ以外 → `false`
     ///
-    /// - `.new` が存在する: `PersistenceError::OrphanNewFile`
-    /// - 存在確認 IO エラー: `PersistenceError::Io`
-    pub(crate) fn detect_orphan(new_path: &Path) -> Result<(), PersistenceError> {
-        match new_path.try_exists() {
-            Ok(true) => Err(PersistenceError::OrphanNewFile {
-                path: new_path.to_path_buf(),
-            }),
-            Ok(false) => Ok(()),
-            Err(e) => Err(PersistenceError::Io {
-                path: new_path.to_path_buf(),
-                source: e,
-            }),
+    /// `cfg(not(windows))`: 常に `false`。
+    fn should_retry(&self, raw_os_error: i32) -> bool;
+}
+
+// -------------------------------------------------------------------
+// ExponentialBackoffRetryPolicy
+// -------------------------------------------------------------------
+
+/// 指数バックオフ retry の production default 実装。
+///
+/// `max_attempts = 5`、`base_ms = 50`、`jitter = ±25ms`（`OsRng` 一様乱数）。
+///
+/// | attempt | 中央値 | range       | 累積中央値 |
+/// |---------|--------|-------------|----------|
+/// | 1       | 50ms   | 25〜75ms   | 50ms     |
+/// | 2       | 100ms  | 75〜125ms  | 150ms    |
+/// | 3       | 200ms  | 175〜225ms | 350ms    |
+/// | 4       | 400ms  | 375〜425ms | 750ms    |
+/// | 5       | 800ms  | 775〜825ms | 1550ms   |
+///
+/// 最悪 ~1675ms / 平均 ~1550ms。SSoT:
+/// `docs/features/vault-persistence/basic-design/security.md` §jitter。
+pub(crate) struct ExponentialBackoffRetryPolicy;
+
+impl Default for ExponentialBackoffRetryPolicy {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl RetryPolicy for ExponentialBackoffRetryPolicy {
+    fn max_attempts(&self) -> u32 {
+        5
+    }
+
+    fn sleep_duration(&self, attempt: u32) -> Duration {
+        #[cfg(windows)]
+        {
+            use rand_core::{OsRng, RngCore};
+
+            const BASE_MS: u64 = 50;
+            const JITTER_HALF_RANGE_MS: u64 = 25;
+            // 0..=50 を一様抽選後 -25 シフトで [-25, +25]
+            // HALF_RANGE_MS ≤ 127 の範囲で u8 へのキャストは安全
+            const JITTER_RANGE: u8 = (JITTER_HALF_RANGE_MS * 2 + 1) as u8;
+
+            let mut buf = [0u8; 1];
+            OsRng.fill_bytes(&mut buf);
+            let jitter_pos = u64::from(buf[0] % JITTER_RANGE);
+            // attempt は 1..=max_attempts(=5) なので左シフト overflow なし
+            let multiplier: u64 = 1u64 << (attempt.saturating_sub(1));
+            let center_ms = BASE_MS.saturating_mul(multiplier);
+            let delay_ms = center_ms + jitter_pos - JITTER_HALF_RANGE_MS;
+            Duration::from_millis(delay_ms)
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = attempt;
+            Duration::ZERO
         }
     }
 
-    /// `vault.db.new` に vault の内容を書き込む。
+    fn should_retry(&self, raw_os_error: i32) -> bool {
+        #[cfg(windows)]
+        {
+            matches!(raw_os_error, 5 | 32 | 33)
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = raw_os_error;
+            false
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// NoSleepRetryPolicy（テスト専用）
+// -------------------------------------------------------------------
+
+/// テスト専用 `RetryPolicy`（sleep なし・CI 高速化）。
+///
+/// `sleep_duration` は常に `Duration::ZERO`。`should_retry` は
+/// `ExponentialBackoffRetryPolicy` と同じ判定ロジックを使用。
+/// TC-I29 / TC-I29-B の retry 発火テストで実際の sleep を排除する（`./classes.md` §3.4）。
+#[cfg(test)]
+pub(crate) struct NoSleepRetryPolicy {
+    pub(crate) max_attempts: u32,
+}
+
+#[cfg(test)]
+impl RetryPolicy for NoSleepRetryPolicy {
+    fn max_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
+    fn sleep_duration(&self, _attempt: u32) -> Duration {
+        Duration::ZERO
+    }
+
+    fn should_retry(&self, raw_os_error: i32) -> bool {
+        #[cfg(windows)]
+        {
+            matches!(raw_os_error, 5 | 32 | 33)
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = raw_os_error;
+            false
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// AtomicWriteSession
+// -------------------------------------------------------------------
+
+/// SQLite 書込中の `Connection` を保持するセッション型（Phase 8 新設、Issue #73）。
+///
+/// `new(paths, vault)` でセッション開始、`finalize(self, retry_policy)` の所有権消費で
+/// クローズ順序契約（PRAGMA → `close()` → sidecar DACL → fsync → rename）を
+/// 型レベルで強制する（`./classes.md` §3.1 / §3.2 参照）。
+///
+/// **`Drop`**: `finalize` 未呼出のまま drop された場合は `AtomicWriter::cleanup_new` を
+/// best-effort 実行し panic しない（Fail Safe）。
+/// `new_path` が `None` ならば cleanup 不要（`finalize` が所有権を取得済）。
+pub(crate) struct AtomicWriteSession {
+    conn: Option<rusqlite::Connection>,
+    /// `finalize` 冒頭で `take()` し `None` にする。
+    /// `Drop` は `Some` の場合のみ cleanup_new を呼ぶ。
+    new_path: Option<PathBuf>,
+    final_path: PathBuf,
+    dir_path: PathBuf,
+}
+
+impl AtomicWriteSession {
+    /// `.new` ファイル作成から SQLite COMMIT まで実行し、`conn` を保持したセッションを返す。
     ///
-    /// Issue #65 補強: tx.commit 後に `PRAGMA wal_checkpoint(TRUNCATE)` +
-    /// `PRAGMA journal_mode = DELETE` + `Connection::close()` を明示実施し、
-    /// rusqlite Drop の `sqlite3_close_v2` 遅延 semantics を回避する。
-    /// close 失敗時は `.new` を best-effort 削除して元の Sqlite エラーを伝播する。
-    /// 最後に残存サイドカー（`-journal` / `-wal` / `-shm`）に owner-only DACL を強制適用する。
+    /// `flows.md §save` step 6.1〜6.10 に対応（`./classes.md` §3.2 参照）。
     ///
     /// # Errors
     ///
     /// - ファイル作成失敗: `PersistenceError::AtomicWriteFailed { stage: PrepareNew }`
-    /// - `SQLite` エラー（PRAGMA / DDL / トランザクション / close）: `PersistenceError::Sqlite`
-    pub(crate) fn write_new(paths: &VaultPaths, vault: &Vault) -> Result<(), PersistenceError> {
-        let new_path = paths.vault_db_new();
+    /// - パーミッション設定失敗: `PersistenceError::InvalidPermission` / `PersistenceError::Io`
+    /// - `SQLite` エラー（PRAGMA / DDL / TX / COMMIT）: `PersistenceError::Sqlite`
+    pub(crate) fn new(paths: &VaultPaths, vault: &Vault) -> Result<Self, PersistenceError> {
+        let new_path = paths.vault_db_new().to_path_buf();
+        let final_path = paths.vault_db().to_path_buf();
+        let dir_path = paths.dir().to_path_buf();
 
-        // 適切なパーミッションでファイルを事前作成
-        Self::create_with_permissions(new_path)?;
+        // Step 6.1-6.2: 適切なパーミッションでファイルを事前作成し、file handle を drop
+        Self::create_with_permissions(&new_path)?;
 
-        // SQLite 接続を開く
+        // Step 6.3: SQLite 接続を開く
         let conn = rusqlite::Connection::open_with_flags(
-            new_path,
+            &new_path,
             OpenFlags::SQLITE_OPEN_CREATE
                 | OpenFlags::SQLITE_OPEN_READ_WRITE
                 | OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )
         .map_err(|e| PersistenceError::Sqlite { source: e })?;
 
-        // PRAGMA 設定とテーブル作成
+        // Step 6.4: ensure_file — SQLite が open 時に mode を変えた場合の再強制。
+        // Windows では owner-only DACL を rename 前に設定する（`MoveFileExW` がソース SD を
+        // 保持するため rename 後の vault.db へ DACL が引き継がれる、`./classes.md` §3.3 参照）。
+        PermissionGuard::ensure_file(&new_path)?;
+
+        // Step 6.5: PRAGMA 設定
         conn.execute_batch(SchemaSql::PRAGMA_APPLICATION_ID_SET)
             .map_err(|e| PersistenceError::Sqlite { source: e })?;
         conn.execute_batch(SchemaSql::PRAGMA_USER_VERSION_SET)
             .map_err(|e| PersistenceError::Sqlite { source: e })?;
         conn.execute_batch(SchemaSql::PRAGMA_JOURNAL_MODE)
             .map_err(|e| PersistenceError::Sqlite { source: e })?;
+
+        // Step 6.6: テーブル / インデックス作成
         conn.execute_batch(SchemaSql::CREATE_VAULT_HEADER)
             .map_err(|e| PersistenceError::Sqlite { source: e })?;
         conn.execute_batch(SchemaSql::CREATE_RECORDS)
@@ -153,7 +247,7 @@ impl AtomicWriter {
         conn.execute_batch(SchemaSql::CREATE_HOTKEY_INDEX)
             .map_err(|e| PersistenceError::Sqlite { source: e })?;
 
-        // トランザクション: vault_header と全レコードを挿入
+        // Steps 6.7-6.10: 単一トランザクション内で vault_header + 全レコードを INSERT → COMMIT
         {
             let tx = conn
                 .unchecked_transaction()
@@ -198,56 +292,267 @@ impl AtomicWriter {
                 .map_err(|e| PersistenceError::Sqlite { source: e })?;
         }
 
-        // Issue #65: WAL サイドカーをチェックポイント+truncate で物理空にする
-        // （DELETE モード採用時は no-op、副作用なし。SQLite "Write-Ahead Logging" §`PRAGMA wal_checkpoint`）。
-        Self::sqlite_pragma(&conn, new_path, "PRAGMA wal_checkpoint(TRUNCATE);")?;
-
-        // Issue #65: 残存サイドカーを削除モードに切替し、close 時の物理消去を契約として固定。
-        // schema.rs の初期 PRAGMA_JOURNAL_MODE と冗長だが、将来 WAL モードへ切り替える設計判断が
-        // 入った時に Win rename race を再導入する罠を構造的に塞ぐ Boy Scout / Fail Safe。
-        Self::sqlite_pragma(&conn, new_path, "PRAGMA journal_mode = DELETE;")?;
-
-        // Issue #65: rusqlite Drop の sqlite3_close_v2 遅延 semantics
-        // （pending stmt cache があると close 遅延）を回避するため明示クローズ。
-        // 失敗時は .new を best-effort 削除し元の Sqlite エラーを伝播
-        // （`docs/features/vault-persistence/basic-design/security.md`
-        //  §atomic write の二次防衛線 §`Connection::close()` 失敗時の `.new` クリーンアップ）。
-        if let Err((_, e)) = conn.close() {
-            Self::cleanup_orphan_best_effort(new_path);
-            return Err(PersistenceError::Sqlite { source: e });
-        }
-
-        // Issue #65: 残存サイドカーに owner-only DACL を強制適用（多層防御）。
-        // 通常は journal_mode=DELETE で消去済だが、SQLite の特殊ケース（journal_mode=TRUNCATE
-        // 採用時のヘッダ残存等）を取り溢さないよう存在チェックの上で best-effort 適用する。
-        Self::apply_sidecar_permissions_if_present(new_path);
-
-        Ok(())
-    }
-
-    /// `Connection::execute_batch` の薄いラッパ（`write_new` の close-flow 用）。
-    ///
-    /// 失敗時は `.new` を best-effort 削除して `PersistenceError::Sqlite` を返す。
-    /// commit 後の close-flow（`wal_checkpoint` / `journal_mode`）で失敗した場合、
-    /// `.new` は中途半端な状態になるため Fail Secure で破棄する（次回 save の `OrphanNewFile` を回避）。
-    fn sqlite_pragma(
-        conn: &rusqlite::Connection,
-        new_path: &Path,
-        sql: &'static str,
-    ) -> Result<(), PersistenceError> {
-        conn.execute_batch(sql).map_err(|e| {
-            Self::cleanup_orphan_best_effort(new_path);
-            PersistenceError::Sqlite { source: e }
+        Ok(AtomicWriteSession {
+            conn: Some(conn),
+            new_path: Some(new_path),
+            final_path,
+            dir_path,
         })
     }
 
-    /// `SQLite` サイドカー（`-journal` / `-wal` / `-shm`）が残存していれば owner-only
-    /// パーミッションを強制適用する（best-effort、失敗は warn のみ）。
+    /// `AtomicWriteSession` を所有権消費し、クローズ順序固定で以下を順次実行する:
     ///
-    /// 通常は `PRAGMA journal_mode = DELETE` + `Connection::close()` で消去されるが、
-    /// 多層防御として存在チェックの上で適用する
-    /// （`docs/features/vault-persistence/basic-design/security.md`
-    ///  §atomic write の二次防衛線 §サイドカーの DACL 適用）。
+    /// 1. `PRAGMA wal_checkpoint(TRUNCATE)` — WAL サイドカー物理空化
+    /// 2. `PRAGMA journal_mode = DELETE` — close 時サイドカー物理消去の契約再強制
+    /// 3. `conn.close()` 明示呼出 — Drop 任せの遅延クローズを回避
+    /// 4. サイドカー DACL 適用（best-effort）
+    /// 5. FsyncTemp
+    /// 6. FsyncDir（Unix のみ）
+    /// 7. rename（Win: `retry_policy` に従う指数バックオフ retry + symlink 再検証）
+    ///
+    /// `flows.md §save` step 7.1〜7.7 に対応（`./classes.md` §3.2 参照）。
+    ///
+    /// # Errors
+    ///
+    /// - PRAGMA / close 失敗: `PersistenceError::Sqlite`
+    /// - FsyncTemp 失敗: `PersistenceError::AtomicWriteFailed { stage: FsyncTemp }`
+    /// - FsyncDir 失敗（Unix のみ）: `PersistenceError::AtomicWriteFailed { stage: FsyncDir }`
+    /// - rename 失敗（Win: retry 全敗後）: `PersistenceError::AtomicWriteFailed { stage: Rename }`
+    /// - retry 中 symlink / reparse point 検出（Win のみ）: `PersistenceError::InvalidVaultDir`
+    pub(crate) fn finalize(
+        mut self,
+        retry_policy: &dyn RetryPolicy,
+    ) -> Result<(), PersistenceError> {
+        // new_path を take して None に — Drop がこの後 cleanup_new を呼ばないようにする。
+        // 以降の失敗パスでは AtomicWriter::cleanup_new(&path) を明示呼出する。
+        let path = self.new_path.take().expect("new_path already consumed");
+        let conn = self.conn.take().expect("conn already consumed");
+        let final_path = self.final_path.clone();
+        let dir_path = self.dir_path.clone();
+
+        // Step 7.1: WAL チェックポイント（DELETE モード採用時は no-op、副作用なし）
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+            .map_err(|e| {
+                AtomicWriter::cleanup_new(&path);
+                PersistenceError::Sqlite { source: e }
+            })?;
+
+        // Step 7.2: journal_mode を DELETE に再強制
+        // （schema.rs::PRAGMA_JOURNAL_MODE と冗長だが、将来 WAL 採用時に本 step を消し忘れて
+        //   Win rename race を再導入する罠を構造的に塞ぐ Boy Scout / Fail Safe）
+        conn.execute_batch("PRAGMA journal_mode = DELETE;")
+            .map_err(|e| {
+                AtomicWriter::cleanup_new(&path);
+                PersistenceError::Sqlite { source: e }
+            })?;
+
+        // Step 7.3: 明示的 close（Drop の sqlite3_close_v2 遅延 semantics を回避）
+        // 失敗時は PersistenceError::Sqlite を直接返す（型情報を失う変換禁止、
+        // `../basic-design/error.md` §禁止事項と整合）。
+        if let Err((_, e)) = conn.close() {
+            AtomicWriter::cleanup_new(&path);
+            return Err(PersistenceError::Sqlite { source: e });
+        }
+
+        // Step 7.4: サイドカー DACL 適用（best-effort）
+        Self::apply_sidecar_permissions_if_present(&path);
+
+        // Step 7.5: FsyncTemp
+        // Windows では FlushFileBuffers が書込権限を要求するため read+write でオープン
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|e| {
+                AtomicWriter::cleanup_new(&path);
+                PersistenceError::AtomicWriteFailed {
+                    stage: AtomicWriteStage::FsyncTemp,
+                    source: e,
+                }
+            })?;
+        file.sync_all().map_err(|e| {
+            AtomicWriter::cleanup_new(&path);
+            PersistenceError::AtomicWriteFailed {
+                stage: AtomicWriteStage::FsyncTemp,
+                source: e,
+            }
+        })?;
+        drop(file);
+
+        // Step 7.6: FsyncDir（Unix のみ、POSIX 2008 rename メタデータ永続化）
+        #[cfg(unix)]
+        {
+            let dir = std::fs::File::open(&dir_path).map_err(|e| {
+                AtomicWriter::cleanup_new(&path);
+                PersistenceError::AtomicWriteFailed {
+                    stage: AtomicWriteStage::FsyncDir,
+                    source: e,
+                }
+            })?;
+            dir.sync_all().map_err(|e| {
+                AtomicWriter::cleanup_new(&path);
+                PersistenceError::AtomicWriteFailed {
+                    stage: AtomicWriteStage::FsyncDir,
+                    source: e,
+                }
+            })?;
+        }
+        // dir_path は cfg(unix) 以外で未使用だが、フィールドとして保持するため lint 抑制
+        #[cfg(not(unix))]
+        let _ = &dir_path;
+
+        // Step 7.7: アトミックリネーム（Win: retry_policy に従う retry + symlink 再検証）
+        Self::rename_atomic(&path, &final_path, retry_policy)
+    }
+
+    // ------------------------------------------------------------------
+    // 内部ヘルパ
+    // ------------------------------------------------------------------
+
+    /// アトミックリネーム本体。初回成功時は即 return。
+    /// 失敗時は Windows のみ retry に委譲、それ以外は即 fail fast。
+    fn rename_atomic(
+        new_path: &Path,
+        final_path: &Path,
+        retry_policy: &dyn RetryPolicy,
+    ) -> Result<(), PersistenceError> {
+        let initial_err = match std::fs::rename(new_path, final_path) {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+
+        #[cfg(windows)]
+        {
+            let raw = initial_err.raw_os_error().unwrap_or(0);
+            if retry_policy.should_retry(raw) {
+                return Self::windows_rename_retry(new_path, final_path, initial_err, retry_policy);
+            }
+        }
+
+        // cfg(not(windows)) ではここに到達。unused_variables 抑制（retry_policy は
+        // cfg(windows) ブロックでのみ参照される）。
+        let _ = retry_policy;
+
+        // Unix 全般 / Windows 非一過性エラーは即 fail fast
+        AtomicWriter::cleanup_new(new_path);
+        Err(PersistenceError::AtomicWriteFailed {
+            stage: AtomicWriteStage::Rename,
+            source: initial_err,
+        })
+    }
+
+    /// `cfg(windows)` 限定 rename retry ループ（Issue #65、Bug-G-001 反映済）。
+    ///
+    /// 各試行前に `retry_policy.sleep_duration(attempt)` だけ sleep し、
+    /// rename 直前に symlink / reparse point を再検証して TOCTOU 差替えを fail fast。
+    /// 各試行発火・成功・全敗を `Audit::retry_event` で監査ログに記録。
+    #[cfg(windows)]
+    fn windows_rename_retry(
+        new_path: &Path,
+        final_path: &Path,
+        initial_err: std::io::Error,
+        retry_policy: &dyn RetryPolicy,
+    ) -> Result<(), PersistenceError> {
+        let start = std::time::Instant::now();
+        let mut last_err = initial_err;
+        let max = retry_policy.max_attempts();
+
+        for attempt in 1..=max {
+            let last_raw_os = last_err.raw_os_error().unwrap_or(0);
+            let elapsed_ms_pending = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+            Audit::retry_event(
+                "rename",
+                attempt,
+                last_raw_os,
+                elapsed_ms_pending,
+                RetryOutcome::Pending,
+            );
+
+            std::thread::sleep(retry_policy.sleep_duration(attempt));
+
+            // TOCTOU 再検証 — retry 窓中の symlink / junction 差替えを fail fast
+            Self::reverify_no_reparse_point(new_path)?;
+            Self::reverify_no_reparse_point(final_path)?;
+
+            match std::fs::rename(new_path, final_path) {
+                Ok(()) => {
+                    let elapsed_ms_ok =
+                        u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+                    Audit::retry_event(
+                        "rename",
+                        attempt,
+                        last_raw_os,
+                        elapsed_ms_ok,
+                        RetryOutcome::Succeeded,
+                    );
+                    return Ok(());
+                }
+                Err(e) => {
+                    let raw = e.raw_os_error().unwrap_or(0);
+                    if !retry_policy.should_retry(raw) {
+                        AtomicWriter::cleanup_new(new_path);
+                        return Err(PersistenceError::AtomicWriteFailed {
+                            stage: AtomicWriteStage::Rename,
+                            source: e,
+                        });
+                    }
+                    last_err = e;
+                }
+            }
+        }
+
+        let elapsed_ms_exhausted = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let final_raw_os = last_err.raw_os_error().unwrap_or(0);
+        Audit::retry_event(
+            "rename",
+            max,
+            final_raw_os,
+            elapsed_ms_exhausted,
+            RetryOutcome::Exhausted,
+        );
+        AtomicWriter::cleanup_new(new_path);
+        Err(PersistenceError::AtomicWriteFailed {
+            stage: AtomicWriteStage::Rename,
+            source: last_err,
+        })
+    }
+
+    /// retry 直前の symlink / NTFS reparse point 再検証（Win TOCTOU 対策）。
+    ///
+    /// `FILE_ATTRIBUTE_REPARSE_POINT (0x400)` または `is_symlink()` を検出したら fail fast。
+    /// 対象パスが未存在（vault.db の初回作成時等）は Ok を返す。
+    /// `../basic-design/security.md` §atomic write の二次防衛線 §Win retry 中 TOCTOU 参照。
+    #[cfg(windows)]
+    fn reverify_no_reparse_point(path: &Path) -> Result<(), PersistenceError> {
+        use crate::persistence::error::VaultDirReason;
+        use std::os::windows::fs::MetadataExt;
+
+        // https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+
+        match std::fs::symlink_metadata(path) {
+            Ok(meta) => {
+                let is_reparse = (meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+                if meta.file_type().is_symlink() || is_reparse {
+                    Err(PersistenceError::InvalidVaultDir {
+                        path: path.to_path_buf(),
+                        reason: VaultDirReason::SymlinkNotAllowed,
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+            // 初回 save 時に vault.db (final_path) が未存在のケースは正常
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(PersistenceError::Io {
+                path: path.to_path_buf(),
+                source: e,
+            }),
+        }
+    }
+
+    /// `SQLite` サイドカーが残存していれば owner-only パーミッションを強制適用する
+    /// （best-effort、失敗は warn のみ）。
     fn apply_sidecar_permissions_if_present(new_path: &Path) {
         let Some(parent) = new_path.parent() else {
             return;
@@ -281,300 +586,7 @@ impl AtomicWriter {
         }
     }
 
-    /// `.new` ファイルを fsync し、`vault.db` にアトミックにリネームする。
-    ///
-    /// rename 段は POSIX では `rename(2)`、Windows では `MoveFileExW` 経由で原子的。
-    /// Windows のみ Issue #65 由来の一過性エラー（`ERROR_ACCESS_DENIED` /
-    /// `ERROR_SHARING_VIOLATION` / `ERROR_LOCK_VIOLATION`）に対し
-    /// 50ms ± jitter × 最大 5 回 retry を補強し、retry 直前に symlink / reparse point の
-    /// 再検証で TOCTOU 差替えを fail fast する
-    /// （`docs/features/vault-persistence/detailed-design/flows.md` §`save` step 7）。
-    ///
-    /// # Errors
-    ///
-    /// - `.new` オープン失敗: `PersistenceError::AtomicWriteFailed { stage: FsyncTemp }`
-    /// - fsync 失敗: `PersistenceError::AtomicWriteFailed { stage: FsyncTemp }`
-    /// - ディレクトリ fsync 失敗（Unix のみ）: `PersistenceError::AtomicWriteFailed { stage: FsyncDir }`
-    /// - リネーム失敗（Win では retry 5 回全敗後）: `PersistenceError::AtomicWriteFailed { stage: Rename }`
-    /// - retry 中 symlink / reparse point 検出（Win のみ）: `PersistenceError::InvalidVaultDir { reason: SymlinkNotAllowed }`
-    /// - リネーム後の DACL 設定失敗: `PersistenceError::Io` / `PersistenceError::InvalidPermission`
-    pub(crate) fn fsync_and_rename(paths: &VaultPaths) -> Result<(), PersistenceError> {
-        let new_path = paths.vault_db_new();
-        let final_path = paths.vault_db();
-
-        // `.new` ファイルを fsync
-        // Windows では FlushFileBuffers（sync_all の実装）に書き込みアクセスが必要なため、
-        // read(true).write(true) でオープンする。Unix では read-only でも sync_all は成功する。
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(new_path)
-            .map_err(|e| PersistenceError::AtomicWriteFailed {
-                stage: AtomicWriteStage::FsyncTemp,
-                source: e,
-            })?;
-        file.sync_all().map_err(|e| {
-            Self::cleanup_orphan_best_effort(new_path);
-            PersistenceError::AtomicWriteFailed {
-                stage: AtomicWriteStage::FsyncTemp,
-                source: e,
-            }
-        })?;
-        drop(file);
-
-        // 親ディレクトリの fsync（Unix: POSIX 耐久性保証のため）
-        #[cfg(unix)]
-        {
-            let dir = std::fs::File::open(paths.dir()).map_err(|e| {
-                Self::cleanup_orphan_best_effort(new_path);
-                PersistenceError::AtomicWriteFailed {
-                    stage: AtomicWriteStage::FsyncDir,
-                    source: e,
-                }
-            })?;
-            dir.sync_all().map_err(|e| {
-                Self::cleanup_orphan_best_effort(new_path);
-                PersistenceError::AtomicWriteFailed {
-                    stage: AtomicWriteStage::FsyncDir,
-                    source: e,
-                }
-            })?;
-        }
-
-        // アトミックリネーム（POSIX では原子的、Windows は MoveFileExW 経由）
-        // ensure_file は DELETE を含まない DACL を設定するため、rename 前ではなく rename 後に適用する。
-        Self::rename_atomic(new_path, final_path)?;
-
-        // リネーム後に最終ファイルへ owner-only DACL を適用する
-        PermissionGuard::ensure_file(final_path)?;
-
-        Ok(())
-    }
-
-    /// `.new` → `vault.db` のアトミックリネーム本体。
-    ///
-    /// 第 1 試行が成功すれば即 return。失敗時、Windows のみ一過性エラーを判別して
-    /// `windows_rename_retry` に委譲。それ以外（POSIX 全般 / Windows 非一過性）は
-    /// `.new` を best-effort 削除して `AtomicWriteFailed { stage: Rename }` を return。
-    fn rename_atomic(new_path: &Path, final_path: &Path) -> Result<(), PersistenceError> {
-        let initial_err = match std::fs::rename(new_path, final_path) {
-            Ok(()) => return Ok(()),
-            Err(e) => e,
-        };
-
-        #[cfg(windows)]
-        {
-            if Self::is_windows_transient_rename_error(&initial_err) {
-                return Self::windows_rename_retry(new_path, final_path, initial_err);
-            }
-        }
-
-        Self::cleanup_orphan_best_effort(new_path);
-        Err(PersistenceError::AtomicWriteFailed {
-            stage: AtomicWriteStage::Rename,
-            source: initial_err,
-        })
-    }
-
-    /// `.new` ファイルのクリーンアップを試みる（ベストエフォート）。
-    fn cleanup_orphan_best_effort(new_path: &Path) {
-        if let Err(e) = std::fs::remove_file(new_path) {
-            tracing::warn!(
-                path = %new_path.display(),
-                error = %e,
-                "failed to cleanup .new file (best-effort)"
-            );
-        }
-    }
-
-    /// Windows の一過性 rename エラー（Win Indexer / Defender / SQLite Drop 残響等）を判定する。
-    ///
-    /// retry 対象:
-    /// - `ERROR_ACCESS_DENIED (5)` — file handle 解放遅延
-    /// - `ERROR_SHARING_VIOLATION (32)` — 共有モード不一致
-    /// - `ERROR_LOCK_VIOLATION (33)` — ファイルロック競合
-    ///
-    /// それ以外（`ERROR_DISK_FULL (112)` / `ERROR_PATH_NOT_FOUND (3)` 等）は即 fail fast。
-    #[cfg(windows)]
-    fn is_windows_transient_rename_error(e: &std::io::Error) -> bool {
-        matches!(e.raw_os_error(), Some(5 | 32 | 33))
-    }
-
-    /// `cfg(windows)` 限定の rename retry ループ（Issue #65、Bug-G-001 反映済）。
-    ///
-    /// 各試行の前に **指数バックオフ jitter sleep**（`50ms × 2^(n-1)` ± `25ms` 一様乱数、
-    /// timing oracle 防止）を挟み、rename 直前に `.new` / `vault.db` 双方の symlink /
-    /// NTFS reparse point を再検証する
-    /// （`docs/features/vault-persistence/basic-design/security.md`
-    ///  §atomic write の二次防衛線 §Win retry 中 TOCTOU）。
-    /// 各試行の発火・成功・全敗を `Audit::retry_event` で監査ログに記録し、
-    /// daemon 側 subscriber が DoS 兆候として上位通報する経路を有効化する。
-    ///
-    /// 上限は jitter 込み最悪 ~1675ms / 平均 ~1550ms（同 §jitter）。Win CI ランナーで
-    /// Defender / Search Indexer が `vault.db` を 250ms+ 保持する CI 実測 (Bug-G-001) を
-    /// 確実に吸収する budget。
-    #[cfg(windows)]
-    fn windows_rename_retry(
-        new_path: &Path,
-        final_path: &Path,
-        initial_err: std::io::Error,
-    ) -> Result<(), PersistenceError> {
-        let start = std::time::Instant::now();
-        let mut last_err = initial_err;
-
-        for attempt in 1..=RENAME_MAX_RETRIES {
-            let last_raw_os = last_err.raw_os_error().unwrap_or(0);
-            let elapsed_ms_pending = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-            Audit::retry_event(
-                RENAME_STAGE_LABEL,
-                attempt,
-                last_raw_os,
-                elapsed_ms_pending,
-                RetryOutcome::Pending,
-            );
-
-            std::thread::sleep(Self::jittered_retry_delay(attempt));
-
-            // TOCTOU 再検証 — retry 窓中の symlink / junction 差替えを fail fast する
-            Self::reverify_no_reparse_point(new_path)?;
-            Self::reverify_no_reparse_point(final_path)?;
-
-            match std::fs::rename(new_path, final_path) {
-                Ok(()) => {
-                    let elapsed_ms_ok =
-                        u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-                    Audit::retry_event(
-                        RENAME_STAGE_LABEL,
-                        attempt,
-                        last_raw_os,
-                        elapsed_ms_ok,
-                        RetryOutcome::Succeeded,
-                    );
-                    return Ok(());
-                }
-                Err(e) => {
-                    if !Self::is_windows_transient_rename_error(&e) {
-                        Self::cleanup_orphan_best_effort(new_path);
-                        return Err(PersistenceError::AtomicWriteFailed {
-                            stage: AtomicWriteStage::Rename,
-                            source: e,
-                        });
-                    }
-                    last_err = e;
-                }
-            }
-        }
-
-        let elapsed_ms_exhausted = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-        let final_raw_os = last_err.raw_os_error().unwrap_or(0);
-        Audit::retry_event(
-            RENAME_STAGE_LABEL,
-            RENAME_MAX_RETRIES,
-            final_raw_os,
-            elapsed_ms_exhausted,
-            RetryOutcome::Exhausted,
-        );
-        Self::cleanup_orphan_best_effort(new_path);
-        Err(PersistenceError::AtomicWriteFailed {
-            stage: AtomicWriteStage::Rename,
-            source: last_err,
-        })
-    }
-
-    /// retry 間隔の jitter 込み Duration を `OsRng` 由来の 1 byte で生成する。
-    ///
-    /// 指数バックオフ: `BASE × 2^(attempt-1) ± HALF_RANGE` ms 一様乱数。
-    /// `attempt` は 1-indexed（1〜`RENAME_MAX_RETRIES`）。
-    ///
-    /// | `attempt` | 中央値 | range |
-    /// |-----------|------|-------|
-    /// | 1 | 50ms | 25–75ms |
-    /// | 2 | 100ms | 75–125ms |
-    /// | 3 | 200ms | 175–225ms |
-    /// | 4 | 400ms | 375–425ms |
-    /// | 5 | 800ms | 775–825ms |
-    ///
-    /// `OsRng.fill_bytes` は対象 OS では事実上失敗しない
-    /// （`crypto::rng` と同じ CSPRNG 経路）。`% 51` の僅かな mod bias は
-    /// timing jitter 用途では無視可能（KISS）。
-    ///
-    /// Bug-G-001 反映: 当初 `BASE` 固定の線形 retry だったが、Win CI ランナーで
-    /// Defender / Search Indexer による 250ms+ ハンドル保持を吸収しきれず
-    /// `code:5 PermissionDenied` が継続発生したため、指数バックオフへ拡張した。
-    #[cfg(windows)]
-    fn jittered_retry_delay(attempt: u32) -> std::time::Duration {
-        use rand_core::{OsRng, RngCore};
-
-        let mut buf = [0u8; 1];
-        OsRng.fill_bytes(&mut buf);
-        let jitter_pos = u64::from(buf[0] % RENAME_JITTER_RANGE); // 0..=50
-
-        // 指数バックオフ: attempt 1→×1, 2→×2, 3→×4, 4→×8, 5→×16
-        // attempt は 1..=RENAME_MAX_RETRIES (≤5) なので shift overflow は起こらない。
-        let multiplier: u64 = 1u64 << (attempt.saturating_sub(1));
-        let center_ms = RENAME_BASE_DELAY_MS.saturating_mul(multiplier);
-        let delay_ms = center_ms + jitter_pos - RENAME_JITTER_HALF_RANGE_MS;
-        std::time::Duration::from_millis(delay_ms)
-    }
-
-    /// retry 直前の symlink / NTFS reparse point 再検証（Win TOCTOU 対策）。
-    ///
-    /// `fs::symlink_metadata` で `is_symlink()` または
-    /// `FILE_ATTRIBUTE_REPARSE_POINT (0x400)` ビットを検出したら fail fast。
-    /// 対象パスが未存在（vault.db の初回作成時等）の場合は Ok を返す。
-    /// 詳細は `docs/features/vault-persistence/basic-design/security.md`
-    /// §atomic write の二次防衛線 §Win retry 中 TOCTOU を参照。
-    #[cfg(windows)]
-    fn reverify_no_reparse_point(path: &Path) -> Result<(), PersistenceError> {
-        use crate::persistence::error::VaultDirReason;
-        use std::os::windows::fs::MetadataExt;
-
-        // FILE_ATTRIBUTE_REPARSE_POINT — Microsoft Learn "File Attribute Constants"
-        // https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
-        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
-
-        match std::fs::symlink_metadata(path) {
-            Ok(meta) => {
-                let is_reparse = (meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
-                if meta.file_type().is_symlink() || is_reparse {
-                    Err(PersistenceError::InvalidVaultDir {
-                        path: path.to_path_buf(),
-                        reason: VaultDirReason::SymlinkNotAllowed,
-                    })
-                } else {
-                    Ok(())
-                }
-            }
-            // 初回 save 時に vault.db (final_path) が未存在のケースは正常
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(e) => Err(PersistenceError::Io {
-                path: path.to_path_buf(),
-                source: e,
-            }),
-        }
-    }
-
-    /// `vault.db.new` を書き込むが fsync/rename は行わない（テスト専用）。
-    ///
-    /// atomic write の中断状態を決定的に再現するためのテストフック。
-    /// `write_new` と同一ロジックで `.new` を書き込み、`fsync_and_rename` を呼ばずに返す。
-    ///
-    /// # Errors
-    ///
-    /// - `write_new` と同じ
-    #[cfg(test)]
-    pub(crate) fn write_new_only(
-        paths: &VaultPaths,
-        vault: &Vault,
-    ) -> Result<(), PersistenceError> {
-        Self::write_new(paths, vault)
-    }
-
-    /// 適切なパーミッションでファイルを作成する。
-    ///
-    /// # Errors
-    ///
-    /// - ファイル作成失敗: `PersistenceError::AtomicWriteFailed { stage: PrepareNew }`
+    /// 適切なパーミッションでファイルを作成し、file handle を drop する（step 6.1-6.2）。
     fn create_with_permissions(path: &Path) -> Result<(), PersistenceError> {
         cfg_if::cfg_if! {
             if #[cfg(unix)] {
@@ -601,6 +613,82 @@ impl AtomicWriter {
                     })?;
             }
         }
+        Ok(())
+    }
+}
+
+impl Drop for AtomicWriteSession {
+    /// `finalize` 未呼出のまま drop された場合は `.new` を best-effort 削除（Fail Safe）。
+    ///
+    /// `new_path` が `None`（`finalize` が所有権を取得済）の場合は何もしない。
+    fn drop(&mut self) {
+        if let Some(ref path) = self.new_path {
+            AtomicWriter::cleanup_new(path);
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// AtomicWriter（ZST 名前空間）
+// -------------------------------------------------------------------
+
+/// アトミック書き込みの補助ユーティリティ（ZST 名前空間）。
+///
+/// Phase 8 リファクタで主要ロジックは `AtomicWriteSession` に移行。
+/// `detect_orphan` / `cleanup_new` の名前空間として残存する。
+pub(crate) struct AtomicWriter;
+
+impl AtomicWriter {
+    /// `vault.db.new` が存在する場合に孤立ファイルエラーを返す。
+    ///
+    /// # Errors
+    ///
+    /// - `.new` が存在する: `PersistenceError::OrphanNewFile`
+    /// - 存在確認 IO エラー: `PersistenceError::Io`
+    pub(crate) fn detect_orphan(new_path: &Path) -> Result<(), PersistenceError> {
+        match new_path.try_exists() {
+            Ok(true) => Err(PersistenceError::OrphanNewFile {
+                path: new_path.to_path_buf(),
+            }),
+            Ok(false) => Ok(()),
+            Err(e) => Err(PersistenceError::Io {
+                path: new_path.to_path_buf(),
+                source: e,
+            }),
+        }
+    }
+
+    /// `vault.db.new` を best-effort 削除する。
+    ///
+    /// 失敗時は `tracing::warn!` でログ出力し、呼出側のエラーを上書きしない（上位に伝播しない）。
+    pub(crate) fn cleanup_new(new_path: &Path) {
+        if let Err(e) = std::fs::remove_file(new_path) {
+            tracing::warn!(
+                path = %new_path.display(),
+                error = %e,
+                "failed to cleanup .new file (best-effort)"
+            );
+        }
+    }
+
+    /// `vault.db.new` に vault の内容を書き込むが fsync/rename は行わない（テスト専用）。
+    ///
+    /// `AtomicWriteSession::new` と同一ロジックで `.new` を書き込み、`finalize` を呼ばずに返す。
+    /// atomic write の中断状態を決定的に再現するためのテストフック（AC-06 対応）。
+    ///
+    /// # Errors
+    ///
+    /// - `AtomicWriteSession::new` と同じ
+    #[cfg(test)]
+    pub(crate) fn write_new_only(
+        paths: &VaultPaths,
+        vault: &Vault,
+    ) -> Result<(), PersistenceError> {
+        let mut session = AtomicWriteSession::new(paths, vault)?;
+        // conn を正常 drop して SQLite を閉じる（sqlite3_close_v2 経由）
+        drop(session.conn.take());
+        // new_path を None に — Drop が cleanup_new を呼ばないようにして .new を残す
+        session.new_path = None;
         Ok(())
     }
 }
@@ -637,7 +725,7 @@ mod tests {
 
     /// TC-I06 — `write_new_only` フックで .new のみ書き込み→load が `OrphanNewFile` を返す。
     ///
-    /// AC-06 対応。`write_new_only` は `fsync_and_rename` を呼ばないため .new が残り、
+    /// AC-06 対応。`write_new_only` は `finalize` を呼ばないため .new が残り、
     /// vault.db の内容は初期 vault のままになる。
     #[test]
     fn tc_i06_write_new_only_hook_orphan() {
@@ -649,8 +737,8 @@ mod tests {
 
         // 初期 vault を save（vault.db が存在する状態にする）
         let initial_vault = plaintext_vault("initial", "initial-value");
-        AtomicWriter::write_new(&paths, &initial_vault).unwrap();
-        AtomicWriter::fsync_and_rename(&paths).unwrap();
+        let session = AtomicWriteSession::new(&paths, &initial_vault).unwrap();
+        session.finalize(&ExponentialBackoffRetryPolicy).unwrap();
 
         // vault.db のバイト列を記録
         let db_bytes_before = std::fs::read(paths.vault_db()).unwrap();
@@ -666,7 +754,6 @@ mod tests {
         );
 
         // .new が残存している状態での load は OrphanNewFile になる
-        // （ここでは detect_orphan を直接呼んでテスト）
         let orphan_result = AtomicWriter::detect_orphan(paths.vault_db_new());
         assert!(
             matches!(orphan_result, Err(PersistenceError::OrphanNewFile { .. })),
@@ -685,17 +772,12 @@ mod tests {
     // TC-I29-D (unit) — Win retry 中 TOCTOU 再検証ユニットテスト群
     // -------------------------------------------------------------------
     //
-    // `reverify_no_reparse_point` は `cfg(windows)` の rename retry ループ内で
-    // 各 attempt の sleep 直後に呼ばれ、retry 窓中の symlink / NTFS reparse point
-    // 差替え (`mklink /J` 等) を fail fast する。基本設計
-    // `security.md §atomic write の二次防衛線 §Win retry 中 TOCTOU` 対応。
+    // `AtomicWriteSession::reverify_no_reparse_point` は `cfg(windows)` の
+    // rename retry ループ内で各 attempt の sleep 直後に呼ばれ、retry 窓中の
+    // symlink / NTFS reparse point 差替えを fail fast する。
+    // 基本設計 `security.md §atomic write の二次防衛線 §Win retry 中 TOCTOU` 対応。
     //
     // 整合する受入基準: AC-19 (Issue #65 retry 補強の二次防衛線、TOCTOU 側)。
-    //
-    // integration test ではなく unit に置く理由:
-    // - 関数が `pub(crate)` 未満 (private) で integration からアクセス不可
-    // - retry sleep 窓中に junction を差し替える race は非決定的で flaky になりやすい
-    //   ため、判定単体を直接呼んで決定的に検証する方が SSoT 担保になる
 
     /// TC-I29-D-1: 通常ファイル → Ok。
     #[cfg(windows)]
@@ -704,7 +786,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let f = dir.path().join("regular.bin");
         std::fs::write(&f, b"x").unwrap();
-        AtomicWriter::reverify_no_reparse_point(&f)
+        AtomicWriteSession::reverify_no_reparse_point(&f)
             .expect("通常ファイルで reverify が誤判定 (Ok を期待)");
     }
 
@@ -714,15 +796,11 @@ mod tests {
     fn tc_i29_d2_reverify_returns_ok_for_missing_path() {
         let dir = TempDir::new().unwrap();
         let f = dir.path().join("not_yet.bin");
-        AtomicWriter::reverify_no_reparse_point(&f)
+        AtomicWriteSession::reverify_no_reparse_point(&f)
             .expect("未存在パスで reverify が誤判定 (Ok を期待 — 初回 save の final_path 経路)");
     }
 
     /// TC-I29-D-3: ディレクトリ junction (`mklink /J`) → SymlinkNotAllowed。
-    ///
-    /// junction はディレクトリの reparse point で **管理者権限不要** で作成できる。
-    /// `FILE_ATTRIBUTE_REPARSE_POINT (0x400)` ビット検出経路を直接検証する。
-    /// `mklink` 不能ランナー (一部の minimal 環境) では skip する。
     #[cfg(windows)]
     #[test]
     fn tc_i29_d3_reverify_detects_directory_junction() {
@@ -733,17 +811,14 @@ mod tests {
         std::fs::create_dir(&target).unwrap();
         let junction = dir.path().join("junction_dir");
 
-        // mklink /J は cmd.exe 経由でしか叩けない (Windows の組み込みコマンド)
         let status = std::process::Command::new("cmd")
             .args(["/C", "mklink", "/J"])
             .arg(&junction)
             .arg(&target)
             .status()
-            .expect("cmd /C mklink /J 実行不能 (Windows ランナーで mklink が見つからない)");
+            .expect("cmd /C mklink /J 実行不能");
 
         if !status.success() {
-            // 一部の制約付きランナーで junction 作成権限が無い場合は skip
-            // (本 TC の決定性は確保できないが、本流 Windows runner は通常通る)
             eprintln!(
                 "skipping tc_i29_d3: mklink /J が失敗した (権限不足の可能性、exit={:?})",
                 status.code()
@@ -751,7 +826,7 @@ mod tests {
             return;
         }
 
-        let result = AtomicWriter::reverify_no_reparse_point(&junction);
+        let result = AtomicWriteSession::reverify_no_reparse_point(&junction);
         match result {
             Err(PersistenceError::InvalidVaultDir {
                 reason: VaultDirReason::SymlinkNotAllowed,
@@ -764,11 +839,7 @@ mod tests {
         }
     }
 
-    /// TC-I29-D-4: ディレクトリ symlink (`std::os::windows::fs::symlink_dir`) → SymlinkNotAllowed。
-    ///
-    /// `is_symlink()` 検出経路を直接検証する (junction とは別経路)。
-    /// dir symlink は **Developer Mode 有効または管理者権限** が必要なので、
-    /// 作成失敗時は skip する (windows-latest GA runner は Developer Mode 有効)。
+    /// TC-I29-D-4: ディレクトリ symlink → SymlinkNotAllowed。
     #[cfg(windows)]
     #[test]
     fn tc_i29_d4_reverify_detects_directory_symlink() {
@@ -785,7 +856,7 @@ mod tests {
             return;
         }
 
-        let result = AtomicWriter::reverify_no_reparse_point(&link);
+        let result = AtomicWriteSession::reverify_no_reparse_point(&link);
         match result {
             Err(PersistenceError::InvalidVaultDir {
                 reason: VaultDirReason::SymlinkNotAllowed,


### PR DESCRIPTION
## 概要

Issue #73 Phase 8 実装。設計書 `docs/features/vault-persistence/detailed-design/` に従い、`AtomicWriter` ZST + 静的メソッド連鎖をセッション型 `AtomicWriteSession` にリファクタリング。

closes #73

## 変更内容

### `crates/shikomi-infra/src/persistence/sqlite/atomic.rs`

- **`AtomicWriteSession`** 新設
  - `new(paths, vault)` — `.new` ファイル作成 → DACL設定 → Connection::open → PRAGMA/DDL → TX → COMMIT
  - `finalize(self, retry_policy)` — 所有権消費で PRAGMA → close → sidecar DACL → fsync → rename の順序を型レベルで強制（`classes.md` §3.1）
  - `Drop` — `new_path.is_some()` の場合のみ `cleanup_new` best-effort実行（Fail Safe）
- **`RetryPolicy` trait** 新設（Phase 8、§3.4）
  - `max_attempts()` / `sleep_duration(attempt)` / `should_retry(raw_os_error)`
- **`ExponentialBackoffRetryPolicy`** 新設
  - `50ms × 2^(n-1) ±25ms` jitter（OsRng）、最大5回、最悪 ~1675ms（Bug-G-001対応）
- **`#[cfg(test)] NoSleepRetryPolicy`** 新設
  - `sleep_duration` = `Duration::ZERO`（CI高速化）
- Windows DACL適用順序: rename前に `.new` へ `ensure_file` → `MoveFileExW` がソースSD保持（§3.3確定方針）
- `AtomicWriter` ZST: `detect_orphan` / `cleanup_new` / `write_new_only` のみ残存

### `crates/shikomi-infra/src/persistence/repository.rs`

- `save_inner` の step 6-7 を session API に切り替え
  ```rust
  let session = AtomicWriteSession::new(&self.paths, vault)?;
  session.finalize(&ExponentialBackoffRetryPolicy)?;
  ```

## テスト観点

- `tc_i06_write_new_only_hook_orphan`: `write_new_only` で `.new` が残存すること
- `tc_i15_orphan_new_file_on_save`: `finalize` 未呼出時の Drop が `cleanup_new` を実行すること
- Windows retry テスト: `NoSleepRetryPolicy` を使用して実際の sleep なしで retry 発火を確認

## ローカル検証結果

- `cargo fmt --all -- --check` ✅
- `cargo clippy -p shikomi-infra --all-targets --all-features` ✅（`all=deny` エラーなし）
- `cargo test -p shikomi-infra --lib` ✅ 107 passed
- `cargo test -p shikomi-infra --test integration_roundtrip` ✅ 8 passed
- `cargo test -p shikomi-infra --test integration_error` ✅ 6 passed

> ⚠️ ローカル環境に GTK/DBus 開発パッケージ未インストールのため `cargo clippy --workspace` / `cargo test --workspace` は実行不可。CI での確認が必要。