### PR TITLE
feat(cli): daemon autostart サブコマンド実装 (Issue #127 Sub-B)

### DIFF
--- a/crates/shikomi-cli/src/autostart/launchd.rs
+++ b/crates/shikomi-cli/src/autostart/launchd.rs
@@ -1,0 +1,144 @@
+//! macOS launchd バックエンド（Sub-B Issue #127）。
+//!
+//! 設計根拠: docs/features/daemon-default-mode/autostart/detailed-design/launchd.md
+
+use std::path::PathBuf;
+
+use super::{resolve_daemon_path, truncate_stderr, AutostartBackend, AutostartError};
+
+// plist テンプレート（{daemon_path} / {log_dir} を文字列置換する）
+const PLIST_TEMPLATE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.shikomi.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{daemon_path}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>{log_dir}/shikomi-daemon.log</string>
+    <key>StandardErrorPath</key>
+    <string>{log_dir}/shikomi-daemon.log</string>
+</dict>
+</plist>
+"#;
+
+const LABEL: &str = "dev.shikomi.daemon";
+
+pub struct LaunchdBackend;
+
+impl LaunchdBackend {
+    fn plist_path() -> Option<PathBuf> {
+        dirs::home_dir().map(|h| h.join("Library/LaunchAgents/dev.shikomi.daemon.plist"))
+    }
+
+    fn log_dir() -> Option<PathBuf> {
+        dirs::home_dir().map(|h| h.join("Library/Logs/shikomi"))
+    }
+
+    fn uid() -> u32 {
+        // SAFETY: getuid は常に安全
+        unsafe { libc::getuid() }
+    }
+
+    fn gui_service_target() -> String {
+        format!("gui/{}/{LABEL}", Self::uid())
+    }
+
+    fn run_launchctl(args: &[&str]) -> Result<std::process::Output, AutostartError> {
+        let out = std::process::Command::new("launchctl")
+            .args(args)
+            .output()?;
+        Ok(out)
+    }
+}
+
+impl AutostartBackend for LaunchdBackend {
+    fn name(&self) -> &'static str {
+        "LaunchdBackend"
+    }
+
+    fn install(&self) -> Result<(), AutostartError> {
+        let daemon_path = resolve_daemon_path()?;
+        let daemon_path_str = daemon_path.display().to_string();
+
+        let log_dir = Self::log_dir().ok_or_else(|| {
+            AutostartError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "cannot determine home directory",
+            ))
+        })?;
+        std::fs::create_dir_all(&log_dir)?;
+
+        let log_dir_str = log_dir.display().to_string();
+        let plist_content = PLIST_TEMPLATE
+            .replace("{daemon_path}", &daemon_path_str)
+            .replace("{log_dir}", &log_dir_str);
+
+        let launch_agents = dirs::home_dir()
+            .ok_or_else(|| {
+                AutostartError::IoError(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "cannot determine home directory",
+                ))
+            })?
+            .join("Library/LaunchAgents");
+        std::fs::create_dir_all(&launch_agents)?;
+
+        let plist_path = Self::plist_path().ok_or_else(|| {
+            AutostartError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "cannot determine home directory",
+            ))
+        })?;
+        std::fs::write(&plist_path, plist_content)?;
+
+        // 冪等確保: 事前に bootout（未登録エラーは無視）
+        let _ = Self::run_launchctl(&["bootout", &Self::gui_service_target()]);
+
+        // bootstrap で登録
+        let plist_path_str = plist_path.display().to_string();
+        let target = format!("gui/{}", Self::uid());
+        let out = Self::run_launchctl(&["bootstrap", &target, &plist_path_str])?;
+        if !out.status.success() {
+            return Err(AutostartError::CommandFailed {
+                cmd: format!("launchctl bootstrap {target} {plist_path_str}"),
+                stderr_excerpt: truncate_stderr(&out.stderr),
+            });
+        }
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), AutostartError> {
+        // bootout（未登録でも許容）
+        let _ = Self::run_launchctl(&["bootout", &Self::gui_service_target()]);
+
+        // plist 削除（NotFound → Ok、冪等）
+        if let Some(plist) = Self::plist_path() {
+            match std::fs::remove_file(&plist) {
+                Ok(()) => {}
+                Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(AutostartError::IoError(e)),
+            }
+        }
+        Ok(())
+    }
+
+    fn is_registered(&self) -> bool {
+        Self::plist_path().map(|p| p.exists()).unwrap_or(false)
+    }
+
+    fn install_hint(&self) -> Option<String> {
+        Some(format!(
+            "hint: to start immediately: launchctl kickstart gui/{uid}/{LABEL}",
+            uid = Self::uid(),
+        ))
+    }
+}

--- a/crates/shikomi-cli/src/autostart/launchd.rs
+++ b/crates/shikomi-cli/src/autostart/launchd.rs
@@ -4,6 +4,8 @@
 
 use std::path::PathBuf;
 
+use nix::unistd::getuid;
+
 use super::{resolve_daemon_path, truncate_stderr, AutostartBackend, AutostartError};
 
 // plist テンプレート（{daemon_path} / {log_dir} を文字列置換する）
@@ -44,8 +46,8 @@ impl LaunchdBackend {
     }
 
     fn uid() -> u32 {
-        // SAFETY: getuid は常に安全
-        unsafe { libc::getuid() }
+        // nix::unistd::getuid() は unsafe 不要（POSIX getuid の safe wrapper）
+        getuid().as_raw()
     }
 
     fn gui_service_target() -> String {

--- a/crates/shikomi-cli/src/autostart/mod.rs
+++ b/crates/shikomi-cli/src/autostart/mod.rs
@@ -148,10 +148,7 @@ mod tests {
 
         let result = resolve_daemon_path_from(dir.path());
         assert!(result.is_ok(), "daemon 存在時は Ok を返すべき: {result:?}");
-        assert!(
-            result.unwrap().exists(),
-            "返却パスが実際に存在すること"
-        );
+        assert!(result.unwrap().exists(), "返却パスが実際に存在すること");
     }
 
     /// TC-UT-165: daemon バイナリ不在時に `AutostartError::IoError(NotFound)` を返すこと

--- a/crates/shikomi-cli/src/autostart/mod.rs
+++ b/crates/shikomi-cli/src/autostart/mod.rs
@@ -69,10 +69,13 @@ pub enum AutostartError {
 
 /// `shikomi-daemon` バイナリの絶対パスを解決する共通ヘルパー。
 ///
+/// autostart 登録ファイルに書き込む起動パスを返す。バイナリが現時点で存在しなくても
+/// パスの構築は成功する（ユーザがログイン時に daemon が存在すれば良い）。
+///
 /// 設計根拠: backend-trait.md §resolve_daemon_path() 共通ヘルパー
 ///
 /// # Errors
-/// 実行ファイルの解決に失敗した場合 `AutostartError::IoError` を返す。
+/// 実行ファイルのディレクトリ解決に失敗した場合 `AutostartError::IoError` を返す。
 pub fn resolve_daemon_path() -> Result<PathBuf, AutostartError> {
     let exe = std::env::current_exe()?;
     // canonicalize でシンボリックリンクを解決（シンボリックリンク攻撃防止 / security.md §脅威モデル）
@@ -88,15 +91,7 @@ pub fn resolve_daemon_path() -> Result<PathBuf, AutostartError> {
     } else {
         "shikomi-daemon"
     };
-    let daemon_path = dir.join(daemon_name);
-    // Fail Fast: 不在なら IoError(NotFound)
-    if !daemon_path.exists() {
-        return Err(AutostartError::IoError(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("shikomi-daemon not found at {}", daemon_path.display()),
-        )));
-    }
-    Ok(daemon_path)
+    Ok(dir.join(daemon_name))
 }
 
 // -------------------------------------------------------------------

--- a/crates/shikomi-cli/src/autostart/mod.rs
+++ b/crates/shikomi-cli/src/autostart/mod.rs
@@ -1,0 +1,195 @@
+//! OS 自動起動管理モジュール（Sub-B Issue #127）。
+//!
+//! 設計根拠: docs/features/daemon-default-mode/autostart/detailed-design/backend-trait.md
+
+use std::path::PathBuf;
+
+// -------------------------------------------------------------------
+// AutostartBackend trait
+// -------------------------------------------------------------------
+
+/// OS 自動起動バックエンドの統一インターフェース。
+///
+/// 各 OS バックエンド（launchd / systemd / XDG / Task Scheduler）が実装する。
+/// 設計根拠: backend-trait.md §AutostartBackend trait 型シグネチャ
+pub trait AutostartBackend {
+    /// バックエンド識別名（tracing::info! の `backend=` フィールドで使用）。
+    fn name(&self) -> &'static str;
+
+    /// OS 自動起動に daemon を登録する。冪等（登録済みなら再登録せず Ok を返す）。
+    ///
+    /// # Errors
+    /// 登録に失敗した場合 `AutostartError` を返す。
+    fn install(&self) -> Result<(), AutostartError>;
+
+    /// OS 自動起動登録を解除する。冪等（未登録なら Ok を返す）。
+    ///
+    /// # Errors
+    /// 解除に失敗した場合 `AutostartError` を返す。
+    fn uninstall(&self) -> Result<(), AutostartError>;
+
+    /// 自動起動登録状態を返す。probe 失敗時は `false`（Fail Safe）。
+    fn is_registered(&self) -> bool;
+
+    /// install 成功時に stdout へ追記する OS 固有の hint（None なら追記なし）。
+    fn install_hint(&self) -> Option<String> {
+        None
+    }
+}
+
+// -------------------------------------------------------------------
+// AutostartError
+// -------------------------------------------------------------------
+
+/// autostart 操作のエラー型。
+///
+/// 設計根拠: backend-trait.md §AutostartError 型定義
+#[derive(Debug, thiserror::Error)]
+pub enum AutostartError {
+    /// 外部コマンド実行失敗。
+    #[error("command failed: `{cmd}`: {stderr_excerpt}")]
+    CommandFailed {
+        cmd: String,
+        /// stderr の最初の 80 文字のみ（secret 非含有 / security.md §脅威モデル「stderr 情報漏洩」）
+        stderr_excerpt: String,
+    },
+
+    /// I/O エラー。
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    /// 未サポートプラットフォーム。
+    #[error("unsupported: {reason}")]
+    Unsupported { reason: String },
+}
+
+// -------------------------------------------------------------------
+// resolve_daemon_path
+// -------------------------------------------------------------------
+
+/// `shikomi-daemon` バイナリの絶対パスを解決する共通ヘルパー。
+///
+/// 設計根拠: backend-trait.md §resolve_daemon_path() 共通ヘルパー
+///
+/// # Errors
+/// 実行ファイルの解決に失敗した場合 `AutostartError::IoError` を返す。
+pub fn resolve_daemon_path() -> Result<PathBuf, AutostartError> {
+    let exe = std::env::current_exe()?;
+    // canonicalize でシンボリックリンクを解決（シンボリックリンク攻撃防止 / security.md §脅威モデル）
+    let real = exe.canonicalize()?;
+    let dir = real.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "cannot determine binary directory",
+        )
+    })?;
+    let daemon_name = if cfg!(target_os = "windows") {
+        "shikomi-daemon.exe"
+    } else {
+        "shikomi-daemon"
+    };
+    let daemon_path = dir.join(daemon_name);
+    // Fail Fast: 不在なら IoError(NotFound)
+    if !daemon_path.exists() {
+        return Err(AutostartError::IoError(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("shikomi-daemon not found at {}", daemon_path.display()),
+        )));
+    }
+    Ok(daemon_path)
+}
+
+// -------------------------------------------------------------------
+// detect
+// -------------------------------------------------------------------
+
+/// OS を判定して適切な AutostartBackend 実装を返す（コンパイル時 #[cfg] 分岐）。
+///
+/// 設計根拠: backend-trait.md §detect() 関数定義
+#[must_use]
+pub fn detect() -> Box<dyn AutostartBackend> {
+    _detect_impl()
+}
+
+#[cfg(target_os = "macos")]
+fn _detect_impl() -> Box<dyn AutostartBackend> {
+    Box::new(launchd::LaunchdBackend)
+}
+
+#[cfg(target_os = "windows")]
+fn _detect_impl() -> Box<dyn AutostartBackend> {
+    Box::new(windows::WindowsTaskSchedulerBackend)
+}
+
+#[cfg(target_os = "linux")]
+fn _detect_impl() -> Box<dyn AutostartBackend> {
+    if systemd::SystemdBackend::is_available() {
+        Box::new(systemd::SystemdBackend)
+    } else {
+        Box::new(xdg::XdgAutostartBackend)
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+fn _detect_impl() -> Box<dyn AutostartBackend> {
+    Box::new(UnsupportedBackend)
+}
+
+// -------------------------------------------------------------------
+// UnsupportedBackend（FreeBSD 等）
+// -------------------------------------------------------------------
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+struct UnsupportedBackend;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+impl AutostartBackend for UnsupportedBackend {
+    fn name(&self) -> &'static str {
+        "UnsupportedBackend"
+    }
+
+    fn install(&self) -> Result<(), AutostartError> {
+        Err(AutostartError::Unsupported {
+            reason: "platform not supported".to_owned(),
+        })
+    }
+
+    fn uninstall(&self) -> Result<(), AutostartError> {
+        Err(AutostartError::Unsupported {
+            reason: "platform not supported".to_owned(),
+        })
+    }
+
+    fn is_registered(&self) -> bool {
+        false
+    }
+}
+
+// -------------------------------------------------------------------
+// モジュール宣言
+// -------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+pub mod launchd;
+
+#[cfg(target_os = "linux")]
+pub mod systemd;
+
+#[cfg(target_os = "linux")]
+pub mod xdg;
+
+#[cfg(target_os = "windows")]
+pub mod windows;
+
+// -------------------------------------------------------------------
+// stderr_excerpt ヘルパー（コマンド失敗時の stderr を 80 文字に切り詰める）
+// -------------------------------------------------------------------
+
+/// stderr バイト列を lossy UTF-8 変換して先頭 80 文字に切り詰める。
+///
+/// マルチバイト境界を `char_indices` で考慮する。
+pub(super) fn truncate_stderr(stderr: &[u8]) -> String {
+    let s = String::from_utf8_lossy(stderr);
+    let end = s.char_indices().nth(80).map(|(i, _)| i).unwrap_or(s.len());
+    s[..end].to_owned()
+}

--- a/crates/shikomi-cli/src/autostart/mod.rs
+++ b/crates/shikomi-cli/src/autostart/mod.rs
@@ -67,6 +67,34 @@ pub enum AutostartError {
 // resolve_daemon_path
 // -------------------------------------------------------------------
 
+/// `exe_dir` を直接受け取って `shikomi-daemon` パスを解決する内部ヘルパー。
+///
+/// `current_exe()` に依存しないため unit test でパス注入が可能。
+/// `resolve_daemon_path()` の実装本体。
+///
+/// 設計根拠: test-design/unit.md §TC-UT-164〜165 実装メモ
+///
+/// # Errors
+/// `shikomi-daemon` バイナリが存在しない場合 `AutostartError::IoError(NotFound)` を返す。
+pub(crate) fn resolve_daemon_path_from(
+    exe_dir: &std::path::Path,
+) -> Result<PathBuf, AutostartError> {
+    let daemon_name = if cfg!(target_os = "windows") {
+        "shikomi-daemon.exe"
+    } else {
+        "shikomi-daemon"
+    };
+    let daemon_path = exe_dir.join(daemon_name);
+    // Fail Fast: バイナリ不在なら即時失敗（backend-trait.md §resolve_daemon_path() Step 6）
+    if !daemon_path.exists() {
+        return Err(AutostartError::IoError(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "shikomi-daemon binary not found",
+        )));
+    }
+    Ok(daemon_path)
+}
+
 /// `shikomi-daemon` バイナリの絶対パスを解決する共通ヘルパー。
 ///
 /// autostart 登録ファイルに書き込む起動パスを返す。
@@ -91,20 +119,57 @@ pub fn resolve_daemon_path() -> Result<PathBuf, AutostartError> {
             "cannot determine binary directory",
         )
     })?;
-    let daemon_name = if cfg!(target_os = "windows") {
-        "shikomi-daemon.exe"
-    } else {
-        "shikomi-daemon"
-    };
-    let daemon_path = dir.join(daemon_name);
-    // Fail Fast: バイナリ不在なら即時失敗（backend-trait.md §resolve_daemon_path() Step 6）
-    if !daemon_path.exists() {
-        return Err(AutostartError::IoError(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "shikomi-daemon binary not found",
-        )));
+    resolve_daemon_path_from(dir)
+}
+
+// -------------------------------------------------------------------
+// unit tests — TC-UT-164〜165
+// -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    /// TC-UT-164: daemon バイナリ存在時に `Ok(PathBuf)` を返すこと
+    ///
+    /// 対応要件: REQ-DDM-010〜017
+    /// 受入基準: AC-DDM-07
+    /// 設計根拠: test-design/unit.md §5.2 TC-UT-164
+    #[test]
+    fn tc_ut_164_resolve_daemon_path_from_returns_ok_when_binary_exists() {
+        let dir = tempfile::tempdir().expect("tempdir 作成失敗");
+        let daemon_name = if cfg!(target_os = "windows") {
+            "shikomi-daemon.exe"
+        } else {
+            "shikomi-daemon"
+        };
+        std::fs::write(dir.path().join(daemon_name), b"").expect("ダミーバイナリ書き込み失敗");
+
+        let result = resolve_daemon_path_from(dir.path());
+        assert!(result.is_ok(), "daemon 存在時は Ok を返すべき: {result:?}");
+        assert!(
+            result.unwrap().exists(),
+            "返却パスが実際に存在すること"
+        );
     }
-    Ok(daemon_path)
+
+    /// TC-UT-165: daemon バイナリ不在時に `AutostartError::IoError(NotFound)` を返すこと
+    ///
+    /// 対応要件: REQ-DDM-010〜017
+    /// 受入基準: AC-DDM-07
+    /// 設計根拠: test-design/unit.md §5.2 TC-UT-165
+    #[test]
+    fn tc_ut_165_resolve_daemon_path_from_returns_not_found_when_binary_absent() {
+        let dir = tempfile::tempdir().expect("tempdir 作成失敗");
+        // shikomi-daemon を作成しない（空ディレクトリのまま）
+
+        let result = resolve_daemon_path_from(dir.path());
+        assert!(
+            matches!(&result, Err(AutostartError::IoError(e)) if e.kind() == io::ErrorKind::NotFound),
+            "daemon 不在時は AutostartError::IoError(NotFound) を返すべき: {result:?}"
+        );
+    }
 }
 
 // -------------------------------------------------------------------

--- a/crates/shikomi-cli/src/autostart/mod.rs
+++ b/crates/shikomi-cli/src/autostart/mod.rs
@@ -69,13 +69,18 @@ pub enum AutostartError {
 
 /// `shikomi-daemon` バイナリの絶対パスを解決する共通ヘルパー。
 ///
-/// autostart 登録ファイルに書き込む起動パスを返す。バイナリが現時点で存在しなくても
-/// パスの構築は成功する（ユーザがログイン時に daemon が存在すれば良い）。
+/// autostart 登録ファイルに書き込む起動パスを返す。
+///
+/// **Fail Fast**: バイナリが現時点で存在しない場合は即座に
+/// `AutostartError::IoError(NotFound)` を返す。
+/// 悪意あるバイナリ置換攻撃への対策として `canonicalize()` 後に `exists()` を確認する
+/// （設計根拠: security.md §脅威モデル「resolve_daemon_path が悪意あるバイナリを解決」）。
 ///
 /// 設計根拠: backend-trait.md §resolve_daemon_path() 共通ヘルパー
 ///
 /// # Errors
-/// 実行ファイルのディレクトリ解決に失敗した場合 `AutostartError::IoError` を返す。
+/// - 実行ファイルのディレクトリ解決に失敗した場合 `AutostartError::IoError` を返す。
+/// - `shikomi-daemon` バイナリが存在しない場合 `AutostartError::IoError(NotFound)` を返す。
 pub fn resolve_daemon_path() -> Result<PathBuf, AutostartError> {
     let exe = std::env::current_exe()?;
     // canonicalize でシンボリックリンクを解決（シンボリックリンク攻撃防止 / security.md §脅威モデル）
@@ -91,7 +96,15 @@ pub fn resolve_daemon_path() -> Result<PathBuf, AutostartError> {
     } else {
         "shikomi-daemon"
     };
-    Ok(dir.join(daemon_name))
+    let daemon_path = dir.join(daemon_name);
+    // Fail Fast: バイナリ不在なら即時失敗（backend-trait.md §resolve_daemon_path() Step 6）
+    if !daemon_path.exists() {
+        return Err(AutostartError::IoError(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "shikomi-daemon binary not found",
+        )));
+    }
+    Ok(daemon_path)
 }
 
 // -------------------------------------------------------------------

--- a/crates/shikomi-cli/src/autostart/systemd.rs
+++ b/crates/shikomi-cli/src/autostart/systemd.rs
@@ -1,0 +1,150 @@
+//! Linux systemd user unit バックエンド（Sub-B Issue #127）。
+//!
+//! 設計根拠: docs/features/daemon-default-mode/autostart/detailed-design/systemd.md
+
+use std::path::PathBuf;
+
+use super::{resolve_daemon_path, truncate_stderr, AutostartBackend, AutostartError};
+
+const UNIT_TEMPLATE: &str = "[Unit]
+Description=shikomi credential vault daemon
+After=default.target
+
+[Service]
+ExecStart={daemon_path}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+";
+
+pub struct SystemdBackend;
+
+impl SystemdBackend {
+    fn unit_path() -> Option<PathBuf> {
+        dirs::home_dir().map(|h| h.join(".config/systemd/user/shikomi-daemon.service"))
+    }
+
+    fn run_systemctl(args: &[&str]) -> Result<std::process::Output, AutostartError> {
+        let out = std::process::Command::new("systemctl")
+            .args(args)
+            .output()?;
+        Ok(out)
+    }
+
+    /// systemd user session が利用可能かを判定する。
+    ///
+    /// 設計根拠: systemd.md §SystemdBackend::is_available() 判定ロジック
+    pub fn is_available() -> bool {
+        // 1. PATH 上に systemctl が存在するか
+        if !is_on_path("systemctl") {
+            return false;
+        }
+        // 2. D-Bus セッションバスが存在するか
+        if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_err() {
+            return false;
+        }
+        // 3. systemctl --user status の exit code が 4 以外か
+        match std::process::Command::new("systemctl")
+            .args(["--user", "status", "--no-pager"])
+            .output()
+        {
+            Ok(out) => {
+                let code = out.status.code().unwrap_or(1);
+                code != 4
+            }
+            Err(_) => false,
+        }
+    }
+}
+
+impl AutostartBackend for SystemdBackend {
+    fn name(&self) -> &'static str {
+        "SystemdBackend"
+    }
+
+    fn install(&self) -> Result<(), AutostartError> {
+        let daemon_path = resolve_daemon_path()?;
+        let daemon_path_str = daemon_path.display().to_string();
+
+        let unit_content = UNIT_TEMPLATE.replace("{daemon_path}", &daemon_path_str);
+
+        let unit_dir = dirs::home_dir()
+            .ok_or_else(|| {
+                AutostartError::IoError(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "cannot determine home directory",
+                ))
+            })?
+            .join(".config/systemd/user");
+        std::fs::create_dir_all(&unit_dir)?;
+
+        let unit_path = Self::unit_path().ok_or_else(|| {
+            AutostartError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "cannot determine home directory",
+            ))
+        })?;
+        std::fs::write(&unit_path, unit_content)?;
+
+        // daemon-reload
+        let reload = Self::run_systemctl(&["--user", "daemon-reload"])?;
+        if !reload.status.success() {
+            return Err(AutostartError::CommandFailed {
+                cmd: "systemctl --user daemon-reload".to_owned(),
+                stderr_excerpt: truncate_stderr(&reload.stderr),
+            });
+        }
+
+        // enable --now（登録 + 即時起動）
+        let enable = Self::run_systemctl(&["--user", "enable", "--now", "shikomi-daemon.service"])?;
+        if !enable.status.success() {
+            return Err(AutostartError::CommandFailed {
+                cmd: "systemctl --user enable --now shikomi-daemon.service".to_owned(),
+                stderr_excerpt: truncate_stderr(&enable.stderr),
+            });
+        }
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), AutostartError> {
+        // disable --now（未登録でも無視）
+        let _ = Self::run_systemctl(&["--user", "disable", "--now", "shikomi-daemon.service"]);
+
+        // unit ファイル削除（NotFound → Ok、冪等）
+        if let Some(unit) = Self::unit_path() {
+            match std::fs::remove_file(&unit) {
+                Ok(()) => {}
+                Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(AutostartError::IoError(e)),
+            }
+        }
+
+        // daemon-reload（unit ファイル削除後の再読込）
+        let _ = Self::run_systemctl(&["--user", "daemon-reload"]);
+        Ok(())
+    }
+
+    fn is_registered(&self) -> bool {
+        Self::unit_path().map(|p| p.exists()).unwrap_or(false)
+    }
+
+    fn install_hint(&self) -> Option<String> {
+        Some("hint: to check status: systemctl --user status shikomi-daemon".to_owned())
+    }
+}
+
+/// PATH 上にコマンドが存在するかを確認する（which crate の簡易代替）。
+///
+/// `std::env::split_paths` で OS 非依存に分割し、実行ファイルの存在を確認する。
+fn is_on_path(cmd: &str) -> bool {
+    if let Some(path_var) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            if dir.join(cmd).is_file() {
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/crates/shikomi-cli/src/autostart/windows.rs
+++ b/crates/shikomi-cli/src/autostart/windows.rs
@@ -1,0 +1,82 @@
+//! Windows Task Scheduler バックエンド（Sub-B Issue #127）。
+//!
+//! 設計根拠: docs/features/daemon-default-mode/autostart/detailed-design/windows.md
+
+use super::{resolve_daemon_path, truncate_stderr, AutostartBackend, AutostartError};
+
+const TASK_NAME: &str = r"shikomi\shikomi-daemon";
+
+pub struct WindowsTaskSchedulerBackend;
+
+impl WindowsTaskSchedulerBackend {
+    fn run_schtasks(args: &[&str]) -> Result<std::process::Output, AutostartError> {
+        let out = std::process::Command::new("schtasks").args(args).output()?;
+        Ok(out)
+    }
+}
+
+impl AutostartBackend for WindowsTaskSchedulerBackend {
+    fn name(&self) -> &'static str {
+        "WindowsTaskSchedulerBackend"
+    }
+
+    fn install(&self) -> Result<(), AutostartError> {
+        let daemon_path = resolve_daemon_path()?;
+        let daemon_path_str = daemon_path.display().to_string();
+
+        // 冪等確保（事前確認）: 登録済みなら早期返却
+        let query = Self::run_schtasks(&["/Query", "/TN", TASK_NAME])?;
+        if query.status.success() {
+            return Ok(());
+        }
+
+        // タスク登録（/F で既存タスクを強制上書き）
+        let out = Self::run_schtasks(&[
+            "/Create",
+            "/SC",
+            "ONLOGON",
+            "/TN",
+            TASK_NAME,
+            "/TR",
+            &daemon_path_str,
+            "/F",
+        ])?;
+        if !out.status.success() {
+            return Err(AutostartError::CommandFailed {
+                cmd: format!(
+                    "schtasks /Create /SC ONLOGON /TN {TASK_NAME} /TR {daemon_path_str} /F"
+                ),
+                stderr_excerpt: truncate_stderr(&out.stderr),
+            });
+        }
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), AutostartError> {
+        let out = Self::run_schtasks(&["/Delete", "/TN", TASK_NAME, "/F"])?;
+        if !out.status.success() {
+            let stderr_str = String::from_utf8_lossy(&out.stderr);
+            // 「未登録タスクの削除」は冪等 → Ok(())
+            if stderr_str.contains("The system cannot find the file") {
+                return Ok(());
+            }
+            return Err(AutostartError::CommandFailed {
+                cmd: format!("schtasks /Delete /TN {TASK_NAME} /F"),
+                stderr_excerpt: truncate_stderr(&out.stderr),
+            });
+        }
+        Ok(())
+    }
+
+    fn is_registered(&self) -> bool {
+        Self::run_schtasks(&["/Query", "/TN", TASK_NAME])
+            .map(|out| out.status.success())
+            .unwrap_or(false)
+    }
+
+    fn install_hint(&self) -> Option<String> {
+        Some(format!(
+            r#"hint: to start immediately: schtasks /Run /TN "{TASK_NAME}""#
+        ))
+    }
+}

--- a/crates/shikomi-cli/src/autostart/xdg.rs
+++ b/crates/shikomi-cli/src/autostart/xdg.rs
@@ -1,0 +1,76 @@
+//! Linux XDG Autostart フォールバックバックエンド（Sub-B Issue #127）。
+//!
+//! 設計根拠: docs/features/daemon-default-mode/autostart/detailed-design/xdg.md
+
+use std::path::PathBuf;
+
+use super::{resolve_daemon_path, AutostartBackend, AutostartError};
+
+const DESKTOP_TEMPLATE: &str = "[Desktop Entry]
+Type=Application
+Name=shikomi-daemon
+Comment=shikomi credential vault daemon
+Exec={daemon_path}
+Hidden=false
+NoDisplay=false
+X-GNOME-Autostart-enabled=true
+";
+
+pub struct XdgAutostartBackend;
+
+impl XdgAutostartBackend {
+    fn desktop_path() -> Option<PathBuf> {
+        dirs::home_dir().map(|h| h.join(".config/autostart/shikomi-daemon.desktop"))
+    }
+}
+
+impl AutostartBackend for XdgAutostartBackend {
+    fn name(&self) -> &'static str {
+        "XdgAutostartBackend"
+    }
+
+    fn install(&self) -> Result<(), AutostartError> {
+        let daemon_path = resolve_daemon_path()?;
+        let daemon_path_str = daemon_path.display().to_string();
+
+        let content = DESKTOP_TEMPLATE.replace("{daemon_path}", &daemon_path_str);
+
+        let autostart_dir = dirs::home_dir()
+            .ok_or_else(|| {
+                AutostartError::IoError(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "cannot determine home directory",
+                ))
+            })?
+            .join(".config/autostart");
+        std::fs::create_dir_all(&autostart_dir)?;
+
+        let desktop_path = Self::desktop_path().ok_or_else(|| {
+            AutostartError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "cannot determine home directory",
+            ))
+        })?;
+        std::fs::write(&desktop_path, content)?;
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), AutostartError> {
+        if let Some(desktop) = Self::desktop_path() {
+            match std::fs::remove_file(&desktop) {
+                Ok(()) => {}
+                Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(AutostartError::IoError(e)),
+            }
+        }
+        Ok(())
+    }
+
+    fn is_registered(&self) -> bool {
+        Self::desktop_path().map(|p| p.exists()).unwrap_or(false)
+    }
+
+    fn install_hint(&self) -> Option<String> {
+        Some("hint: this uses XDG Autostart; shikomi-daemon will start on next login".to_owned())
+    }
+}

--- a/crates/shikomi-cli/src/cli.rs
+++ b/crates/shikomi-cli/src/cli.rs
@@ -91,6 +91,37 @@ pub enum Subcommand {
     /// 設計根拠: `docs/features/shikomi-gui/feature-spec.md` R1-GUI-01
     #[command(about = "Launch the graphical interface")]
     Gui,
+
+    /// OS 自動起動の管理と daemon 稼働状態確認（Sub-B Issue #127）。
+    ///
+    /// 設計根拠: docs/features/daemon-default-mode/autostart/basic-design.md
+    #[command(
+        subcommand,
+        about = "Manage daemon autostart registration and check daemon status"
+    )]
+    Daemon(DaemonSubcommand),
+}
+
+// -------------------------------------------------------------------
+// DaemonSubcommand（Sub-B Issue #127）
+// -------------------------------------------------------------------
+
+/// `shikomi daemon {subcommand}` の 3 サブコマンド group。
+///
+/// 設計根拠: docs/features/daemon-default-mode/autostart/basic-design.md §DaemonSubcommand の CLI 仕様
+#[derive(ClapSubcommand, Debug)]
+pub enum DaemonSubcommand {
+    /// OS の自動起動機能に shikomi-daemon を登録する。
+    #[command(about = "Register shikomi-daemon as an OS autostart service")]
+    Install,
+
+    /// OS の自動起動登録を解除する。
+    #[command(about = "Unregister shikomi-daemon from OS autostart")]
+    Uninstall,
+
+    /// daemon の稼働状態と自動起動登録状態を表示する。
+    #[command(about = "Show daemon running status and autostart registration")]
+    Status,
 }
 
 // -------------------------------------------------------------------

--- a/crates/shikomi-cli/src/daemon_runners.rs
+++ b/crates/shikomi-cli/src/daemon_runners.rs
@@ -1,0 +1,133 @@
+//! `shikomi daemon` サブコマンドの dispatcher 群。
+//!
+//! 工程5 ペガサス指摘 (lib.rs 500 行ルール超過) 解消のため、`lib.rs` から
+//! `run_daemon_subcommand` と `probe_daemon_running` を本ファイルに切り出した。
+//! `lib.rs` はコンポジションルート + IPC handshake + vault サブコマンド経路に
+//! 責務を集約する設計に整理。
+//!
+//! 設計根拠:
+//! - docs/features/daemon-default-mode/autostart/detailed-design/index.md
+//!   §run_daemon_subcommand
+
+use crate::cli::DaemonSubcommand;
+use crate::error::ExitCode;
+use crate::io;
+use crate::presenter::{self, Locale};
+use crate::{autostart, eprint_stderr};
+use io::ipc_vault_repository::IpcVaultRepository;
+
+/// daemon サブコマンドを処理する（RepositoryHandle 不要のため early-return 経路）。
+///
+/// 設計根拠: docs/features/daemon-default-mode/autostart/detailed-design/index.md
+/// §run_daemon_subcommand
+pub(crate) fn run_daemon_subcommand(
+    sub: &DaemonSubcommand,
+    no_ipc: bool,
+    locale: Locale,
+    quiet: bool,
+) -> ExitCode {
+    match sub {
+        DaemonSubcommand::Install => {
+            let backend = autostart::detect();
+            match backend.install() {
+                Ok(()) => {
+                    tracing::info!(
+                        target: "shikomi_cli::autostart",
+                        "autostart install: backend={}",
+                        backend.name()
+                    );
+                    if !quiet {
+                        print!("{}", presenter::success::render_autostart_installed(locale));
+                        if let Some(hint) = backend.install_hint() {
+                            println!("{hint}");
+                        }
+                    }
+                    ExitCode::Success
+                }
+                Err(ref err) => {
+                    let msg = presenter::error::render_autostart_install_error(err, locale);
+                    eprint_stderr(&msg);
+                    ExitCode::UserError
+                }
+            }
+        }
+        DaemonSubcommand::Uninstall => {
+            let backend = autostart::detect();
+            match backend.uninstall() {
+                Ok(()) => {
+                    tracing::info!(
+                        target: "shikomi_cli::autostart",
+                        "autostart uninstall: backend={}",
+                        backend.name()
+                    );
+                    if !quiet {
+                        print!(
+                            "{}",
+                            presenter::success::render_autostart_uninstalled(locale)
+                        );
+                    }
+                    ExitCode::Success
+                }
+                Err(ref err) => {
+                    let msg = presenter::error::render_autostart_uninstall_error(err, locale);
+                    eprint_stderr(&msg);
+                    ExitCode::UserError
+                }
+            }
+        }
+        DaemonSubcommand::Status => {
+            // IPC probe（no_ipc=true の場合は省略）
+            let daemon_line = if no_ipc {
+                "daemon: unknown (--no-ipc)".to_owned()
+            } else {
+                probe_daemon_running()
+            };
+
+            let backend = autostart::detect();
+            let autostart_line = if backend.is_registered() {
+                "autostart: enabled"
+            } else {
+                "autostart: disabled"
+            };
+
+            println!("{daemon_line}");
+            println!("{autostart_line}");
+            // Status は常に Success（REQ-DDM-012 「情報提供のみ、副作用なし」）
+            ExitCode::Success
+        }
+    }
+}
+
+/// daemon IPC 接続を 200ms タイムアウトで probe し、稼働状態を文字列で返す。
+///
+/// 設計根拠: index.md §Status 処理手順 — IPC probe 200ms タイムアウト
+pub(crate) fn probe_daemon_running() -> String {
+    let socket_path = match IpcVaultRepository::default_socket_path() {
+        Ok(p) => p,
+        Err(_) => return "daemon: not running".to_owned(),
+    };
+
+    // tokio runtime で 200ms タイムアウト付き接続を試みる
+    let connected = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map(|rt| {
+            rt.block_on(async {
+                matches!(
+                    tokio::time::timeout(
+                        std::time::Duration::from_millis(200),
+                        io::ipc_client::IpcClient::connect(&socket_path),
+                    )
+                    .await,
+                    Ok(Ok(_))
+                )
+            })
+        })
+        .unwrap_or(false);
+
+    if connected {
+        "daemon: running".to_owned()
+    } else {
+        "daemon: not running".to_owned()
+    }
+}

--- a/crates/shikomi-cli/src/lib.rs
+++ b/crates/shikomi-cli/src/lib.rs
@@ -33,6 +33,9 @@ pub mod view;
 // Sub-B (#127): OS 自動起動バックエンド群。
 #[doc(hidden)]
 pub mod autostart;
+// Sub-B (#127): daemon サブコマンド dispatcher 群（lib.rs 500 行ルール対応）。
+#[doc(hidden)]
+pub mod daemon_runners;
 
 pub use error::{CliError, ExitCode};
 
@@ -42,7 +45,7 @@ use std::sync::OnceLock;
 
 use shikomi_infra::persistence::SqliteVaultRepository;
 
-use cli::{CliArgs, DaemonSubcommand, Subcommand, VaultSubcommand};
+use cli::{CliArgs, Subcommand, VaultSubcommand};
 use io::ipc_vault_repository::IpcVaultRepository;
 use presenter::Locale;
 
@@ -192,7 +195,7 @@ pub fn run() -> ExitCode {
 
     // Sub-B (#127): daemon サブコマンドは RepositoryHandle 不要のため early return する。
     if let Subcommand::Daemon(daemon_sub) = &args.subcommand {
-        return run_daemon_subcommand(daemon_sub, args.no_ipc, locale, quiet);
+        return daemon_runners::run_daemon_subcommand(daemon_sub, args.no_ipc, locale, quiet);
     }
 
     // Sub-F (#44) Phase 2: vault サブコマンドは daemon IPC 経路に**強制**する。
@@ -406,125 +409,5 @@ fn run_gui(locale: Locale) -> ExitCode {
             }
         }
         Err(e) => emit_error_and_exit(&CliError::GuiLaunchFailed(e.to_string()), locale),
-    }
-}
-
-// -------------------------------------------------------------------
-// Sub-B (#127): daemon サブコマンド dispatch
-// -------------------------------------------------------------------
-
-/// daemon サブコマンドを処理する（RepositoryHandle 不要のため early-return 経路）。
-///
-/// 設計根拠: docs/features/daemon-default-mode/autostart/detailed-design/index.md
-/// §run_daemon_subcommand
-fn run_daemon_subcommand(
-    sub: &DaemonSubcommand,
-    no_ipc: bool,
-    locale: Locale,
-    quiet: bool,
-) -> ExitCode {
-    match sub {
-        DaemonSubcommand::Install => {
-            let backend = autostart::detect();
-            match backend.install() {
-                Ok(()) => {
-                    tracing::info!(
-                        target: "shikomi_cli::autostart",
-                        "autostart install: backend={}",
-                        backend.name()
-                    );
-                    if !quiet {
-                        print!("{}", presenter::success::render_autostart_installed(locale));
-                        if let Some(hint) = backend.install_hint() {
-                            println!("{hint}");
-                        }
-                    }
-                    ExitCode::Success
-                }
-                Err(ref err) => {
-                    let msg = presenter::error::render_autostart_install_error(err, locale);
-                    eprint_stderr(&msg);
-                    ExitCode::UserError
-                }
-            }
-        }
-        DaemonSubcommand::Uninstall => {
-            let backend = autostart::detect();
-            match backend.uninstall() {
-                Ok(()) => {
-                    tracing::info!(
-                        target: "shikomi_cli::autostart",
-                        "autostart uninstall: backend={}",
-                        backend.name()
-                    );
-                    if !quiet {
-                        print!(
-                            "{}",
-                            presenter::success::render_autostart_uninstalled(locale)
-                        );
-                    }
-                    ExitCode::Success
-                }
-                Err(ref err) => {
-                    let msg = presenter::error::render_autostart_uninstall_error(err, locale);
-                    eprint_stderr(&msg);
-                    ExitCode::UserError
-                }
-            }
-        }
-        DaemonSubcommand::Status => {
-            // IPC probe（no_ipc=true の場合は省略）
-            let daemon_line = if no_ipc {
-                "daemon: unknown (--no-ipc)".to_owned()
-            } else {
-                probe_daemon_running()
-            };
-
-            let backend = autostart::detect();
-            let autostart_line = if backend.is_registered() {
-                "autostart: enabled"
-            } else {
-                "autostart: disabled"
-            };
-
-            println!("{daemon_line}");
-            println!("{autostart_line}");
-            // Status は常に Success（REQ-DDM-012 「情報提供のみ、副作用なし」）
-            ExitCode::Success
-        }
-    }
-}
-
-/// daemon IPC 接続を 200ms タイムアウトで probe し、稼働状態を文字列で返す。
-///
-/// 設計根拠: index.md §Status 処理手順 — IPC probe 200ms タイムアウト
-fn probe_daemon_running() -> String {
-    let socket_path = match IpcVaultRepository::default_socket_path() {
-        Ok(p) => p,
-        Err(_) => return "daemon: not running".to_owned(),
-    };
-
-    // tokio runtime で 200ms タイムアウト付き接続を試みる
-    let connected = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map(|rt| {
-            rt.block_on(async {
-                matches!(
-                    tokio::time::timeout(
-                        std::time::Duration::from_millis(200),
-                        io::ipc_client::IpcClient::connect(&socket_path),
-                    )
-                    .await,
-                    Ok(Ok(_))
-                )
-            })
-        })
-        .unwrap_or(false);
-
-    if connected {
-        "daemon: running".to_owned()
-    } else {
-        "daemon: not running".to_owned()
     }
 }

--- a/crates/shikomi-cli/src/lib.rs
+++ b/crates/shikomi-cli/src/lib.rs
@@ -510,12 +510,14 @@ fn probe_daemon_running() -> String {
         .build()
         .map(|rt| {
             rt.block_on(async {
-                tokio::time::timeout(
-                    std::time::Duration::from_millis(200),
-                    io::ipc_client::IpcClient::connect(&socket_path),
+                matches!(
+                    tokio::time::timeout(
+                        std::time::Duration::from_millis(200),
+                        io::ipc_client::IpcClient::connect(&socket_path),
+                    )
+                    .await,
+                    Ok(Ok(_))
                 )
-                .await
-                .is_ok()
             })
         })
         .unwrap_or(false);

--- a/crates/shikomi-cli/src/lib.rs
+++ b/crates/shikomi-cli/src/lib.rs
@@ -30,6 +30,9 @@ pub mod record_runners;
 pub mod usecase;
 #[doc(hidden)]
 pub mod view;
+// Sub-B (#127): OS 自動起動バックエンド群。
+#[doc(hidden)]
+pub mod autostart;
 
 pub use error::{CliError, ExitCode};
 
@@ -39,7 +42,7 @@ use std::sync::OnceLock;
 
 use shikomi_infra::persistence::SqliteVaultRepository;
 
-use cli::{CliArgs, Subcommand, VaultSubcommand};
+use cli::{CliArgs, DaemonSubcommand, Subcommand, VaultSubcommand};
 use io::ipc_vault_repository::IpcVaultRepository;
 use presenter::Locale;
 
@@ -187,6 +190,11 @@ pub fn run() -> ExitCode {
         return run_gui(locale);
     }
 
+    // Sub-B (#127): daemon サブコマンドは RepositoryHandle 不要のため early return する。
+    if let Subcommand::Daemon(daemon_sub) = &args.subcommand {
+        return run_daemon_subcommand(daemon_sub, args.no_ipc, locale, quiet);
+    }
+
     // Sub-F (#44) Phase 2: vault サブコマンドは daemon IPC 経路に**強制**する。
     // V1 の `RepositoryHandle::Sqlite` 経路は vault に直接触らない契約 (Phase 2 規定、
     // cli-subcommands.md §Clean Architecture の依存方向) のため、ここで先に
@@ -222,6 +230,8 @@ pub fn run() -> ExitCode {
         Subcommand::Vault(_) => unreachable!("vault subcommand handled above"),
         // 上の `if let Subcommand::Gui` early return で処理済（網羅性のため unreachable）。
         Subcommand::Gui => unreachable!("gui subcommand handled above"),
+        // 上の `if let Subcommand::Daemon(_)` early return で処理済（網羅性のため unreachable）。
+        Subcommand::Daemon(_) => unreachable!("daemon subcommand handled above"),
     };
 
     match result {
@@ -396,5 +406,123 @@ fn run_gui(locale: Locale) -> ExitCode {
             }
         }
         Err(e) => emit_error_and_exit(&CliError::GuiLaunchFailed(e.to_string()), locale),
+    }
+}
+
+// -------------------------------------------------------------------
+// Sub-B (#127): daemon サブコマンド dispatch
+// -------------------------------------------------------------------
+
+/// daemon サブコマンドを処理する（RepositoryHandle 不要のため early-return 経路）。
+///
+/// 設計根拠: docs/features/daemon-default-mode/autostart/detailed-design/index.md
+/// §run_daemon_subcommand
+fn run_daemon_subcommand(
+    sub: &DaemonSubcommand,
+    no_ipc: bool,
+    locale: Locale,
+    quiet: bool,
+) -> ExitCode {
+    match sub {
+        DaemonSubcommand::Install => {
+            let backend = autostart::detect();
+            match backend.install() {
+                Ok(()) => {
+                    tracing::info!(
+                        target: "shikomi_cli::autostart",
+                        "autostart install: backend={}",
+                        backend.name()
+                    );
+                    if !quiet {
+                        print!("{}", presenter::success::render_autostart_installed(locale));
+                        if let Some(hint) = backend.install_hint() {
+                            println!("{hint}");
+                        }
+                    }
+                    ExitCode::Success
+                }
+                Err(ref err) => {
+                    let msg = presenter::error::render_autostart_install_error(err, locale);
+                    eprint_stderr(&msg);
+                    ExitCode::UserError
+                }
+            }
+        }
+        DaemonSubcommand::Uninstall => {
+            let backend = autostart::detect();
+            match backend.uninstall() {
+                Ok(()) => {
+                    tracing::info!(
+                        target: "shikomi_cli::autostart",
+                        "autostart uninstall: backend={}",
+                        backend.name()
+                    );
+                    if !quiet {
+                        print!(
+                            "{}",
+                            presenter::success::render_autostart_uninstalled(locale)
+                        );
+                    }
+                    ExitCode::Success
+                }
+                Err(ref err) => {
+                    let msg = presenter::error::render_autostart_uninstall_error(err, locale);
+                    eprint_stderr(&msg);
+                    ExitCode::UserError
+                }
+            }
+        }
+        DaemonSubcommand::Status => {
+            // IPC probe（no_ipc=true の場合は省略）
+            let daemon_line = if no_ipc {
+                "daemon: unknown (--no-ipc)".to_owned()
+            } else {
+                probe_daemon_running()
+            };
+
+            let backend = autostart::detect();
+            let autostart_line = if backend.is_registered() {
+                "autostart: enabled"
+            } else {
+                "autostart: disabled"
+            };
+
+            println!("{daemon_line}");
+            println!("{autostart_line}");
+            // Status は常に Success（REQ-DDM-012 「情報提供のみ、副作用なし」）
+            ExitCode::Success
+        }
+    }
+}
+
+/// daemon IPC 接続を 200ms タイムアウトで probe し、稼働状態を文字列で返す。
+///
+/// 設計根拠: index.md §Status 処理手順 — IPC probe 200ms タイムアウト
+fn probe_daemon_running() -> String {
+    let socket_path = match IpcVaultRepository::default_socket_path() {
+        Ok(p) => p,
+        Err(_) => return "daemon: not running".to_owned(),
+    };
+
+    // tokio runtime で 200ms タイムアウト付き接続を試みる
+    let connected = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map(|rt| {
+            rt.block_on(async {
+                tokio::time::timeout(
+                    std::time::Duration::from_millis(200),
+                    io::ipc_client::IpcClient::connect(&socket_path),
+                )
+                .await
+                .is_ok()
+            })
+        })
+        .unwrap_or(false);
+
+    if connected {
+        "daemon: running".to_owned()
+    } else {
+        "daemon: not running".to_owned()
     }
 }

--- a/crates/shikomi-cli/src/presenter/error.rs
+++ b/crates/shikomi-cli/src/presenter/error.rs
@@ -317,6 +317,39 @@ fn render_persistence_lines(pe: &PersistenceError) -> (String, String, String, S
     }
 }
 
+// -------------------------------------------------------------------
+// Sub-B (#127): autostart エラーメッセージ（MSG-CLI-120 / MSG-CLI-121）
+//
+// 設計根拠: docs/features/daemon-default-mode/autostart/detailed-design/presenter.md
+// §MSG-CLI-120 / MSG-CLI-121 追加
+// -------------------------------------------------------------------
+
+/// MSG-CLI-120: `shikomi daemon install` 失敗文言。
+#[must_use]
+pub fn render_autostart_install_error(
+    err: &crate::autostart::AutostartError,
+    locale: Locale,
+) -> String {
+    let mut out = format!("error: failed to enable autostart: {err}\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!("エラー: 自動起動の有効化に失敗しました: {err}\n"));
+    }
+    out
+}
+
+/// MSG-CLI-121: `shikomi daemon uninstall` 失敗文言。
+#[must_use]
+pub fn render_autostart_uninstall_error(
+    err: &crate::autostart::AutostartError,
+    locale: Locale,
+) -> String {
+    let mut out = format!("error: failed to disable autostart: {err}\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!("エラー: 自動起動の無効化に失敗しました: {err}\n"));
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/shikomi-cli/src/presenter/success.rs
+++ b/crates/shikomi-cli/src/presenter/success.rs
@@ -235,6 +235,37 @@ fn push_word_lines(out: &mut String, words: &[SerializableSecretBytes]) {
 // への委譲構造に統合済（同モジュール 1 箇所が MSG-S20 文言の SSoT、DRY を維持しつつ
 // `*_with_fallback_notice` 公開 API を C-31/C-36 articulate に整合）。
 
+// -------------------------------------------------------------------
+// Sub-B (#127): autostart 成功メッセージ（ペガサス指摘②対応）
+//
+// 設計根拠: docs/features/daemon-default-mode/autostart/detailed-design/presenter.md
+// §render_autostart_installed / §render_autostart_uninstalled
+// -------------------------------------------------------------------
+
+/// `shikomi daemon install` 成功文言。
+///
+/// `quiet == true` の場合は呼出側（`run_daemon_subcommand`）で呼ばない（presenter 層は quiet 非関与）。
+#[must_use]
+pub fn render_autostart_installed(locale: Locale) -> String {
+    let mut out = String::from("shikomi-daemon autostart enabled\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str("shikomi-daemon の自動起動を有効にしました\n");
+    }
+    out
+}
+
+/// `shikomi daemon uninstall` 成功文言。
+///
+/// `quiet == true` の場合は呼出側（`run_daemon_subcommand`）で呼ばない（presenter 層は quiet 非関与）。
+#[must_use]
+pub fn render_autostart_uninstalled(locale: Locale) -> String {
+    let mut out = String::from("shikomi-daemon autostart disabled\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str("shikomi-daemon の自動起動を無効にしました\n");
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/shikomi-cli/src/tests.rs
+++ b/crates/shikomi-cli/src/tests.rs
@@ -129,8 +129,8 @@ fn tc_ut_159_no_ipc_referenced_in_lib_rs() {
         })
         .count();
     assert_eq!(
-        code_refs, 2,
-        "args.no_ipc should appear in exactly 2 non-comment, non-test lines in lib.rs \
-         (① build_handle branch / ② vault MSG-CLI-052 dispatch), got {code_refs}"
+        code_refs, 3,
+        "args.no_ipc should appear in exactly 3 non-comment, non-test lines in lib.rs \
+         (① build_handle branch / ② vault MSG-CLI-052 dispatch / ③ daemon status IPC probe), got {code_refs}"
     );
 }

--- a/crates/shikomi-cli/tests/e2e_sc_ddm_002.rs
+++ b/crates/shikomi-cli/tests/e2e_sc_ddm_002.rs
@@ -98,8 +98,7 @@ fn sc_ddm_002_tc001_ac07_daemon_install_creates_autostart_file() {
             autostart_path.display()
         );
         // プレースホルダが残っていないこと
-        let content = std::fs::read_to_string(&autostart_path)
-            .expect("autostart file readable");
+        let content = std::fs::read_to_string(&autostart_path).expect("autostart file readable");
         assert!(
             !content.contains("{daemon_path}"),
             "AC-DDM-07: テンプレートプレースホルダ {{daemon_path}} が残っているべきでない\n内容:\n{content}"
@@ -133,8 +132,7 @@ fn sc_ddm_002_tc002_ac08_daemon_uninstall_removes_autostart_file() {
     let home = make_home_dir();
 
     // 前提: install 済み状態にする
-    run_daemon_cmd(home.path(), &["install"])
-        .success();
+    run_daemon_cmd(home.path(), &["install"]).success();
 
     // autostart ファイルが存在することを確認してから uninstall
     if let Some(autostart_path) = expected_autostart_file(home.path()) {
@@ -148,7 +146,9 @@ fn sc_ddm_002_tc002_ac08_daemon_uninstall_removes_autostart_file() {
         // exit 0
         .success()
         // stdout に成功メッセージ
-        .stdout(predicate::str::contains("shikomi-daemon autostart disabled"))
+        .stdout(predicate::str::contains(
+            "shikomi-daemon autostart disabled",
+        ))
         // stderr に "error:" なし
         .stderr(predicate::str::contains("error:").not());
 
@@ -412,7 +412,9 @@ fn tc_it_128b_daemon_uninstall_idempotent_when_not_registered() {
     // install せずに直接 uninstall
     run_daemon_cmd(home.path(), &["uninstall"])
         .success()
-        .stdout(predicate::str::contains("shikomi-daemon autostart disabled"))
+        .stdout(predicate::str::contains(
+            "shikomi-daemon autostart disabled",
+        ))
         .stderr(predicate::str::contains("error:").not());
 }
 
@@ -438,7 +440,10 @@ fn tc_it_132_status_reflects_install_uninstall_cycle() {
             .output()
             .expect("実行失敗");
         let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("autostart: disabled"), "初期状態は disabled であるべき。\nstdout:\n{stdout}");
+        assert!(
+            stdout.contains("autostart: disabled"),
+            "初期状態は disabled であるべき。\nstdout:\n{stdout}"
+        );
     }
 
     // install 後: enabled
@@ -451,7 +456,10 @@ fn tc_it_132_status_reflects_install_uninstall_cycle() {
             .output()
             .expect("実行失敗");
         let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("autostart: enabled"), "install 後は enabled であるべき。\nstdout:\n{stdout}");
+        assert!(
+            stdout.contains("autostart: enabled"),
+            "install 後は enabled であるべき。\nstdout:\n{stdout}"
+        );
     }
 
     // uninstall 後: disabled に戻る
@@ -464,6 +472,9 @@ fn tc_it_132_status_reflects_install_uninstall_cycle() {
             .output()
             .expect("実行失敗");
         let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("autostart: disabled"), "uninstall 後は disabled に戻るべき。\nstdout:\n{stdout}");
+        assert!(
+            stdout.contains("autostart: disabled"),
+            "uninstall 後は disabled に戻るべき。\nstdout:\n{stdout}"
+        );
     }
 }

--- a/crates/shikomi-cli/tests/e2e_sc_ddm_002.rs
+++ b/crates/shikomi-cli/tests/e2e_sc_ddm_002.rs
@@ -1,0 +1,469 @@
+//! 受入テスト E2E — SC-DDM-002: daemon OS 自動起動（Sub-B）
+//!
+//! 対応受入基準: AC-DDM-07〜10
+//!   docs/acceptance-tests/scenarios/SC-DDM-002-daemon-autostart.md
+//! Vモデル: 受入テスト（最上位・完全ブラックボックス）
+//! 対応 TC: SC-DDM-002-TC-001〜004
+//! 対応 Issue: #127
+//!
+//! **ブラックボックス方針**:
+//!   `assert_cmd::Command::cargo_bin("shikomi")` でサブプロセスを起動し、
+//!   stdout / stderr / exit code とファイルシステム観測のみで判定する。
+//!   DB 直接確認・内部状態参照・テスト用裏口・内部関数呼び出しは一切行わない。
+//!
+//! **副作用隔離**:
+//!   `HOME` 環境変数を `tempfile::TempDir` にオーバーライドし、
+//!   実システムの設定ディレクトリ（`~/Library/LaunchAgents/` 等）への副作用を排除する。
+//!   環境変数操作は `#[serial_test::serial]` で直列実行し、競合を防ぐ。
+//!
+//! **CI 実行条件**:
+//!   Linux CI: XDG Autostart バックエンド（D-Bus 未設定のため systemd フォールバック）
+//!   macOS CI: launchd バックエンド（ファイル書き込み部分のみ検証、launchctl は ignore）
+//!   Windows CI: 本テストファイルは #[cfg(unix)] でスコープ外
+
+#![cfg(unix)]
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serial_test::serial;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+/// テスト用の HOME ディレクトリを作成し `(TempDir, PathBuf)` を返す。
+/// TempDir が Drop するまで HOME オーバーライドが有効。
+fn make_home_dir() -> TempDir {
+    TempDir::new().expect("tempdir")
+}
+
+/// このテスト環境でインストールされる自動起動ファイルのパスを推定する。
+///
+/// Linux (D-Bus 未設定 → XDG Autostart): `~/.config/autostart/shikomi-daemon.desktop`
+/// macOS: `~/Library/LaunchAgents/dev.shikomi.daemon.plist`
+/// その他: None（パス確認スキップ）
+fn expected_autostart_file(home: &std::path::Path) -> Option<PathBuf> {
+    if cfg!(target_os = "linux") {
+        Some(home.join(".config/autostart/shikomi-daemon.desktop"))
+    } else if cfg!(target_os = "macos") {
+        Some(home.join("Library/LaunchAgents/dev.shikomi.daemon.plist"))
+    } else {
+        None
+    }
+}
+
+/// `shikomi daemon <args>` を `HOME=home_dir` 環境で実行して結果を返す。
+fn run_daemon_cmd(home_dir: &std::path::Path, args: &[&str]) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("shikomi")
+        .expect("shikomi binary")
+        .env("HOME", home_dir)
+        .arg("daemon")
+        .args(args)
+        .assert()
+}
+
+// ---------------------------------------------------------------------------
+// SC-DDM-002-TC-001: AC-DDM-07 — install 成功 + 自動起動ファイル配置確認
+// ---------------------------------------------------------------------------
+
+/// AC-DDM-07: `shikomi daemon install` が成功し、
+///   stdout に "shikomi-daemon autostart enabled" + OS 固有 hint が出力され、
+///   OS 固有の自動起動ファイルが配置されること。
+///
+/// 設計根拠: docs/acceptance-tests/scenarios/SC-DDM-002-daemon-autostart.md §AC-DDM-07
+/// REQ-DDM-010, REQ-DDM-013〜016
+#[test]
+#[serial]
+fn sc_ddm_002_tc001_ac07_daemon_install_creates_autostart_file() {
+    let home = make_home_dir();
+
+    run_daemon_cmd(home.path(), &["install"])
+        // exit 0
+        .success()
+        // stdout に成功メッセージ
+        .stdout(predicate::str::contains("shikomi-daemon autostart enabled"))
+        // stdout に OS 固有 hint
+        .stdout(predicate::str::contains("hint:"))
+        // stderr に "error:" なし（tracing INFO は許容）
+        .stderr(predicate::str::contains("error:").not());
+
+    // OS 固有の自動起動ファイルが配置されていること
+    if let Some(autostart_path) = expected_autostart_file(home.path()) {
+        assert!(
+            autostart_path.exists(),
+            "AC-DDM-07: 自動起動ファイルが配置されるべき: {}",
+            autostart_path.display()
+        );
+        // プレースホルダが残っていないこと
+        let content = std::fs::read_to_string(&autostart_path)
+            .expect("autostart file readable");
+        assert!(
+            !content.contains("{daemon_path}"),
+            "AC-DDM-07: テンプレートプレースホルダ {{daemon_path}} が残っているべきでない\n内容:\n{content}"
+        );
+        assert!(
+            !content.contains("{log_dir}"),
+            "AC-DDM-07: テンプレートプレースホルダ {{log_dir}} が残っているべきでない\n内容:\n{content}"
+        );
+        // 秘密情報非含有（横串アサート）
+        let lower = content.to_lowercase();
+        assert!(
+            !lower.contains("password") && !lower.contains("secret") && !lower.contains("token"),
+            "AC-DDM-07: 自動起動ファイルに秘密情報が含まれるべきでない\n内容:\n{content}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SC-DDM-002-TC-002: AC-DDM-08 — uninstall 成功 + ファイル削除確認
+// ---------------------------------------------------------------------------
+
+/// AC-DDM-08: `shikomi daemon uninstall` が成功し、
+///   stdout に "shikomi-daemon autostart disabled" が出力され、
+///   自動起動ファイルが削除されること。
+///
+/// 設計根拠: docs/acceptance-tests/scenarios/SC-DDM-002-daemon-autostart.md §AC-DDM-08
+/// REQ-DDM-011, REQ-DDM-013〜016
+#[test]
+#[serial]
+fn sc_ddm_002_tc002_ac08_daemon_uninstall_removes_autostart_file() {
+    let home = make_home_dir();
+
+    // 前提: install 済み状態にする
+    run_daemon_cmd(home.path(), &["install"])
+        .success();
+
+    // autostart ファイルが存在することを確認してから uninstall
+    if let Some(autostart_path) = expected_autostart_file(home.path()) {
+        assert!(
+            autostart_path.exists(),
+            "AC-DDM-08 前提: install 後にファイルが存在するべき"
+        );
+    }
+
+    run_daemon_cmd(home.path(), &["uninstall"])
+        // exit 0
+        .success()
+        // stdout に成功メッセージ
+        .stdout(predicate::str::contains("shikomi-daemon autostart disabled"))
+        // stderr に "error:" なし
+        .stderr(predicate::str::contains("error:").not());
+
+    // 自動起動ファイルが削除されていること
+    if let Some(autostart_path) = expected_autostart_file(home.path()) {
+        assert!(
+            !autostart_path.exists(),
+            "AC-DDM-08: uninstall 後に自動起動ファイルが存在するべきでない: {}",
+            autostart_path.display()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SC-DDM-002-TC-003: AC-DDM-09 — status が常に exit 0 + 2 行出力
+// ---------------------------------------------------------------------------
+
+/// AC-DDM-09 シナリオ C: `--no-ipc` フラグ指定時に
+///   stdout 1 行目が "daemon: unknown (--no-ipc)"、
+///   stdout 2 行目が "autostart: enabled" または "autostart: disabled"、
+///   かつ常に exit 0 で終了すること。
+///
+/// 設計根拠: docs/acceptance-tests/scenarios/SC-DDM-002-daemon-autostart.md §AC-DDM-09 シナリオ C
+/// REQ-DDM-012 §設計原則（情報提供のみ、副作用なし）
+#[test]
+#[serial]
+fn sc_ddm_002_tc003_ac09_daemon_status_no_ipc_always_exit_0() {
+    let home = make_home_dir();
+
+    // ケース A: autostart 未登録状態
+    {
+        let output = Command::cargo_bin("shikomi")
+            .expect("shikomi binary")
+            .env("HOME", home.path())
+            .args(["daemon", "status", "--no-ipc"])
+            .output()
+            .expect("実行失敗");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "AC-DDM-09: daemon status は常に exit 0 であるべき。\
+             exit={:?} stdout={stdout} stderr={stderr}",
+            output.status.code()
+        );
+        let lines: Vec<&str> = stdout.lines().collect();
+        assert!(
+            lines.len() >= 2,
+            "AC-DDM-09: stdout は 2 行以上であるべき。\nstdout:\n{stdout}"
+        );
+        assert_eq!(
+            lines[0], "daemon: unknown (--no-ipc)",
+            "AC-DDM-09: 1 行目は 'daemon: unknown (--no-ipc)' であるべき"
+        );
+        assert_eq!(
+            lines[1], "autostart: disabled",
+            "AC-DDM-09: autostart 未登録状態では 2 行目が 'autostart: disabled' であるべき"
+        );
+        assert!(
+            !stderr.contains("error:"),
+            "AC-DDM-09: stderr に 'error:' が含まれるべきでない。stderr:\n{stderr}"
+        );
+    }
+
+    // ケース B: install 後 → autostart: enabled
+    {
+        run_daemon_cmd(home.path(), &["install"]).success();
+
+        let output = Command::cargo_bin("shikomi")
+            .expect("shikomi binary")
+            .env("HOME", home.path())
+            .args(["daemon", "status", "--no-ipc"])
+            .output()
+            .expect("実行失敗");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success(),
+            "AC-DDM-09: daemon status は install 後も exit 0 であるべき"
+        );
+        let lines: Vec<&str> = stdout.lines().collect();
+        assert!(lines.len() >= 2, "AC-DDM-09: stdout は 2 行以上であるべき");
+        assert_eq!(lines[0], "daemon: unknown (--no-ipc)");
+        assert_eq!(
+            lines[1], "autostart: enabled",
+            "AC-DDM-09: install 後は 2 行目が 'autostart: enabled' であるべき"
+        );
+    }
+}
+
+/// AC-DDM-09 シナリオ B: daemon 未起動 + autostart 未登録で
+///   stdout に "daemon: not running" + "autostart: disabled" が出力され、
+///   exit 0 であること。
+///
+/// REQ-DDM-012 §設計原則（確認できない状態も結果として出力する）
+#[test]
+#[serial]
+fn sc_ddm_002_tc003b_ac09_daemon_status_not_running_when_no_daemon() {
+    let home = make_home_dir();
+    // XDG_RUNTIME_DIR を存在しないパスに向けて daemon を「not running」にする
+    let fake_xdg = TempDir::new().expect("tempdir");
+    // sock ファイルを作らないことで「not running」を再現
+
+    let output = Command::cargo_bin("shikomi")
+        .expect("shikomi binary")
+        .env("HOME", home.path())
+        .env("XDG_RUNTIME_DIR", fake_xdg.path())
+        .args(["daemon", "status"])
+        .output()
+        .expect("実行失敗");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "AC-DDM-09: daemon status は daemon 未起動でも exit 0 であるべき。\
+         exit={:?} stdout={stdout} stderr={stderr}",
+        output.status.code()
+    );
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.len() >= 2, "AC-DDM-09: stdout は 2 行以上であるべき");
+    assert_eq!(
+        lines[0], "daemon: not running",
+        "AC-DDM-09: daemon 未起動時の 1 行目は 'daemon: not running' であるべき"
+    );
+    assert_eq!(
+        lines[1], "autostart: disabled",
+        "AC-DDM-09: autostart 未登録時の 2 行目は 'autostart: disabled' であるべき"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SC-DDM-002-TC-004: AC-DDM-10 — install 冪等性（2 回連続で exit 0）
+// ---------------------------------------------------------------------------
+
+/// AC-DDM-10: `shikomi daemon install` を 2 回連続実行しても
+///   2 回目も exit 0 で成功し、自動起動ファイルが依然として存在すること。
+///
+/// 設計根拠: docs/acceptance-tests/scenarios/SC-DDM-002-daemon-autostart.md §AC-DDM-10
+/// REQ-DDM-010 §設計原則（冪等性）
+#[test]
+#[serial]
+fn sc_ddm_002_tc004_ac10_daemon_install_idempotent() {
+    let home = make_home_dir();
+
+    // 1 回目
+    run_daemon_cmd(home.path(), &["install"])
+        .success()
+        .stdout(predicate::str::contains("shikomi-daemon autostart enabled"));
+
+    // 2 回目（冪等性確認）
+    run_daemon_cmd(home.path(), &["install"])
+        .success()
+        .stdout(predicate::str::contains("shikomi-daemon autostart enabled"))
+        .stderr(predicate::str::contains("error:").not());
+
+    // ファイルが依然として存在すること
+    if let Some(autostart_path) = expected_autostart_file(home.path()) {
+        assert!(
+            autostart_path.exists(),
+            "AC-DDM-10: 2 回目 install 後も自動起動ファイルが存在するべき"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 追加 IT: --quiet フラグで成功メッセージが抑制されること（IT-128 相当）
+// ---------------------------------------------------------------------------
+
+/// `--quiet` フラグ指定時に install の成功メッセージが stdout に出力されないこと。
+/// tracing は stderr に出力される（--quiet は stdout のみ制御）。
+///
+/// 設計根拠: docs/features/daemon-default-mode/autostart/test-design/integration.md §TC-IT-127 相当
+/// REQ-DDM-010 / detailed-design §run_daemon_subcommand (quiet=true 分岐)
+#[test]
+#[serial]
+fn tc_it_127_quiet_flag_suppresses_install_success_message() {
+    let home = make_home_dir();
+
+    let output = Command::cargo_bin("shikomi")
+        .expect("shikomi binary")
+        .env("HOME", home.path())
+        .args(["daemon", "install", "--quiet"])
+        .output()
+        .expect("実行失敗");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "--quiet install は exit 0 であるべき。exit={:?} stderr={stderr}",
+        output.status.code()
+    );
+    assert!(
+        !stdout.contains("shikomi-daemon autostart enabled"),
+        "--quiet 時に stdout に成功メッセージが出力されるべきでない。\nstdout:\n{stdout}"
+    );
+    // exit 0 で成功しているのに stdout が空（hint も出ない）
+    assert!(
+        stdout.trim().is_empty(),
+        "--quiet 時に stdout は空であるべき。\nstdout:\n{stdout}"
+    );
+    // stderr に error: が含まれないこと
+    assert!(
+        !stderr.contains("error:"),
+        "--quiet install の stderr に 'error:' が含まれるべきでない。\nstderr:\n{stderr}"
+    );
+}
+
+/// `--quiet` フラグ指定時に uninstall の成功メッセージが stdout に出力されないこと。
+///
+/// REQ-DDM-011 / detailed-design §run_daemon_subcommand (quiet=true 分岐)
+#[test]
+#[serial]
+fn tc_it_128_quiet_flag_suppresses_uninstall_success_message() {
+    let home = make_home_dir();
+
+    // 前提: install 済み
+    run_daemon_cmd(home.path(), &["install"]).success();
+
+    let output = Command::cargo_bin("shikomi")
+        .expect("shikomi binary")
+        .env("HOME", home.path())
+        .args(["daemon", "uninstall", "--quiet"])
+        .output()
+        .expect("実行失敗");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "--quiet uninstall は exit 0 であるべき。exit={:?} stderr={stderr}",
+        output.status.code()
+    );
+    assert!(
+        !stdout.contains("shikomi-daemon autostart disabled"),
+        "--quiet 時に stdout に成功メッセージが出力されるべきでない。\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "--quiet 時に stdout は空であるべき。\nstdout:\n{stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 追加 IT: uninstall 冪等性（未登録でも exit 0）
+// ---------------------------------------------------------------------------
+
+/// `shikomi daemon uninstall` を未登録状態から実行しても exit 0 で成功すること（冪等性）。
+///
+/// REQ-DDM-011 §設計原則（未登録の場合は冪等、成功扱い）
+#[test]
+#[serial]
+fn tc_it_128b_daemon_uninstall_idempotent_when_not_registered() {
+    let home = make_home_dir();
+    // install せずに直接 uninstall
+    run_daemon_cmd(home.path(), &["uninstall"])
+        .success()
+        .stdout(predicate::str::contains("shikomi-daemon autostart disabled"))
+        .stderr(predicate::str::contains("error:").not());
+}
+
+// ---------------------------------------------------------------------------
+// 追加 IT: install → status → uninstall → status のサイクル検証
+// ---------------------------------------------------------------------------
+
+/// install → status(no-ipc) → uninstall → status(no-ipc) のサイクルで
+///   autostart 状態が正しく反映されること。
+///
+/// REQ-DDM-010〜012 / AC-DDM-07〜09
+#[test]
+#[serial]
+fn tc_it_132_status_reflects_install_uninstall_cycle() {
+    let home = make_home_dir();
+
+    // 初期状態: disabled
+    {
+        let output = Command::cargo_bin("shikomi")
+            .expect("shikomi binary")
+            .env("HOME", home.path())
+            .args(["daemon", "status", "--no-ipc"])
+            .output()
+            .expect("実行失敗");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("autostart: disabled"), "初期状態は disabled であるべき。\nstdout:\n{stdout}");
+    }
+
+    // install 後: enabled
+    {
+        run_daemon_cmd(home.path(), &["install"]).success();
+        let output = Command::cargo_bin("shikomi")
+            .expect("shikomi binary")
+            .env("HOME", home.path())
+            .args(["daemon", "status", "--no-ipc"])
+            .output()
+            .expect("実行失敗");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("autostart: enabled"), "install 後は enabled であるべき。\nstdout:\n{stdout}");
+    }
+
+    // uninstall 後: disabled に戻る
+    {
+        run_daemon_cmd(home.path(), &["uninstall"]).success();
+        let output = Command::cargo_bin("shikomi")
+            .expect("shikomi binary")
+            .env("HOME", home.path())
+            .args(["daemon", "status", "--no-ipc"])
+            .output()
+            .expect("実行失敗");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("autostart: disabled"), "uninstall 後は disabled に戻るべき。\nstdout:\n{stdout}");
+    }
+}

--- a/justfile
+++ b/justfile
@@ -53,7 +53,10 @@ test-infra:
 # `shikomi-infra/test-fixtures` feature を有効化して `ensure_vault_dir` / `ensure_vault_file`
 # テスト専用ヘルパを利用可能にする（Issue #89 工程5 P1-① 対応）。
 # CI / lefthook / 手動 3 経路は本レシピ 1 行で SSoT 化。
+# Sub-B (#127): `resolve_daemon_path()` の Fail Fast 仕様（exists() 確認）を満たすため、
+# e2e_sc_ddm_002 実行前に shikomi-daemon バイナリをビルドしておく必要がある。
 test-cli:
+    cargo build -p shikomi-daemon
     cargo test --no-fail-fast --all-targets -p shikomi-cli --features "shikomi-infra/test-fixtures"
 
 # Sub-F (#44) 工程4 マユリ Bug-F-003 解消: shikomi-daemon 専用テスト CI ジョブ。


### PR DESCRIPTION
## Summary

- `AutostartBackend` trait + `AutostartError` を `crates/shikomi-cli/src/autostart/mod.rs` に実装
- OS 別バックエンド: `LaunchdBackend`（macOS）/ `SystemdBackend`（Linux systemd）/ `XdgAutostartBackend`（Linux fallback）/ `WindowsTaskSchedulerBackend`（Windows）
- `shikomi daemon install/uninstall/status` サブコマンドを `cli.rs` / `lib.rs` に追加
- `presenter/success.rs` に `render_autostart_installed()` / `render_autostart_uninstalled()` 追加（ペガサス指摘②対応）
- `presenter/error.rs` に MSG-CLI-120 / MSG-CLI-121 追加
- `daemon status` で IPC probe 200ms タイムアウト実装（`tokio::time::timeout`）
- **TC-UT-159 期待値を 2→3 に更新**（daemon status IPC probe 追加による `no_ipc` 参照増加）

## Closes

Closes #127

## Test plan

- [ ] `cargo test -p shikomi-cli --lib` — 全 151 テスト PASS（TC-UT-159 含む）
- [ ] `cargo clippy -p shikomi-cli` — エラー 0 件
- [ ] `cargo fmt --all -- --check` — diff なし
- [ ] CI 全ジョブ通過確認

## テスト担当への確認観点

- `TC-UT-176`（TC-UT-159 が 3 件参照を正しく検証できているか）
- autostart 各バックエンドの install/uninstall 冪等性（Linux systemd / XDG どちらが選択されるか）
- `shikomi daemon status --no-ipc` で IPC probe をスキップして `daemon: unknown (--no-ipc)` が返るか
- `quiet` フラグ時に成功メッセージが抑制され、`tracing::info!` は出力されるか