### PR TITLE
feat(cli): MSG-CLI-110 に autostart hint 追加 (Issue #134)

### DIFF
--- a/crates/shikomi-cli/src/presenter/error.rs
+++ b/crates/shikomi-cli/src/presenter/error.rs
@@ -83,6 +83,12 @@ fn render_daemon_not_running(path: &std::path::Path, locale: Locale) -> String {
             "hint: または --vault-dir <DIR> で vault.db の所在ディレクトリを指定してください（同ディレクトリの shikomi.sock が daemon socket として使われます）\n",
         );
     }
+    // Issue #134 (MSG-CLI-110): Sub-B 完了後の autostart hint 追加
+    // (basic-design.md §Sub-B完了後に更新するメッセージ)
+    out.push_str("hint: or enable autostart: shikomi daemon install\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str("hint: または自動起動を有効にする場合: shikomi daemon install\n");
+    }
     out
 }
 

--- a/crates/shikomi-cli/src/presenter/error.rs
+++ b/crates/shikomi-cli/src/presenter/error.rs
@@ -445,4 +445,39 @@ mod tests {
             );
         }
     }
+
+    /// TC-UT-158b (Issue #134 / MSG-CLI-110): `render_daemon_not_running()` の出力に
+    /// `"shikomi daemon install"` autostart hint が含まれること。
+    ///
+    /// 英語・JapaneseEn 両ロケールで検証する。
+    /// 設計根拠: basic-design.md §Sub-B完了後に更新するメッセージ / §テスト戦略 TC-UT-158 拡張
+    #[test]
+    fn tc_ut_158b_daemon_not_running_contains_autostart_hint_for_english_locale() {
+        use std::path::PathBuf;
+        let err = CliError::DaemonNotRunning(PathBuf::from("/tmp/test.sock"));
+        let rendered = render_error(&err, Locale::English);
+        assert!(
+            rendered.contains("shikomi daemon install"),
+            "MSG-CLI-110 English must contain autostart hint 'shikomi daemon install': {rendered:?}"
+        );
+    }
+
+    /// TC-UT-158c (Issue #134 / MSG-CLI-110): JapaneseEn ロケールで
+    /// `"shikomi daemon install"` と日本語 hint 行の両方が含まれること。
+    ///
+    /// 設計根拠: basic-design.md §Sub-B完了後に更新するメッセージ / §テスト戦略 TC-UT-158 拡張
+    #[test]
+    fn tc_ut_158c_daemon_not_running_contains_autostart_hint_for_japanese_en_locale() {
+        use std::path::PathBuf;
+        let err = CliError::DaemonNotRunning(PathBuf::from("/tmp/test.sock"));
+        let rendered = render_error(&err, Locale::JapaneseEn);
+        assert!(
+            rendered.contains("shikomi daemon install"),
+            "MSG-CLI-110 JapaneseEn must contain 'shikomi daemon install': {rendered:?}"
+        );
+        assert!(
+            rendered.contains("または自動起動を有効にする場合"),
+            "MSG-CLI-110 JapaneseEn must contain Japanese autostart hint: {rendered:?}"
+        );
+    }
 }

--- a/docs/features/daemon-default-mode/autostart/basic-design.md
+++ b/docs/features/daemon-default-mode/autostart/basic-design.md
@@ -140,7 +140,7 @@
 
 | ID | 変更内容 |
 |----|---------|
-| MSG-CLI-110 hint（Sub-A で更新済み）| Sub-B 完了後: `"hint: or enable autostart: shikomi daemon install"` を追加（Issue #134 で実装予定）|
+| MSG-CLI-110 hint（Sub-A で更新済み）| Sub-B 完了後: 英語 `"hint: or enable autostart: shikomi daemon install"` / 日本語 `"hint: または自動起動を有効にする場合: shikomi daemon install"` を追加（Issue #134 で実装予定）。確定文面 SSoT は `daemon-ipc/basic-design/error.md §MSG-CLI-110 確定文面`|
 
 ## セキュリティ考慮
 

--- a/docs/features/daemon-default-mode/autostart/basic-design.md
+++ b/docs/features/daemon-default-mode/autostart/basic-design.md
@@ -140,7 +140,7 @@
 
 | ID | 変更内容 |
 |----|---------|
-| MSG-CLI-110 hint（Sub-A で更新済み）| Sub-B 完了後: 英語 `"hint: or enable autostart: shikomi daemon install"` / 日本語 `"hint: または自動起動を有効にする場合: shikomi daemon install"` を追加（Issue #134 で実装予定）。確定文面 SSoT は `daemon-ipc/basic-design/error.md §MSG-CLI-110 確定文面`|
+| MSG-CLI-110 hint（Sub-A で更新済み）| Sub-B 完了後: 英語 `"hint: or enable autostart: shikomi daemon install"` / 日本語 `"hint: または自動起動を有効にする場合: shikomi daemon install"` を追加（Issue #134 で実装済み）。確定文面 SSoT は `daemon-ipc/basic-design/error.md §MSG-CLI-110 確定文面`|
 
 ## セキュリティ考慮
 

--- a/docs/features/daemon-default-mode/cli/basic-design.md
+++ b/docs/features/daemon-default-mode/cli/basic-design.md
@@ -54,10 +54,10 @@
 | OS | hint 行（英語） |
 |----|--------------|
 | Linux / macOS 基本 | `hint: start the daemon with: shikomi-daemon &` |
-| macOS launchd（Sub-B 完了後追記予定）| `hint: or enable autostart: shikomi daemon enable-autostart` |
 | Windows | `hint: start the daemon with: Start-Process -NoNewWindow shikomi-daemon` |
+| 全 OS 共通（Sub-B 完了 — Issue #127 / #134）| `hint: or enable autostart: shikomi daemon install` |
 
-**Phase 2 過渡期（Sub-B 未完了）**: Sub-B（Issue #127）完了まで、autostart hint は出力しない。3 OS の手動起動コマンドのみ案内する。Sub-B 完了後に hint 文面を更新する別 PR を立てる。
+**Sub-B 完了（Issue #127）**: `shikomi daemon install` サブコマンドが実装済み。autostart hint は Issue #134 で `render_daemon_not_running()` に追加済み。確定文面は `daemon-ipc/basic-design/error.md §MSG-CLI-110 確定文面` を参照。
 
 ### REQ-DDM-005: vault サブコマンドの IPC 強制を `--no-ipc` から保護
 

--- a/docs/features/daemon-default-mode/cli/detailed-design.md
+++ b/docs/features/daemon-default-mode/cli/detailed-design.md
@@ -184,10 +184,10 @@ hint: start the daemon first: shikomi-daemon &   (Linux/macOS)
 hint: start the daemon first: Start-Process -NoNewWindow shikomi-daemon   (Windows)
 ```
 
-**Sub-B 移行後（Issue #127 完了後に別 PR で追記）**:
+**Sub-B 完了（Issue #127 / #134 で実装済み）**:
 
 ```
-hint: or enable autostart: shikomi daemon enable-autostart
+hint: or enable autostart: shikomi daemon install
 ```
 
 **設計判断**:

--- a/docs/features/daemon-default-mode/feature-spec.md
+++ b/docs/features/daemon-default-mode/feature-spec.md
@@ -93,7 +93,7 @@ Phase 1（`daemon-ipc` feature）では `--ipc` フラグが opt-in だった。
 | 項目 | 理由 |
 |------|------|
 | OS 再起動後の daemon 自動起動実証 | CI 環境での OS 再起動テストは実施不可。手動受入テストとして実施する（`SC-DDM-002` §手動確認事項）|
-| MSG-CLI-110 hint への `shikomi daemon install` 誘導追加 | Sub-B 完了後の別 PR で実施（`autostart/basic-design.md §Sub-B 完了後に更新するメッセージ`）|
+| MSG-CLI-110 hint への `shikomi daemon install` 誘導追加 | Issue #134 / PR #138 で完了（`autostart/basic-design.md §Sub-B 完了後に更新するメッセージ` 参照）|
 | `--ipc` 廃止の移行支援 CLI（`shikomi migrate` 等）| YAGNI（移行コストは軽微、`CHANGELOG.md` で十分）|
 | IPC プロトコルの変更 | `daemon-ipc` feature の protocol は `V1` で凍結済み（`ipc-protocol.md §バージョニングルール`）|
 | ホットキー / クリップボード / 暗号化 vault の Phase 2 対応 | 各後続 feature のスコープ |

--- a/docs/features/daemon-default-mode/system-test-design.md
+++ b/docs/features/daemon-default-mode/system-test-design.md
@@ -193,7 +193,7 @@
 | OS 再起動後の daemon 自動起動実証 | CI 環境での OS 再起動は不可。`SC-DDM-002 §手動確認事項` として記録 |
 | `--no-ipc` と暗号化 vault の組み合わせ | `daemon-vault-encryption` feature スコープ（未起票）|
 | Windows Named Pipe + `--no-ipc` 同時接続 | CI 環境で `\\.\pipe\` 経路のテスト設定が複雑。Phase 2 過渡期は Linux / macOS のみ重点確認 |
-| MSG-CLI-110 hint への `shikomi daemon install` 誘導 | Sub-B 完了後の別 PR（`autostart/basic-design.md §Sub-B 完了後に更新するメッセージ`）|
+| MSG-CLI-110 hint への `shikomi daemon install` 誘導 | Issue #134 / PR #138 で完了（`autostart/basic-design.md §Sub-B 完了後に更新するメッセージ` 参照）|
 
 ## 6. 受入テストシナリオとの対応
 

--- a/docs/features/daemon-ipc/basic-design/error.md
+++ b/docs/features/daemon-ipc/basic-design/error.md
@@ -90,10 +90,12 @@ hint は **3 OS（Linux / macOS / Windows）の起動コマンドを並記した
 ```
 error: shikomi-daemon is not running (socket {path} unreachable)
 hint: start the daemon in a separate terminal by running one of:
-hint:   Linux/macOS: 'shikomi-daemon &'
-hint:   Linux (systemd user):  'systemctl --user start shikomi-daemon'
-hint:   macOS (launchd user):  'launchctl kickstart gui/$(id -u)/dev.shikomi.daemon'
-hint:   Windows (PowerShell):  'Start-Process -NoNewWindow shikomi-daemon'
+hint:   Linux/macOS:            'shikomi-daemon &'
+hint:   Linux (systemd user):   'systemctl --user start shikomi-daemon'
+hint:   macOS (launchd user):   'launchctl kickstart gui/$(id -u)/dev.shikomi.daemon'
+hint:   Windows (PowerShell):   'Start-Process -NoNewWindow shikomi-daemon'
+hint: or pass --vault-dir <DIR> to point at the vault.db directory whose shikomi.sock you want to use
+hint: or enable autostart: shikomi daemon install
 ```
 
 **日本語併記（`Locale::JapaneseEn`）**: 英語原文をそのまま出力し、直下に以下の日本語訳を出す:
@@ -105,13 +107,16 @@ hint:   Linux/macOS:            'shikomi-daemon &'
 hint:   Linux (systemd user):   'systemctl --user start shikomi-daemon'
 hint:   macOS (launchd user):   'launchctl kickstart gui/$(id -u)/dev.shikomi.daemon'
 hint:   Windows (PowerShell):   'Start-Process -NoNewWindow shikomi-daemon'
+hint: または --vault-dir <DIR> で vault.db の所在ディレクトリを指定してください（同ディレクトリの shikomi.sock が daemon socket として使われます）
+hint: または自動起動を有効にする場合: shikomi daemon install
 ```
 
 **設計規約**:
 - hint 行は複数行出力（`println!` 相当、`render_error` が `\n` 連結で返す）
 - 3 OS 並記の根拠: ペガサス指摘 ② に対応、受入基準 1 / 13 の 3 OS matrix サポートと整合
 - systemd / launchd の起動コマンドは `process-model.md` §4.1 ルール 3 / 4 の規定と整合（将来 feature でサービス定義ファイルを自動配置するが、本 feature 時点では手動配置 + 手動 `systemctl` / `launchctl` 前提）
-- 「存在しないコマンドへの誘導禁止」: `shikomi daemon start` / `shikomi daemon stop` 等のサブコマンドは本 feature でも将来 Issue でも**追加予定はない**（daemon は独立バイナリとして扱う方針、`process-model.md` §4.1）
+- 「存在しないコマンドへの誘導禁止」: `shikomi daemon start` / `shikomi daemon stop` 等のサブコマンドは本 feature でも将来 Issue でも**追加予定はない**（daemon は独立バイナリとして扱う方針、`process-model.md` §4.1）。`shikomi daemon install` は Sub-B（Issue #127）で実装済みの実在コマンドであり例外
+- `--vault-dir` hint（Issue #75 Bug-F-007 解消）および autostart hint（Issue #134）は上記英日ブロックが SSoT
 
 ### MSG-CLI-111 確定文面（本書が単一真実源）
 


### PR DESCRIPTION
## Summary

- `render_daemon_not_running()` 末尾に `hint: or enable autostart: shikomi daemon install` を追加
- `JapaneseEn` ロケール向けに `hint: または自動起動を有効にする場合: shikomi daemon install` も追加
- 設計書 `basic-design.md §Sub-B完了後に更新するメッセージ` に従った実装

## 変更ファイル

- `crates/shikomi-cli/src/presenter/error.rs`

## 関連

Closes #134