### PR TITLE
docs(data-portability): feature-spec + domain 設計書 新規作成

### DIFF
--- a/docs/architecture/context/threat-model.md
+++ b/docs/architecture/context/threat-model.md
@@ -102,6 +102,27 @@ shikomi は「ホットキーで投入 → ユーザが即貼付」が主ユー�
 
 出典: https://v2.tauri.app/security/
 
+### 7.5 data-portability feature 固有の攻撃面（Issue #135 追加）
+
+`shikomi export` / `shikomi import` は vault データをローカルファイルとして読み書きする新しい攻撃面を開く。
+
+#### 7.5.1 STRIDE 補足
+
+| 脅威カテゴリ | data-portability 固有リスク | 対策 |
+|------------|---------------------------|------|
+| **I**nformation Disclosure | `--export-secrets` フラグで全 Secret kind レコードが平文 JSON ファイルに書き出される。誤操作・スクリプト自動化・CI 環境への出力が漏洩経路になる | (1) `MSG-CLI-145` を stderr に必ず出力（`--quiet` 抑止不可）。(2) export ファイルを `0600` で作成（同ユーザ内の他プロセスからの読み取りを OS レベルで阻止）。(3) デフォルト動作では Secret kind を `{"kind":"redacted"}` tagged union でリダクト |
+| **I**nformation Disclosure | export ファイルが `0644`（ワールドリーダブル）で作成された場合、同マシンの他ユーザが読み取り可能になる | `tempfile::Builder::new().permissions(0o600)` で書き込み前にパーミッションを設定する（`threat-model.md §7.1` の vault.db と同等の保護水準）|
+| **T**ampering | 攻撃者が import ファイルを改ざんして不正なレコード（例: 既知のラベル・ID を持つ偽レコード）を注入する | `ImportValidator` が `format_version` / 重複 ID / Redacted payload を検出。ファイル完全性検証（HMAC / 署名）は将来拡張（MVP スコープ外）。ユーザーは信頼できるソースからのファイルのみ import することを README で明示する |
+| **D**enial of Service | 巨大な import ファイル（数 GB）を渡して OOM を引き起こす | `serde_json::from_reader` のストリーミング読み込みを使用する（Sub-B 実装ガイドライン）。レコード数の上限チェック（例: 100 万件超で警告）は将来拡張 |
+
+#### 7.5.2 OWASP A04 補足（Insecure Design）
+
+`--export-secrets` は意図的に設計された危険操作である。誤操作防止のため:
+
+1. `MSG-CLI-145` は `--quiet` フラグでも抑止不可にする
+2. エラーではなく警告（exit 0 で続行）とするが、stderr への出力は保証する
+3. 将来拡張として「Are you sure? (yes/no)」確認プロンプトを Sub-B の後続 Issue で検討する（MVP スコープ外）
+
 ## 8. OWASP Top 10 対応表（2021 版・デスクトップアプリ適用）
 
 OWASP Top 10 はもともと Web アプリ向けだが、サーバを持たないデスクトップアプリでも**多くが該当する**（認可・ログ・暗号失敗・依存コンポーネント等）。設計上の取扱を以下に明示する。
@@ -111,7 +132,7 @@ OWASP Top 10 はもともと Web アプリ向けだが、サーバを持たな�
 | **A01: Broken Access Control** | 該当（ローカル多重プロセス・多重ユーザ） | IPC の UID 検証＋ソケット `0700`（`process-model.md` §4.2）。vault ファイルパーミッション `0600`、ディレクトリ `0700`。Windows は同等の ACL を SDDL で設定 |
 | **A02: Cryptographic Failures** | **暗号化モード（オプトイン）で該当** | 暗号化モード有効時のみ AEAD（AES-256-GCM）＋ Argon2id（OWASP 推奨 `m=19456, t=2, p=1`）を適用。nonce は CSPRNG から毎回 96bit 生成、vault 内に per-record 記録（`../tech-stack.md` §2.4 参照）。VEK は `secrecy` + `zeroize`。MAC（GMAC タグ）で改竄検知。**平文モードは暗号保護を行わないことを明示**（§7.0 のユーザ自己責任リスク表を参照）。デフォルト平文を選ぶ場合、A02 は「暗号を使わない設計判断」として該当外だが、代わりに §7.0 の脅威表を受容する |
 | **A03: Injection** | 該当（SQL / コマンド引数） | SQLite 操作は `rusqlite` の parameter binding のみ使用し生 SQL 連結禁止。CLI → daemon IPC は MessagePack 型付きスキーマ、文字列として shell に渡す経路なし |
-| **A04: Insecure Design** | 該当 | 本ドキュメント全体で扱う（プロセスモデル・Threat Model・Fail Secure 方針）。**デフォルト平文を Insecure Design と誤解されないよう**、§7.0 でリスク提示と UI 可視化（`[plaintext]` 表示）を強制する設計とした。「知らされず平文だった」事故を防ぐ |
+| **A04: Insecure Design** | 該当 | 本ドキュメント全体で扱う（プロセスモデル・Threat Model・Fail Secure 方針）。**デフォルト平文を Insecure Design と誤解されないよう**、§7.0 でリスク提示と UI 可視化（`[plaintext]` 表示）を強制する設計とした。「知らされず平文だった」事故を防ぐ。**data-portability 追加（§7.5.2）**: `--export-secrets` は意図的危険操作として `MSG-CLI-145` 警告を `--quiet` 抑止不可で出力する |
 | **A05: Security Misconfiguration** | 該当 | 既定値を安全側に（自動クリア 30 秒、アイドルタイムアウト 15 分、テレメトリ off、キーチェーン連携 off）。**vault 保護モードはデフォルト平文**だが、それを**必ず可視化する**ことで「設定ミスでオフのまま」を回避。デバッグビルドは別バイナリでリリースチャネルに混入しない。**GUI 追加対策（Issue #90）**: Tauri v2 WebView の `security.csp = "script-src 'self'"` を `tauri.conf.json` で強制し `unsafe-eval` / `unsafe-inline` を禁止する（§7.3.2 参照）。production ビルドで `devTools: false` 必須 |
 | **A06: Vulnerable and Outdated Components** | 該当 | `cargo-deny` + `cargo-audit` + Dependabot（`../dev.md` §5）。`Cargo.lock` をコミットし lock 書換え監査。SBOM（CycloneDX）をリリースに添付 |
 | **A07: Identification and Authentication Failures** | **暗号化モードで該当** | 暗号化モード時のみマスターパスワード認証を行うため、該当は暗号化モードに限定。Argon2id で総当たり耐性、連続失敗 5 回で **非同期タイマー（`tokio::time::sleep`）による指数バックオフを該当 IPC リクエストにのみ適用**（プロセス全体を blocking sleep させない＝ホットキー購読を継続、`../tech-stack.md` §2.4 参照）。IPC 認証（UID 検証は Issue #26 で実装、**セッショントークンは後続 Issue で追加予定**）は両モード共通。リカバリコード：BIP-39 24 語、1 度だけ表示、再発行不可（暗号化モード時のみ） |

--- a/docs/features/data-portability/domain/basic-design.md
+++ b/docs/features/data-portability/domain/basic-design.md
@@ -11,29 +11,31 @@
 
 | 項目 | 内容 |
 |------|------|
-| 入力 | `RecordPayload::Plaintext(secret)` + `kind: RecordKind` + `include_secrets: bool` |
-| 処理 | `include_secrets == false` かつ `kind == RecordKind::Secret` の場合 → `ExportRecordPayload::Redacted` に変換。それ以外は `ExportRecordPayload::Plaintext(String)` に変換（`expose_secret()` 呼び出しは本変換の中にのみ閉じる）。`RecordPayload::Encrypted` の場合は `ExportRecordPayload::Locked`（vault がロック済みエラーを上位で先行検出するため、このバリアントは実装上の安全網）|
-| 出力 | `ExportRecordPayload` enum（JSON では `{ "kind": "plaintext", "value": "..." }` / `{ "kind": "redacted" }` の tagged union）|
-| エラー時 | 該当なし（変換は純粋関数）|
-| 設計原則 | Tell, Don't Ask（`expose_secret` の呼び出しをこの型変換に閉じ込める）/ Fail Fast（`Encrypted` バリアントを `Locked` として明示的に表現）|
+| 入力 | `RecordPayload` + `kind: RecordKind` + `include_secrets: bool` |
+| 処理 | (1) `RecordPayload::Encrypted` の場合 → 即座に `Err(ExportError::VaultLocked)` を返す（Fail Fast）。(2) `include_secrets == false` かつ `kind == RecordKind::Secret` の場合 → `Ok(ExportRecordPayload::Redacted)` を返す。(3) それ以外 → `expose_secret()` を呼び出して `Ok(ExportRecordPayload::Plaintext { value })` を返す（`expose_secret` の呼び出しはこの分岐にのみ閉じる）|
+| 出力 | `Result<ExportRecordPayload, ExportError>` — `ExportRecordPayload` は `Plaintext { value: String }` / `Redacted` の 2 バリアント |
+| エラー時 | `RecordPayload::Encrypted` → `Err(ExportError::VaultLocked)` |
+| 設計原則 | Tell, Don't Ask（`expose_secret` の呼び出しをこの型変換に閉じ込める）/ Fail Fast（`Encrypted` ペイロードを即時エラーにし、不整合な中間状態を作らない）|
 
-**JSON tagged union 表現**:
+**`ExportRecordPayload` バリアント一覧（`Locked` バリアントは存在しない）**:
 
-| バリアント | JSON |
-|-----------|------|
-| `Plaintext(value)` | `{ "kind": "plaintext", "value": "<text>" }` |
-| `Redacted` | `{ "kind": "redacted" }` |
+| バリアント | JSON | 説明 |
+|-----------|------|------|
+| `Plaintext { value: String }` | `{ "kind": "plaintext", "value": "<text>" }` | 平文ペイロード |
+| `Redacted` | `{ "kind": "redacted" }` | Secret kind のリダクト表現 |
 
-`payload_redacted: bool` フラットフィールドではなく tagged union を採用する。理由: `"[REDACTED]"` 文字列リテラルと平文 `"[REDACTED]"` の衝突を構造的に排除するため。
+`payload_redacted: bool` フラットフィールドではなく tagged union を採用する。理由: `"[REDACTED]"` 文字列リテラルと平文 `"[REDACTED]"` の衝突を構造的に排除するため。`Locked` バリアントは設けない——`Encrypted` ペイロードは `from_record` で即時 `Err` にするため、この型に到達しない。
+
+**`ExportError` 型**: `from_record` の戻り値 `Err` に使う。`shikomi-core` の `portability/error.rs` に定義する（`ImportValidationError` と同居）。バリアント: `VaultLocked`。
 
 ### REQ-DP-002: `ExportRecord` — エクスポートレコード値オブジェクト
 
 | 項目 | 内容 |
 |------|------|
 | 入力 | `Record` + `include_secrets: bool` |
-| 処理 | `Record` の各フィールドを JSON シリアライズ可能な値オブジェクトに変換する。(1) `id` → `String`（UUID v7 の文字列表現）/ (2) `kind` → `RecordKind`（既存 serde 実装を流用）/ (3) `label` → `String` / (4) `payload` → `ExportRecordPayload::from_record(record, include_secrets)` / (5) `created_at` / `updated_at` → RFC 3339 文字列（マイクロ秒精度）/ (6) `hotkey` → `Option<String>`（`daemon-hotkey-clipboard` の `Hotkey::display_string()` 形式、`None` の場合は `null`）|
-| 出力 | `ExportRecord`（全フィールドに `Serialize` / `Deserialize` 実装）|
-| エラー時 | 該当なし（変換は純粋関数。`RecordPayload::Encrypted` は `ExportRecordPayload::Locked` として表現されるが、上位の `ExportUseCase` が事前チェックして `DataPortabilityError::VaultLocked` を返す）|
+| 処理 | `Record` の各フィールドを JSON シリアライズ可能な値オブジェクトに変換する。(1) `id` → `String`（UUID v7 の文字列表現）/ (2) `kind` → `RecordKind`（既存 serde 実装を流用）/ (3) `label` → `String` / (4) `payload` → `ExportRecordPayload::from_record(&payload, kind, include_secrets)?`（`ExportError::VaultLocked` を伝播）/ (5) `created_at` / `updated_at` → RFC 3339 文字列（マイクロ秒精度）/ (6) `hotkey` → `Option<String>`（`Hotkey::as_str()` の正規化文字列、`None` の場合は `null`）|
+| 出力 | `Result<ExportRecord, ExportError>`（全フィールドに `Serialize` / `Deserialize` 実装）|
+| エラー時 | `RecordPayload::Encrypted` を持つレコード → `Err(ExportError::VaultLocked)` を伝播 |
 | 設計原則 | DDD 値オブジェクト（不変・同一性なし）/ Composition（`ExportRecordPayload` に変換を委譲）|
 
 ### REQ-DP-003: `ExportPayload` — エクスポートファイル全体
@@ -65,15 +67,15 @@
 | `payload` | `Object` | `ExportRecordPayload` の tagged union |
 | `created_at` | `String` | RFC 3339 マイクロ秒精度 |
 | `updated_at` | `String` | RFC 3339 マイクロ秒精度 |
-| `hotkey` | `String` / `null` | ホットキー文字列または `null` |
+| `hotkey` | `String` / `null` | ホットキー正規化文字列（`"alt+ctrl+1"` 形式）または `null`。文字列形式の SSoT は `daemon-hotkey-clipboard/domain/basic-design.md §文字列表現`（`Hotkey::as_str()` の正規化形式: 修飾キーをアルファベット順に並べた `+` 区切り文字列）。この形式は `format_version: 1` で凍結。将来の形式変更は `format_version` バンプを要する |
 
 ### REQ-DP-004: `ImportPayload` / `ImportRecord` — インポート入力バリデーション前型
 
 | 項目 | 内容 |
 |------|------|
 | 入力 | ファイルから読み込んだ JSON 文字列（`serde_json::from_str`）|
-| 処理 | `ExportPayload` と同じスキーマで `Deserialize` する。`ImportPayload` は `ExportPayload` の alias ではなく独立した型とし、import 固有のバリデーション責務を持つ |
-| 出力 | `ImportPayload { format_version, exported_at, vault_name, records: Vec<ImportRecord> }` |
+| 処理 | `ExportPayload` と同じスキーマで `Deserialize` する。`ImportRecord` は `ExportRecord` の type alias（`type ImportRecord = ExportRecord`）とし、同一フィールド定義を 2 箇所で管理しない（DRY）。`ImportPayload` は `ExportPayload` の alias とせず独立型とする理由: import 固有のバリデーション責務（`ImportValidator::validate()`）を保有するため |
+| 出力 | `ImportPayload { format_version, exported_at, vault_name, records: Vec<ImportRecord> }`（`ImportRecord = ExportRecord` の alias）|
 | エラー時 | JSON パース失敗 → `DataPortabilityError::DeserializationFailed { reason }` |
 | 設計原則 | Fail Fast（JSON 構造不正は即時失敗）|
 
@@ -121,7 +123,8 @@ Sub-A では UI を持たない。メッセージ ID の予約のみ行う。
 | MSG-CLI-141 | export 先ファイルが既に存在（`--force` 未指定）| 1 |
 | MSG-CLI-142 | `--on-conflict error` で衝突発生 | 1 |
 | MSG-CLI-143 | JSON パース失敗 / フォーマットバージョン不一致 | 1 |
-| MSG-CLI-144 | `payload_redacted` レコードの import 試行 | 1 |
+| MSG-CLI-144 | `{"kind":"redacted"}` payload レコードの import 試行 | 1 |
+| MSG-CLI-145 | `--export-secrets` 実行時 Secret 平文 export 警告 | 0（stderr 出力のみ、処理は続行）|
 
 文面の確定は Sub-B（Issue #141）の `cli/basic-design.md §ユーザー向けメッセージ` で行う。
 
@@ -141,4 +144,15 @@ Sub-A では UI を持たない。メッセージ ID の予約のみ行う。
 |--------|------|
 | `shikomi-core` の `Record` / `RecordKind` / `RecordPayload`（実装済み）| `ExportRecord::from` の変換元 |
 | `serde` / `serde_json`（`shikomi-core` の `Cargo.toml` に既存）| JSON シリアライゼーション。追加依存なし |
-| `daemon-hotkey-clipboard` feature の `Hotkey::display_string()` | hotkey フィールドの文字列化。Sub-A では `hotkey` を `Option<String>` として扱う。`daemon-hotkey-clipboard` が未完了の場合、`hotkey` フィールドは常に `null` で export する（フォールバック）|
+| `daemon-hotkey-clipboard` feature の `Hotkey::as_str()`（`shikomi-core::vault::record::hotkey::Hotkey`）| hotkey フィールドの文字列化（SSoT: `daemon-hotkey-clipboard/domain/basic-design.md §文字列表現`）。`daemon-hotkey-clipboard` が未完了の場合、`hotkey` フィールドは常に `null` で export する（フォールバック）|
+
+## セキュリティ考慮
+
+| 脅威 | 対策 |
+|------|------|
+| Secret kind の平文漏洩 | `from_record` が `Result` を返し、`Encrypted` ペイロードは即時 `Err(ExportError::VaultLocked)` にする（Fail Fast）。`expose_secret` の呼び出しはこの関数にのみ閉じる |
+| `[REDACTED]` 文字列リテラルとの混同 | tagged union（`{"kind":"redacted"}`）を採用し、sentinel 文字列の衝突を構造的に排除する |
+| export ファイルの不正読取 | export ファイルは `0600`（owner read/write のみ）で作成する。`tempfile::Builder::new().permissions(0o600)` で書き込み前にパーミッションを設定する。vault.db と同等の保護水準を確保する（`threat-model.md §7.5` 参照）|
+| `--export-secrets` による誤操作全漏洩 | `MSG-CLI-145` を stderr に必ず出力する（`--quiet` でも抑止不可）。ユーザーが意図を確認できる最終ゲート |
+| import ファイルへの不正データ注入 | `ImportValidator` が `format_version` / 重複 ID / Redacted payload を検出して早期失敗させる |
+| 改ざんされた import ファイル | 完全性検証（HMAC 等）は YAGNI（MVP スコープ外）。export ファイルへの署名は将来拡張 |

--- a/docs/features/data-portability/domain/basic-design.md
+++ b/docs/features/data-portability/domain/basic-design.md
@@ -1,0 +1,144 @@
+# 基本設計書 — data-portability / domain（モジュール契約）
+
+<!-- feature: data-portability / sub-feature: domain / Issue #140 -->
+<!-- 配置先: docs/features/data-portability/domain/basic-design.md -->
+<!-- Vモデル対応: 階層 3（sub-feature モジュール契約）-->
+<!-- 親: ../feature-spec.md -->
+
+## §モジュール契約（機能要件）
+
+### REQ-DP-001: `ExportRecordPayload` — ペイロードリダクション表現
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `RecordPayload::Plaintext(secret)` + `kind: RecordKind` + `include_secrets: bool` |
+| 処理 | `include_secrets == false` かつ `kind == RecordKind::Secret` の場合 → `ExportRecordPayload::Redacted` に変換。それ以外は `ExportRecordPayload::Plaintext(String)` に変換（`expose_secret()` 呼び出しは本変換の中にのみ閉じる）。`RecordPayload::Encrypted` の場合は `ExportRecordPayload::Locked`（vault がロック済みエラーを上位で先行検出するため、このバリアントは実装上の安全網）|
+| 出力 | `ExportRecordPayload` enum（JSON では `{ "kind": "plaintext", "value": "..." }` / `{ "kind": "redacted" }` の tagged union）|
+| エラー時 | 該当なし（変換は純粋関数）|
+| 設計原則 | Tell, Don't Ask（`expose_secret` の呼び出しをこの型変換に閉じ込める）/ Fail Fast（`Encrypted` バリアントを `Locked` として明示的に表現）|
+
+**JSON tagged union 表現**:
+
+| バリアント | JSON |
+|-----------|------|
+| `Plaintext(value)` | `{ "kind": "plaintext", "value": "<text>" }` |
+| `Redacted` | `{ "kind": "redacted" }` |
+
+`payload_redacted: bool` フラットフィールドではなく tagged union を採用する。理由: `"[REDACTED]"` 文字列リテラルと平文 `"[REDACTED]"` の衝突を構造的に排除するため。
+
+### REQ-DP-002: `ExportRecord` — エクスポートレコード値オブジェクト
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `Record` + `include_secrets: bool` |
+| 処理 | `Record` の各フィールドを JSON シリアライズ可能な値オブジェクトに変換する。(1) `id` → `String`（UUID v7 の文字列表現）/ (2) `kind` → `RecordKind`（既存 serde 実装を流用）/ (3) `label` → `String` / (4) `payload` → `ExportRecordPayload::from_record(record, include_secrets)` / (5) `created_at` / `updated_at` → RFC 3339 文字列（マイクロ秒精度）/ (6) `hotkey` → `Option<String>`（`daemon-hotkey-clipboard` の `Hotkey::display_string()` 形式、`None` の場合は `null`）|
+| 出力 | `ExportRecord`（全フィールドに `Serialize` / `Deserialize` 実装）|
+| エラー時 | 該当なし（変換は純粋関数。`RecordPayload::Encrypted` は `ExportRecordPayload::Locked` として表現されるが、上位の `ExportUseCase` が事前チェックして `DataPortabilityError::VaultLocked` を返す）|
+| 設計原則 | DDD 値オブジェクト（不変・同一性なし）/ Composition（`ExportRecordPayload` に変換を委譲）|
+
+### REQ-DP-003: `ExportPayload` — エクスポートファイル全体
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `records: Vec<ExportRecord>` + `vault_name: String` + `exported_at: OffsetDateTime` |
+| 処理 | エクスポートファイルのルート JSON オブジェクトを構築する。`format_version: 1`（定数）を必ず含める |
+| 出力 | `ExportPayload`（`Serialize` / `Deserialize` 実装）|
+| エラー時 | 該当なし |
+| 設計原則 | 拡張性（`format_version` で将来のスキーマ変更に対応）|
+
+**JSON スキーマ（`format_version: 1`）**:
+
+| フィールド | 型 | 説明 |
+|-----------|----|----|
+| `format_version` | `u32` | 常に `1`（MVP）|
+| `exported_at` | `String` | RFC 3339（例: `"2026-05-12T09:00:00.000000Z"`）|
+| `vault_name` | `String` | vault ディレクトリの basename（識別用メタデータ）|
+| `records` | `Array<ExportRecord>` | 全レコード |
+
+各 `ExportRecord` のフィールド:
+
+| フィールド | 型 | 説明 |
+|-----------|----|------|
+| `id` | `String` | UUID v7 文字列 |
+| `kind` | `"text"` / `"secret"` | `RecordKind` の snake_case serde 表現 |
+| `label` | `String` | レコードラベル |
+| `payload` | `Object` | `ExportRecordPayload` の tagged union |
+| `created_at` | `String` | RFC 3339 マイクロ秒精度 |
+| `updated_at` | `String` | RFC 3339 マイクロ秒精度 |
+| `hotkey` | `String` / `null` | ホットキー文字列または `null` |
+
+### REQ-DP-004: `ImportPayload` / `ImportRecord` — インポート入力バリデーション前型
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | ファイルから読み込んだ JSON 文字列（`serde_json::from_str`）|
+| 処理 | `ExportPayload` と同じスキーマで `Deserialize` する。`ImportPayload` は `ExportPayload` の alias ではなく独立した型とし、import 固有のバリデーション責務を持つ |
+| 出力 | `ImportPayload { format_version, exported_at, vault_name, records: Vec<ImportRecord> }` |
+| エラー時 | JSON パース失敗 → `DataPortabilityError::DeserializationFailed { reason }` |
+| 設計原則 | Fail Fast（JSON 構造不正は即時失敗）|
+
+### REQ-DP-005: `ImportValidator` — バリデーション責務
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `ImportPayload` + `existing_ids: HashSet<RecordId>`（現在の vault の全 ID）|
+| 処理 | 以下を順次検証する。(1) `format_version` ≤ `CURRENT_FORMAT_VERSION(=1)` であること（未知のバージョンは拒否）/ (2) `records` が空でないこと（空 import は warning 扱い、エラーではない）/ (3) import ファイル内の `id` 重複がないこと / (4) `payload.kind == "redacted"` のレコードが存在しないこと / (5) `existing_ids` との衝突検出（ID 一覧を返す、戦略適用は呼び出し側）|
+| 出力 | `ImportValidationReport { conflicting_ids: Vec<RecordId>, warnings: Vec<ImportWarning> }` |
+| エラー時 | `DataPortabilityError::ValidationFailed(ImportValidationError)` — `ImportValidationError` は以下のバリアントを持つ: `UnknownFormatVersion { found: u32 }` / `DuplicateIdInFile { id: String }` / `RedactedPayload { id: String }` |
+| 設計原則 | Fail Fast（バリデーション失敗は早期に検出して呼び出し側に返す）/ 単一責務（戦略適用は UseCase 側の責務）|
+
+### REQ-DP-006: `DataPortabilityError` — エラー型階層
+
+| バリアント | 発生条件 |
+|-----------|---------|
+| `VaultLocked` | 暗号化 vault がロック済みの状態で export / import が呼ばれた |
+| `OutputFileExists { path: PathBuf }` | export 先ファイルが既に存在し `--force` 未指定 |
+| `DeserializationFailed { reason: String }` | JSON パース失敗 |
+| `ValidationFailed(ImportValidationError)` | import バリデーション失敗 |
+| `IoError(std::io::Error)` | ファイル I/O エラー |
+| `ConflictError { ids: Vec<RecordId> }` | `--on-conflict error` で衝突が発生 |
+
+**設計判断**: `DataPortabilityError` は `shikomi-core` ではなく `shikomi-cli` の `usecase/` 層に定義する。domain 型（`ExportRecord` / `ImportPayload` 等）は `shikomi-core` に置くが、error は CLI UseCase の責務であり、`shikomi-core` に I/O エラーを持ち込まない。
+
+## モジュール配置
+
+| クレート | パス | 内容 |
+|---------|------|------|
+| `shikomi-core` | `src/portability/mod.rs` | `ExportRecordPayload` / `ExportRecord` / `ExportPayload` / `ImportPayload` / `ImportRecord` / `ImportValidator` / `ImportValidationError` |
+| `shikomi-core` | `src/portability/export.rs` | `ExportRecord` / `ExportPayload` 型定義 + `From<(&Record, bool)>` 変換実装 |
+| `shikomi-core` | `src/portability/import.rs` | `ImportPayload` / `ImportRecord` / `ImportValidator` 型定義 |
+| `shikomi-core` | `src/portability/error.rs` | `ImportValidationError` 型定義 |
+
+**設計判断**: `portability` モジュールを `shikomi-core` に新設する。`Record` は `shikomi-core` に存在し、export は `Record` への変換を伴う。`shikomi-cli` の `usecase/` は `portability` モジュールを利用するだけで良い。`serde_json` は `shikomi-core` の `Cargo.toml` に既に存在するため追加依存なし。
+
+## ユーザー向けメッセージ一覧（Sub-A スコープ）
+
+Sub-A では UI を持たない。メッセージ ID の予約のみ行う。
+
+| ID | 表示条件 | 終了コード |
+|----|---------|---------|
+| MSG-CLI-140 | vault がロック済みで export / import 不可 | 1 |
+| MSG-CLI-141 | export 先ファイルが既に存在（`--force` 未指定）| 1 |
+| MSG-CLI-142 | `--on-conflict error` で衝突発生 | 1 |
+| MSG-CLI-143 | JSON パース失敗 / フォーマットバージョン不一致 | 1 |
+| MSG-CLI-144 | `payload_redacted` レコードの import 試行 | 1 |
+
+文面の確定は Sub-B（Issue #141）の `cli/basic-design.md §ユーザー向けメッセージ` で行う。
+
+## テスト戦略（テスト設計 Issue で詳細化）
+
+| テストレベル | 観点 |
+|-------------|------|
+| UT | `ExportRecordPayload::from_record` — Secret kind がリダクトされること / Text kind が平文で返ること |
+| UT | `ExportRecord::from` — 全フィールドが正しく変換されること |
+| UT | `ImportValidator::validate` — UnknownFormatVersion / DuplicateIdInFile / RedactedPayload の各エラーが正しく返ること |
+| UT | `ExportPayload` → JSON → `ImportPayload` のラウンドトリップ（`serde` roundtrip）|
+| IT | 該当なし — domain 型はファイル I/O を持たない |
+
+## 依存関係・前提条件
+
+| 依存先 | 理由 |
+|--------|------|
+| `shikomi-core` の `Record` / `RecordKind` / `RecordPayload`（実装済み）| `ExportRecord::from` の変換元 |
+| `serde` / `serde_json`（`shikomi-core` の `Cargo.toml` に既存）| JSON シリアライゼーション。追加依存なし |
+| `daemon-hotkey-clipboard` feature の `Hotkey::display_string()` | hotkey フィールドの文字列化。Sub-A では `hotkey` を `Option<String>` として扱う。`daemon-hotkey-clipboard` が未完了の場合、`hotkey` フィールドは常に `null` で export する（フォールバック）|

--- a/docs/features/data-portability/domain/detailed-design.md
+++ b/docs/features/data-portability/domain/detailed-design.md
@@ -1,0 +1,145 @@
+# 詳細設計書 — data-portability / domain
+
+<!-- feature: data-portability / sub-feature: domain / Issue #140 -->
+<!-- 配置先: docs/features/data-portability/domain/detailed-design.md -->
+<!-- Vモデル対応: 階層 3（sub-feature 詳細設計）-->
+<!-- 兄弟: ./basic-design.md -->
+
+## 記述ルール
+
+疑似コード禁止。処理順序は番号付き箇条書きで表現する。型・フィールド・モジュールパスは \`code\` 表記で明示する。
+
+## 変更対象ファイル一覧
+
+| ファイル | 変更種別 | 変更内容 |
+|---------|---------|---------|
+| `crates/shikomi-core/src/lib.rs` | 編集 | `pub mod portability;` を追加 |
+| `crates/shikomi-core/src/portability/mod.rs` | 新規 | `portability` モジュールのエクスポート（re-export）|
+| `crates/shikomi-core/src/portability/export.rs` | 新規 | `ExportRecordPayload` / `ExportRecord` / `ExportPayload` |
+| `crates/shikomi-core/src/portability/import.rs` | 新規 | `ImportRecord` / `ImportPayload` / `ImportValidator` |
+| `crates/shikomi-core/src/portability/error.rs` | 新規 | `ImportValidationError` |
+
+変更不要ファイル:
+
+| ファイル | 理由 |
+|---------|------|
+| `crates/shikomi-core/Cargo.toml` | `serde` / `serde_json` / `time(serde)` / `uuid(serde)` は既存依存に含まれる |
+| `crates/shikomi-core/src/vault/` 以下全ファイル | `portability` モジュールは `vault` を参照するが、`vault` は `portability` を参照しない（依存逆転なし）|
+| `crates/shikomi-cli/` 以下全ファイル | Sub-B（Issue #141）スコープ |
+
+## `crates/shikomi-core/src/portability/export.rs` の設計詳細
+
+### `ExportRecordPayload` 型
+
+- `Serialize` / `Deserialize` 実装。`serde(tag = "kind", rename_all = "snake_case")` で tagged union とする
+- バリアント:
+  1. `Plaintext { value: String }` → JSON: `{ "kind": "plaintext", "value": "..." }`
+  2. `Redacted` → JSON: `{ "kind": "redacted" }`
+- `from_record(payload: &RecordPayload, kind: RecordKind, include_secrets: bool)` 関連関数:
+  1. `payload` が `RecordPayload::Encrypted` → 呼び出し側が事前チェック済みのためここには到達しない（`unreachable!` マクロではなく `debug_assert!` で保護）
+  2. `kind == RecordKind::Secret` かつ `include_secrets == false` → `Redacted` を返す
+  3. 上記以外 → `payload.expose_secret()` を呼び出し `Plaintext { value }` を返す
+- **`expose_secret` 呼び出し集約**: この関数が唯一の expose_secret 呼び出し箇所（`cli-vault-commands/basic-design/security.md §expose_secret 経路監査` の方針に準拠）
+
+### `ExportRecord` 型
+
+- 全フィールドに `Serialize` / `Deserialize` 実装
+- フィールドとその変換元:
+
+| フィールド | Rust 型 | serde 表現 | 変換元 |
+|-----------|---------|-----------|--------|
+| `id` | `String` | 文字列 | `record.id().to_string()` |
+| `kind` | `RecordKind` | `"text"` / `"secret"` | `record.kind()` |
+| `label` | `String` | 文字列 | `record.label().as_str().to_owned()` |
+| `payload` | `ExportRecordPayload` | tagged union | `ExportRecordPayload::from_record(...)` |
+| `created_at` | `String` | RFC 3339 | `record.created_at()` → `time::format_description::well_known::Rfc3339` |
+| `updated_at` | `String` | RFC 3339 | `record.updated_at()` → `Rfc3339` |
+| `hotkey` | `Option<String>` | 文字列 or null | `record.hotkey().map(|h| h.display_string())` |
+
+- `From<(&Record, bool)>` を実装する（`bool` は `include_secrets`）。これにより `ExportRecord::from((record, include_secrets))` で変換できる
+
+### `ExportPayload` 型
+
+- 全フィールドに `Serialize` / `Deserialize` 実装
+- フィールド:
+
+| フィールド | Rust 型 | serde 表現 | 注記 |
+|-----------|---------|-----------|------|
+| `format_version` | `u32` | 数値 | 定数 `EXPORT_FORMAT_VERSION: u32 = 1` を使用 |
+| `exported_at` | `String` | RFC 3339 | コンストラクタ引数 `OffsetDateTime` から変換 |
+| `vault_name` | `String` | 文字列 | コンストラクタ引数 |
+| `records` | `Vec<ExportRecord>` | 配列 | コンストラクタ引数 |
+
+- `ExportPayload::new(records, vault_name, now)` コンストラクタを提供する
+
+## `crates/shikomi-core/src/portability/import.rs` の設計詳細
+
+### `ImportRecord` 型
+
+- `ExportRecord` と同一フィールド定義。`Deserialize` のみ実装（import は書き込みのみ。`Serialize` は不要）
+- `serde` の `deny_unknown_fields` は使用しない（将来バージョンが追加フィールドを持っても import できるよう前方互換を保つ）
+
+### `ImportPayload` 型
+
+- `ExportPayload` と同一フィールド定義。`Deserialize` のみ実装
+- 追加責務: `ImportValidator::validate(&self, existing_ids)` を呼び出すファサード
+
+### `ImportValidator` 型
+
+- ステートレス（関連関数のみ）
+- `validate(payload: &ImportPayload, existing_ids: &HashSet<String>) -> Result<ImportValidationReport, ImportValidationError>` の処理順序:
+  1. `payload.format_version > EXPORT_FORMAT_VERSION` → `ImportValidationError::UnknownFormatVersion { found: payload.format_version }` を返す
+  2. `payload.records` を走査し、`id` の重複を `HashSet` で検出 → 重複あれば `ImportValidationError::DuplicateIdInFile { id }` を返す（最初の重複 ID のみ返す。全件列挙は YAGNI）
+  3. `payload.records` を走査し、`payload.kind == "redacted"` のレコードを検出 → `ImportValidationError::RedactedPayload { id }` を返す（最初の 1 件のみ）
+  4. `existing_ids` との衝突 ID を収集 → `conflicting_ids` に格納
+  5. 全バリデーション通過 → `ImportValidationReport { conflicting_ids, warnings }` を返す
+- バリデーション順序の設計判断: フォーマットバージョン → ファイル内重複 → Redacted → 既存衝突。フォーマット不正は最優先でエラーにし、ユーザーが正しい状態から再試行できるようにする
+
+### `ImportValidationReport` 型
+
+| フィールド | 型 | 説明 |
+|-----------|----|----|
+| `conflicting_ids` | `Vec<String>` | 既存 vault と ID が衝突するレコードの ID 一覧 |
+| `warnings` | `Vec<ImportWarning>` | 警告一覧（`records` が空の場合に `EmptyImport` 警告を追加）|
+
+## `crates/shikomi-core/src/portability/error.rs` の設計詳細
+
+### `ImportValidationError` 型
+
+| バリアント | フィールド | 説明 |
+|-----------|-----------|------|
+| `UnknownFormatVersion` | `found: u32` | 未知の `format_version`（`> 1`）|
+| `DuplicateIdInFile` | `id: String` | import ファイル内で ID が重複 |
+| `RedactedPayload` | `id: String` | `payload.kind == "redacted"` のレコードを import 試行 |
+
+- `std::error::Error` / `Display` を実装する
+- `Display` の出力例: `"cannot import: payload is redacted for record id=<id>"` — CLI エラーメッセージの `{reason}` に展開される
+
+## `portability/mod.rs` の re-export 設計
+
+以下を public re-export する:
+
+- `export::ExportRecord`
+- `export::ExportRecordPayload`
+- `export::ExportPayload`
+- `export::EXPORT_FORMAT_VERSION`
+- `import::ImportRecord`
+- `import::ImportPayload`
+- `import::ImportValidator`
+- `import::ImportValidationReport`
+- `import::ImportWarning`
+- `error::ImportValidationError`
+
+## `crates/shikomi-core/src/lib.rs` の変更詳細
+
+- 既存の `pub mod` 宣言群の末尾に `pub mod portability;` を追加する
+- 変更は 1 行のみ
+
+## セキュリティ考慮（domain スコープ）
+
+| 脅威 | 対策 |
+|------|------|
+| Secret kind の平文漏洩 | `from_record` 内で `include_secrets == false` 時に `Redacted` を返す。`expose_secret` の呼び出しはこの関数に閉じる |
+| `[REDACTED]` 文字列リテラルとの混同 | tagged union（`{ "kind": "redacted" }`）を採用し、sentinel 文字列の衝突を構造的に排除する |
+| import ファイルへの不正データ注入 | `ImportValidator` が `format_version` / 重複 ID / Redacted payload を検出して早期失敗させる |
+| 改ざんされた import ファイル | 完全性検証（HMAC 等）は YAGNI（MVP スコープ外）。export ファイルへの署名は将来拡張 |

--- a/docs/features/data-portability/domain/detailed-design.md
+++ b/docs/features/data-portability/domain/detailed-design.md
@@ -17,7 +17,7 @@
 | `crates/shikomi-core/src/portability/mod.rs` | 新規 | `portability` モジュールのエクスポート（re-export）|
 | `crates/shikomi-core/src/portability/export.rs` | 新規 | `ExportRecordPayload` / `ExportRecord` / `ExportPayload` |
 | `crates/shikomi-core/src/portability/import.rs` | 新規 | `ImportRecord` / `ImportPayload` / `ImportValidator` |
-| `crates/shikomi-core/src/portability/error.rs` | 新規 | `ImportValidationError` |
+| `crates/shikomi-core/src/portability/error.rs` | 新規 | `ImportValidationError` / `ExportError` |
 
 変更不要ファイル:
 
@@ -35,10 +35,10 @@
 - バリアント:
   1. `Plaintext { value: String }` → JSON: `{ "kind": "plaintext", "value": "..." }`
   2. `Redacted` → JSON: `{ "kind": "redacted" }`
-- `from_record(payload: &RecordPayload, kind: RecordKind, include_secrets: bool)` 関連関数:
-  1. `payload` が `RecordPayload::Encrypted` → 呼び出し側が事前チェック済みのためここには到達しない（`unreachable!` マクロではなく `debug_assert!` で保護）
-  2. `kind == RecordKind::Secret` かつ `include_secrets == false` → `Redacted` を返す
-  3. 上記以外 → `payload.expose_secret()` を呼び出し `Plaintext { value }` を返す
+- `from_record(payload: &RecordPayload, kind: RecordKind, include_secrets: bool) -> Result<Self, ExportError>` 関連関数:
+  1. `payload` が `RecordPayload::Encrypted` → 即座に `Err(ExportError::VaultLocked)` を返す（Fail Fast。release ビルドでも動作する）
+  2. `kind == RecordKind::Secret` かつ `include_secrets == false` → `Ok(Redacted)` を返す
+  3. 上記以外 → `payload` の平文値から `expose_secret()` を呼び出し `Ok(Plaintext { value })` を返す
 - **`expose_secret` 呼び出し集約**: この関数が唯一の expose_secret 呼び出し箇所（`cli-vault-commands/basic-design/security.md §expose_secret 経路監査` の方針に準拠）
 
 ### `ExportRecord` 型
@@ -51,12 +51,12 @@
 | `id` | `String` | 文字列 | `record.id().to_string()` |
 | `kind` | `RecordKind` | `"text"` / `"secret"` | `record.kind()` |
 | `label` | `String` | 文字列 | `record.label().as_str().to_owned()` |
-| `payload` | `ExportRecordPayload` | tagged union | `ExportRecordPayload::from_record(...)` |
+| `payload` | `ExportRecordPayload` | tagged union | `ExportRecordPayload::from_record(...)?`（`ExportError::VaultLocked` を伝播）|
 | `created_at` | `String` | RFC 3339 | `record.created_at()` → `time::format_description::well_known::Rfc3339` |
 | `updated_at` | `String` | RFC 3339 | `record.updated_at()` → `Rfc3339` |
-| `hotkey` | `Option<String>` | 文字列 or null | `record.hotkey().map(|h| h.display_string())` |
+| `hotkey` | `Option<String>` | 文字列 or null | `record.hotkey().map(|h| h.as_str().to_owned())` |
 
-- `From<(&Record, bool)>` を実装する（`bool` は `include_secrets`）。これにより `ExportRecord::from((record, include_secrets))` で変換できる
+- `ExportRecord::try_from((&Record, bool)) -> Result<Self, ExportError>` を実装する（`bool` は `include_secrets`）。`From` ではなく `TryFrom` を使う理由: `from_record` が `Result` を返すため|
 
 ### `ExportPayload` 型
 
@@ -74,9 +74,10 @@
 
 ## `crates/shikomi-core/src/portability/import.rs` の設計詳細
 
-### `ImportRecord` 型
+### `ImportRecord` 型（`ExportRecord` の type alias）
 
-- `ExportRecord` と同一フィールド定義。`Deserialize` のみ実装（import は書き込みのみ。`Serialize` は不要）
+- `type ImportRecord = ExportRecord` — type alias として定義する。フィールド定義を 2 箇所で管理しない（DRY / KISS）
+- 設計判断: `ImportRecord` を独立した struct にする振る舞い上の差異が存在しない。`ImportPayload.records` の要素型として使うだけで、バリデーション責務は `ImportValidator` が持つ。`ExportRecord` が `Serialize + Deserialize` の両方を実装しているため、roundtrip テストもこのまま成立する
 - `serde` の `deny_unknown_fields` は使用しない（将来バージョンが追加フィールドを持っても import できるよう前方互換を保つ）
 
 ### `ImportPayload` 型

--- a/docs/features/data-portability/domain/test-design.md
+++ b/docs/features/data-portability/domain/test-design.md
@@ -8,10 +8,11 @@
 ## 1. 設計方針
 
 - **対象**: `crates/shikomi-core/src/portability/` モジュール群の型変換・バリデーション純粋関数
-  - `ExportRecordPayload::from_record` — Secret リダクション tagged union 変換
-  - `ExportRecord` フィールドマッピング（`From<(&Record, bool)>` 実装）
+  - `ExportRecordPayload::from_record` — Secret リダクション tagged union 変換。戻り値は `Result<ExportRecordPayload, ExportError>`（`Encrypted` → 即時 `Err(ExportError::VaultLocked)`）
+  - `ExportRecord` フィールドマッピング（`TryFrom<(&Record, bool)>` 実装、戻り値は `Result<ExportRecord, ExportError>`）
   - `ExportPayload::new` — `format_version: 1` 定数埋め込み
   - `ExportPayload` → JSON → `ImportPayload` serde ラウンドトリップ
+  - `ImportRecord = ExportRecord`（type alias）— フィールド定義の二重管理なし（DRY/KISS）。独立した struct にする振る舞い差が存在しないため（`basic-design.md REQ-DP-004` 参照）
   - `ImportValidator::validate` — バリデーション順序（フォーマットバージョン → 重複 ID → Redacted payload → 既存衝突）
   - `ImportValidationError::Display` — エラーメッセージに record id が含まれること
 - **テストレベル**: ユニットテストのみ。`domain` 型は外部 I/O を持たない（`basic-design.md §テスト戦略` 参照）
@@ -48,13 +49,14 @@
 
 | TC-ID | 対応要件 | 対応受入基準 | 種別 | 対象関数 / 観点 |
 |-------|---------|------------|------|----------------|
-| TC-UT-177 | REQ-DP-001 | AC-DP-02 | 正常 | `ExportRecordPayload::from_record`: Secret kind + `include_secrets=false` → `Redacted` |
-| TC-UT-178 | REQ-DP-001 | AC-DP-02 | 正常 | `ExportRecordPayload::from_record`: Secret kind + `include_secrets=true` → `Plaintext` |
-| TC-UT-179 | REQ-DP-001 | AC-DP-01 | 正常 | `ExportRecordPayload::from_record`: Text kind + `include_secrets=false` → `Plaintext`（リダクト対象外）|
+| TC-UT-177 | REQ-DP-001 | AC-DP-02 | 正常 | `ExportRecordPayload::from_record`: Secret kind + `include_secrets=false` → `Ok(Redacted)` |
+| TC-UT-178 | REQ-DP-001 | AC-DP-02 | 正常 | `ExportRecordPayload::from_record`: Secret kind + `include_secrets=true` → `Ok(Plaintext)` |
+| TC-UT-179 | REQ-DP-001 | AC-DP-01 | 正常 | `ExportRecordPayload::from_record`: Text kind + `include_secrets=false` → `Ok(Plaintext)`（リダクト対象外）|
 | TC-UT-180 | REQ-DP-001 | AC-DP-02 | 正常 | `Redacted` の JSON 表現が `{"kind":"redacted"}` で `value` キーを含まない |
 | TC-UT-181 | REQ-DP-001 | AC-DP-01 | 正常 | `Plaintext` の JSON 表現が `{"kind":"plaintext","value":"..."}` |
-| TC-UT-182 | REQ-DP-002 | AC-DP-01 | 正常 | `ExportRecord::from`: 全フィールド（id / kind / label / payload / created_at / updated_at / hotkey=Some）が正しくマッピングされる |
-| TC-UT-183 | REQ-DP-002 | AC-DP-01 | 正常 | `ExportRecord::from`: `hotkey=None` → JSON `null` |
+| TC-UT-195 | REQ-DP-001 | —（設計内部保証）| 異常 | `ExportRecordPayload::from_record`: `Encrypted` payload → `Err(ExportError::VaultLocked)`（Fail Fast、release ビルド動作保証）|
+| TC-UT-182 | REQ-DP-002 | AC-DP-01 | 正常 | `ExportRecord::try_from`: 全フィールド（id / kind / label / payload / created_at / updated_at / hotkey=Some）が正しくマッピングされる |
+| TC-UT-183 | REQ-DP-002 | AC-DP-01 | 正常 | `ExportRecord::try_from`: `hotkey=None` → JSON `null` |
 | TC-UT-184 | REQ-DP-003 | AC-DP-01 | 正常 | `ExportPayload::new` の `format_version` フィールドが常に `1` |
 | TC-UT-185 | REQ-DP-003 / REQ-DP-004 | AC-DP-01 | 正常 | `ExportPayload` → JSON 文字列 → `ImportPayload` serde ラウンドトリップ（全フィールド一致）|
 | TC-UT-186 | REQ-DP-005 | AC-DP-05 | 異常 | `ImportValidator::validate`: `format_version > 1` → `ImportValidationError::UnknownFormatVersion { found }` |
@@ -66,8 +68,9 @@
 | TC-UT-192 | REQ-DP-005 | AC-DP-05 | 正常 | バリデーション順序: `format_version=999` + ファイル内 ID 重複 → `UnknownFormatVersion` を先に返す |
 | TC-UT-193 | REQ-DP-005 | AC-DP-04 | 正常 | バリデーション順序: ファイル内 ID 重複 + Redacted payload → `DuplicateIdInFile` を先に返す |
 | TC-UT-194 | REQ-DP-006 | AC-DP-03 | 正常 | `ImportValidationError::RedactedPayload` の `Display` 出力に record id が含まれる |
+| TC-UT-196 | REQ-DP-005 / REQ-DP-001 | AC-DP-08（domain部分）| 正常 | `--export-secrets` で書き出した plaintext payload（`{"kind":"plaintext","value":"..."}`）→ `ImportValidator` が `Ok` を返す（Redacted 判定されない）|
 
-上位トレーサビリティ: `TC-UT-177〜194` → `ST-DP-*`（system-test-design.md）→ `AC-DP-01〜05`（feature-spec.md §5 Sub-A）
+上位トレーサビリティ: `TC-UT-177〜196` → `ST-DP-*`（system-test-design.md）→ `AC-DP-01〜05、08（domain 部分）`（feature-spec.md §5）
 
 ---
 
@@ -76,6 +79,8 @@
 ### 5.1 `ExportRecordPayload::from_record` — Secret リダクション（REQ-DP-001）
 
 配置: `crates/shikomi-core/src/portability/export.rs` `#[cfg(test)] mod tests`
+
+> **シグネチャ（rev2 反映）**: `from_record(payload: &RecordPayload, kind: RecordKind, include_secrets: bool) -> Result<ExportRecordPayload, ExportError>` — 全 TC の期待結果は `Ok(...)` または `Err(...)` で記述する
 
 #### TC-UT-177: Secret kind + include_secrets=false → Redacted
 
@@ -87,9 +92,9 @@
 | 種別 | 正常系 |
 | 前提条件 | なし |
 | 操作 | 1. `RecordPayload::Plaintext("p@ssword".into())` と `RecordKind::Secret` を用意する / 2. `ExportRecordPayload::from_record(&payload, RecordKind::Secret, false)` を呼ぶ |
-| 期待結果 | 戻り値が `ExportRecordPayload::Redacted` であること |
+| 期待結果 | 戻り値が `Ok(ExportRecordPayload::Redacted)` であること |
 
-#### TC-UT-178: Secret kind + include_secrets=true → Plaintext
+#### TC-UT-178: Secret kind + include_secrets=true → Ok(Plaintext)
 
 | 項目 | 内容 |
 |------|------|
@@ -99,9 +104,9 @@
 | 種別 | 正常系 |
 | 前提条件 | なし |
 | 操作 | 1. `RecordPayload::Plaintext("p@ssword".into())` と `RecordKind::Secret` を用意する / 2. `ExportRecordPayload::from_record(&payload, RecordKind::Secret, true)` を呼ぶ |
-| 期待結果 | 戻り値が `ExportRecordPayload::Plaintext { value }` であり `value == "p@ssword"` |
+| 期待結果 | 戻り値が `Ok(ExportRecordPayload::Plaintext { value })` であり `value == "p@ssword"` |
 
-#### TC-UT-179: Text kind + include_secrets=false → Plaintext（リダクト対象外）
+#### TC-UT-179: Text kind + include_secrets=false → Ok(Plaintext)（リダクト対象外）
 
 | 項目 | 内容 |
 |------|------|
@@ -111,7 +116,7 @@
 | 種別 | 正常系 |
 | 前提条件 | なし |
 | 操作 | 1. `RecordPayload::Plaintext("hello".into())` と `RecordKind::Text` を用意する / 2. `ExportRecordPayload::from_record(&payload, RecordKind::Text, false)` を呼ぶ |
-| 期待結果 | 戻り値が `ExportRecordPayload::Plaintext { value: "hello" }` であること（Text kind は `include_secrets` に関わらずリダクトされない）|
+| 期待結果 | 戻り値が `Ok(ExportRecordPayload::Plaintext { value: "hello" })` であること（Text kind は `include_secrets` に関わらずリダクトされない）|
 
 #### TC-UT-180: `Redacted` の JSON 表現に `value` キーが存在しない
 
@@ -137,11 +142,25 @@
 | 操作 | 1. `ExportRecordPayload::Plaintext { value: "hello".into() }` を構築する / 2. `serde_json::to_string` でシリアライズする |
 | 期待結果 | JSON 文字列に `"kind":"plaintext"` と `"value":"hello"` が含まれる |
 
+#### TC-UT-195: `Encrypted` payload → `Err(ExportError::VaultLocked)`（Fail Fast）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-195 |
+| 対応要件 | REQ-DP-001 |
+| 対応受入基準 | —（設計内部の Fail Fast 保証。release ビルドで動作することを検証）|
+| 種別 | 異常系 |
+| 前提条件 | なし |
+| 操作 | 1. `RecordPayload::Encrypted(...)` と `RecordKind::Secret` を用意する / 2. `ExportRecordPayload::from_record(&payload, RecordKind::Secret, false)` を呼ぶ |
+| 期待結果 | `Err(ExportError::VaultLocked)` が返ること（`debug_assert!` は release で無視されるため、`if let Encrypted` 分岐による即時 `Err` で本番ビルドでも動作することを確認）|
+
 ---
 
 ### 5.2 `ExportRecord` フィールドマッピング（REQ-DP-002）
 
 配置: `crates/shikomi-core/src/portability/export.rs` `#[cfg(test)] mod tests`
+
+> **シグネチャ（rev2 反映）**: `ExportRecord::try_from((&Record, bool)) -> Result<ExportRecord, ExportError>`。全 TC は `.unwrap()` または `?` で `Ok` を取り出してアサートする
 
 #### TC-UT-182: 全フィールドが正しくマッピングされる（hotkey=Some）
 
@@ -152,7 +171,7 @@
 | 対応受入基準 | AC-DP-01 |
 | 種別 | 正常系 |
 | 前提条件 | `Record` のテスト用ビルダーが利用可能 |
-| 操作 | 1. `RecordKind::Text`・label `"my-label"`・hotkey `Some("Ctrl+1")` を持つ `Record` を構築する / 2. `ExportRecord::from((&record, false))` を呼ぶ |
+| 操作 | 1. `RecordKind::Text`・label `"my-label"`・hotkey `Some("Ctrl+1")`・Plaintext payload を持つ `Record` を構築する / 2. `ExportRecord::try_from((&record, false)).unwrap()` を呼ぶ |
 | 期待結果 | (1) `export_record.id` が元 record の id 文字列表現と一致 / (2) `export_record.kind` が `RecordKind::Text` / (3) `export_record.label == "my-label"` / (4) `export_record.hotkey == Some("Ctrl+1".into())` / (5) `created_at` / `updated_at` が空でない RFC 3339 文字列 |
 
 #### TC-UT-183: `hotkey=None` → JSON `null`
@@ -164,7 +183,7 @@
 | 対応受入基準 | AC-DP-01 |
 | 種別 | 正常系 |
 | 前提条件 | `Record` のテスト用ビルダーが利用可能 |
-| 操作 | 1. `hotkey` が `None` の `Record` を構築する / 2. `ExportRecord::from((&record, false))` を呼ぶ / 3. `serde_json::to_value` でシリアライズする |
+| 操作 | 1. `hotkey` が `None`・Plaintext payload の `Record` を構築する / 2. `ExportRecord::try_from((&record, false)).unwrap()` を呼ぶ / 3. `serde_json::to_value` でシリアライズする |
 | 期待結果 | JSON オブジェクトの `"hotkey"` フィールドが `null` |
 
 ---
@@ -319,17 +338,38 @@
 
 ---
 
+### 5.6 AC-DP-08 domain カバレッジ — `--export-secrets` JSON の import 受理（REQ-DP-005 / REQ-DP-001）
+
+配置: `crates/shikomi-core/src/portability/import.rs` `#[cfg(test)] mod tests`
+
+> **背景（ペテルギウス指摘 #2）**: `--export-secrets` フラグ付きで書き出した export ファイルには Secret kind レコードが `{"kind":"plaintext","value":"..."}` 形式で含まれる。この JSON を `ImportValidator` に渡した場合、`RedactedPayload` エラーにならず `Ok` が返ることを保証する TC が不在だった。AC-DP-08 は CLI 操作レベルの検証（Sub-B スコープ）だが、その前提となる domain 層の「plaintext は拒否しない」保証をここで確立する。
+
+#### TC-UT-196: Secret plaintext payload（`--export-secrets` 書き出し想定）→ `ImportValidator` が `Ok` を返す
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-196 |
+| 対応要件 | REQ-DP-005 / REQ-DP-001 |
+| 対応受入基準 | AC-DP-08（domain 部分）|
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. Secret kind レコードを含む `ExportPayload` を `include_secrets=true` で構築する（`ExportRecordPayload` が `Plaintext { value }` になる）/ 2. `serde_json::to_string` でシリアライズする（JSON に `{"kind":"plaintext","value":"..."}` が含まれる）/ 3. `serde_json::from_str::<ImportPayload>` でデシリアライズする / 4. `ImportValidator::validate(&payload, &HashSet::new())` を呼ぶ |
+| 期待結果 | `Ok(report)` が返ること。`{"kind":"plaintext"}` ペイロードは `RedactedPayload` 判定されない。`--export-secrets` で書き出した JSON は `ImportValidator` に拒否されない（TC-UT-189 との対比: `{"kind":"redacted"}` のみが拒否対象）|
+
+---
+
 ## 6. テストケース数サマリー
 
 | グループ | 対象 | TC 数 |
 |---------|------|-------|
-| 5.1 | `ExportRecordPayload::from_record` | 5（TC-UT-177〜181）|
-| 5.2 | `ExportRecord` フィールドマッピング | 2（TC-UT-182〜183）|
+| 5.1 | `ExportRecordPayload::from_record`（Result 戻り値含む）| 6（TC-UT-177〜181、TC-UT-195）|
+| 5.2 | `ExportRecord` フィールドマッピング（`TryFrom` 対応）| 2（TC-UT-182〜183）|
 | 5.3 | `ExportPayload` 構造 / serde ラウンドトリップ | 2（TC-UT-184〜185）|
 | 5.4 | `ImportValidator::validate` バリデーション順序 | 8（TC-UT-186〜193）|
 | 5.5 | `ImportValidationError::Display` | 1（TC-UT-194）|
-| **合計** | | **18** |
+| 5.6 | AC-DP-08 domain カバレッジ（plaintext payload 受理）| 1（TC-UT-196）|
+| **合計** | | **20** |
 
 結合テスト: **なし**（`basic-design.md §テスト戦略` の「IT: 該当なし — domain 型はファイル I/O を持たない」に従う）
 
-受入テスト: AC-DP-01〜05（Sub-A スコープ）の検証は上記 UT で全件カバーされる。E2E（CLI 操作）は Sub-B `cli/test-design.md` で実施する。
+受入テスト: AC-DP-01〜05（Sub-A スコープ）の検証は上記 UT で全件カバーされる。AC-DP-08 の domain 部分は TC-UT-196 でカバー。CLI レベルの完全検証（MSG-CLI-144 表示含む）は Sub-B `cli/test-design.md` で実施する。

--- a/docs/features/data-portability/domain/test-design.md
+++ b/docs/features/data-portability/domain/test-design.md
@@ -1,0 +1,335 @@
+# テスト設計書 — data-portability / domain（ユニットテスト）
+
+<!-- feature: data-portability / sub-feature: domain / Issue #140 -->
+<!-- 配置先: docs/features/data-portability/domain/test-design.md -->
+<!-- Vモデル対応: 階層 3（詳細設計 → ユニットテスト）-->
+<!-- 兄弟: basic-design.md / detailed-design.md / 親: ../feature-spec.md -->
+
+## 1. 設計方針
+
+- **対象**: `crates/shikomi-core/src/portability/` モジュール群の型変換・バリデーション純粋関数
+  - `ExportRecordPayload::from_record` — Secret リダクション tagged union 変換
+  - `ExportRecord` フィールドマッピング（`From<(&Record, bool)>` 実装）
+  - `ExportPayload::new` — `format_version: 1` 定数埋め込み
+  - `ExportPayload` → JSON → `ImportPayload` serde ラウンドトリップ
+  - `ImportValidator::validate` — バリデーション順序（フォーマットバージョン → 重複 ID → Redacted payload → 既存衝突）
+  - `ImportValidationError::Display` — エラーメッセージに record id が含まれること
+- **テストレベル**: ユニットテストのみ。`domain` 型は外部 I/O を持たない（`basic-design.md §テスト戦略` 参照）
+- **粒度**: 1 テスト 1 主要アサーション。命名 `tc_ut_NNN_何をした時_どうなるべきか`
+- **配置**: Rust 慣習、`#[cfg(test)] mod tests` でソースモジュール内
+- **疑似コード禁止**: Rust コードブロックは記述しない。処理手順は番号付き箇条書きで表現する
+
+---
+
+## 2. 外部 I/O 依存マップ
+
+| 外部 I/O | 利用箇所 | 状態 |
+|---------|---------|------|
+| ファイルシステム（JSON 読み書き）| `ImportPayload::from_str` / export ファイル出力 | Sub-B（CLI UseCase）スコープ。domain 型は JSON 文字列↔型変換のみ。UT スコープ外 |
+| `VaultRepository` trait | `ExportUseCase` / `ImportUseCase` | Sub-B スコープ。domain 型には I/O 依存なし |
+| 時刻（`OffsetDateTime::now_utc()`）| `ExportPayload::new` の `exported_at` | テスト内で `OffsetDateTime::UNIX_EPOCH` を固定値注入。外部依存なし |
+
+**依存する外部 I/O ゼロ** — Characterization fixture / factory は不要。`serde_json` は OSS ライブラリ実物を使用（モック不要）。
+
+---
+
+## 3. モック方針（UT）
+
+| 対象 | モック方法 |
+|------|-----------|
+| `RecordPayload` / `Record` | テスト用ビルダー（`RecordBuilder` 既存実装）またはインライン値で構築。外部 I/O なし |
+| `serde_json` シリアライゼーション | OSS ライブラリ実物を使用。モック不要 |
+| `OffsetDateTime` | `OffsetDateTime::UNIX_EPOCH` などの固定値をコンストラクタ引数として渡す |
+| `existing_ids: HashSet<String>` | テスト内でインライン `HashSet::from([...])` を構築。DB 接続なし |
+
+---
+
+## 4. トレーサビリティマトリクス
+
+| TC-ID | 対応要件 | 対応受入基準 | 種別 | 対象関数 / 観点 |
+|-------|---------|------------|------|----------------|
+| TC-UT-177 | REQ-DP-001 | AC-DP-02 | 正常 | `ExportRecordPayload::from_record`: Secret kind + `include_secrets=false` → `Redacted` |
+| TC-UT-178 | REQ-DP-001 | AC-DP-02 | 正常 | `ExportRecordPayload::from_record`: Secret kind + `include_secrets=true` → `Plaintext` |
+| TC-UT-179 | REQ-DP-001 | AC-DP-01 | 正常 | `ExportRecordPayload::from_record`: Text kind + `include_secrets=false` → `Plaintext`（リダクト対象外）|
+| TC-UT-180 | REQ-DP-001 | AC-DP-02 | 正常 | `Redacted` の JSON 表現が `{"kind":"redacted"}` で `value` キーを含まない |
+| TC-UT-181 | REQ-DP-001 | AC-DP-01 | 正常 | `Plaintext` の JSON 表現が `{"kind":"plaintext","value":"..."}` |
+| TC-UT-182 | REQ-DP-002 | AC-DP-01 | 正常 | `ExportRecord::from`: 全フィールド（id / kind / label / payload / created_at / updated_at / hotkey=Some）が正しくマッピングされる |
+| TC-UT-183 | REQ-DP-002 | AC-DP-01 | 正常 | `ExportRecord::from`: `hotkey=None` → JSON `null` |
+| TC-UT-184 | REQ-DP-003 | AC-DP-01 | 正常 | `ExportPayload::new` の `format_version` フィールドが常に `1` |
+| TC-UT-185 | REQ-DP-003 / REQ-DP-004 | AC-DP-01 | 正常 | `ExportPayload` → JSON 文字列 → `ImportPayload` serde ラウンドトリップ（全フィールド一致）|
+| TC-UT-186 | REQ-DP-005 | AC-DP-05 | 異常 | `ImportValidator::validate`: `format_version > 1` → `ImportValidationError::UnknownFormatVersion { found }` |
+| TC-UT-187 | REQ-DP-005 | AC-DP-01 | 正常 | `ImportValidator::validate`: `format_version == 1`・重複なし・Redacted なし → `Ok(ImportValidationReport)` |
+| TC-UT-188 | REQ-DP-005 | AC-DP-04 | 異常 | `ImportValidator::validate`: ファイル内 ID 重複 → `ImportValidationError::DuplicateIdInFile { id }` |
+| TC-UT-189 | REQ-DP-005 | AC-DP-03 | 異常 | `ImportValidator::validate`: `payload.kind == "redacted"` レコード → `ImportValidationError::RedactedPayload { id }` |
+| TC-UT-190 | REQ-DP-005 | AC-DP-01 | 正常 | `ImportValidator::validate`: 既存 vault と ID 衝突 → `Ok` かつ `report.conflicting_ids` に衝突 ID が含まれる |
+| TC-UT-191 | REQ-DP-005 | AC-DP-01 | 境界値 | `ImportValidator::validate`: `records` が空 → `Ok` かつ `report.warnings` に `ImportWarning::EmptyImport` が含まれる |
+| TC-UT-192 | REQ-DP-005 | AC-DP-05 | 正常 | バリデーション順序: `format_version=999` + ファイル内 ID 重複 → `UnknownFormatVersion` を先に返す |
+| TC-UT-193 | REQ-DP-005 | AC-DP-04 | 正常 | バリデーション順序: ファイル内 ID 重複 + Redacted payload → `DuplicateIdInFile` を先に返す |
+| TC-UT-194 | REQ-DP-006 | AC-DP-03 | 正常 | `ImportValidationError::RedactedPayload` の `Display` 出力に record id が含まれる |
+
+上位トレーサビリティ: `TC-UT-177〜194` → `ST-DP-*`（system-test-design.md）→ `AC-DP-01〜05`（feature-spec.md §5 Sub-A）
+
+---
+
+## 5. テストケース一覧
+
+### 5.1 `ExportRecordPayload::from_record` — Secret リダクション（REQ-DP-001）
+
+配置: `crates/shikomi-core/src/portability/export.rs` `#[cfg(test)] mod tests`
+
+#### TC-UT-177: Secret kind + include_secrets=false → Redacted
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-177 |
+| 対応要件 | REQ-DP-001 |
+| 対応受入基準 | AC-DP-02 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `RecordPayload::Plaintext("p@ssword".into())` と `RecordKind::Secret` を用意する / 2. `ExportRecordPayload::from_record(&payload, RecordKind::Secret, false)` を呼ぶ |
+| 期待結果 | 戻り値が `ExportRecordPayload::Redacted` であること |
+
+#### TC-UT-178: Secret kind + include_secrets=true → Plaintext
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-178 |
+| 対応要件 | REQ-DP-001 |
+| 対応受入基準 | AC-DP-02 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `RecordPayload::Plaintext("p@ssword".into())` と `RecordKind::Secret` を用意する / 2. `ExportRecordPayload::from_record(&payload, RecordKind::Secret, true)` を呼ぶ |
+| 期待結果 | 戻り値が `ExportRecordPayload::Plaintext { value }` であり `value == "p@ssword"` |
+
+#### TC-UT-179: Text kind + include_secrets=false → Plaintext（リダクト対象外）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-179 |
+| 対応要件 | REQ-DP-001 |
+| 対応受入基準 | AC-DP-01 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `RecordPayload::Plaintext("hello".into())` と `RecordKind::Text` を用意する / 2. `ExportRecordPayload::from_record(&payload, RecordKind::Text, false)` を呼ぶ |
+| 期待結果 | 戻り値が `ExportRecordPayload::Plaintext { value: "hello" }` であること（Text kind は `include_secrets` に関わらずリダクトされない）|
+
+#### TC-UT-180: `Redacted` の JSON 表現に `value` キーが存在しない
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-180 |
+| 対応要件 | REQ-DP-001 |
+| 対応受入基準 | AC-DP-02 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `ExportRecordPayload::Redacted` を構築する / 2. `serde_json::to_string` でシリアライズする |
+| 期待結果 | JSON 文字列が `{"kind":"redacted"}` であり `"value"` キーを含まない（tagged union の構造的安全性）|
+
+#### TC-UT-181: `Plaintext` の JSON 表現
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-181 |
+| 対応要件 | REQ-DP-001 |
+| 対応受入基準 | AC-DP-01 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `ExportRecordPayload::Plaintext { value: "hello".into() }` を構築する / 2. `serde_json::to_string` でシリアライズする |
+| 期待結果 | JSON 文字列に `"kind":"plaintext"` と `"value":"hello"` が含まれる |
+
+---
+
+### 5.2 `ExportRecord` フィールドマッピング（REQ-DP-002）
+
+配置: `crates/shikomi-core/src/portability/export.rs` `#[cfg(test)] mod tests`
+
+#### TC-UT-182: 全フィールドが正しくマッピングされる（hotkey=Some）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-182 |
+| 対応要件 | REQ-DP-002 |
+| 対応受入基準 | AC-DP-01 |
+| 種別 | 正常系 |
+| 前提条件 | `Record` のテスト用ビルダーが利用可能 |
+| 操作 | 1. `RecordKind::Text`・label `"my-label"`・hotkey `Some("Ctrl+1")` を持つ `Record` を構築する / 2. `ExportRecord::from((&record, false))` を呼ぶ |
+| 期待結果 | (1) `export_record.id` が元 record の id 文字列表現と一致 / (2) `export_record.kind` が `RecordKind::Text` / (3) `export_record.label == "my-label"` / (4) `export_record.hotkey == Some("Ctrl+1".into())` / (5) `created_at` / `updated_at` が空でない RFC 3339 文字列 |
+
+#### TC-UT-183: `hotkey=None` → JSON `null`
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-183 |
+| 対応要件 | REQ-DP-002 |
+| 対応受入基準 | AC-DP-01 |
+| 種別 | 正常系 |
+| 前提条件 | `Record` のテスト用ビルダーが利用可能 |
+| 操作 | 1. `hotkey` が `None` の `Record` を構築する / 2. `ExportRecord::from((&record, false))` を呼ぶ / 3. `serde_json::to_value` でシリアライズする |
+| 期待結果 | JSON オブジェクトの `"hotkey"` フィールドが `null` |
+
+---
+
+### 5.3 `ExportPayload` 構造と serde ラウンドトリップ（REQ-DP-003 / REQ-DP-004）
+
+配置: `crates/shikomi-core/src/portability/export.rs` / `import.rs` `#[cfg(test)] mod tests`
+
+#### TC-UT-184: `format_version` が常に `1`
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-184 |
+| 対応要件 | REQ-DP-003 |
+| 対応受入基準 | AC-DP-01 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `ExportPayload::new(vec![], "test-vault".into(), OffsetDateTime::UNIX_EPOCH)` を呼ぶ / 2. `serde_json::to_value` でシリアライズする |
+| 期待結果 | JSON の `"format_version"` フィールドが `1` |
+
+#### TC-UT-185: `ExportPayload` → JSON → `ImportPayload` ラウンドトリップ
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-185 |
+| 対応要件 | REQ-DP-003 / REQ-DP-004 |
+| 対応受入基準 | AC-DP-01 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `ExportRecord`（Text kind・`include_secrets=false`）を含む `ExportPayload` を構築する / 2. `serde_json::to_string` でシリアライズする / 3. `serde_json::from_str::<ImportPayload>` でデシリアライズする |
+| 期待結果 | デシリアライズ成功 / `import_payload.format_version == 1` / `import_payload.records` の件数・label が元データと一致 |
+
+---
+
+### 5.4 `ImportValidator::validate` — バリデーション順序（REQ-DP-005）
+
+配置: `crates/shikomi-core/src/portability/import.rs` `#[cfg(test)] mod tests`
+
+#### TC-UT-186: `format_version > 1` → `UnknownFormatVersion`
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-186 |
+| 対応要件 | REQ-DP-005 |
+| 対応受入基準 | AC-DP-05 |
+| 種別 | 異常系 |
+| 前提条件 | なし |
+| 操作 | 1. `format_version: 999`・`records: vec![]` の `ImportPayload` を JSON 文字列から構築する / 2. `ImportValidator::validate(&payload, &HashSet::new())` を呼ぶ |
+| 期待結果 | `Err(ImportValidationError::UnknownFormatVersion { found: 999 })` |
+
+#### TC-UT-187: 正常バリデーション通過 → `Ok(ImportValidationReport)`
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-187 |
+| 対応要件 | REQ-DP-005 |
+| 対応受入基準 | AC-DP-01 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `format_version: 1`・重複なし・Redacted なし の `ImportPayload` を構築する / 2. `existing_ids` が空の `HashSet` を用意する / 3. `ImportValidator::validate(&payload, &existing_ids)` を呼ぶ |
+| 期待結果 | `Ok(report)` / `report.conflicting_ids` が空 / `report.warnings` が空 |
+
+#### TC-UT-188: ファイル内 ID 重複 → `DuplicateIdInFile`
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-188 |
+| 対応要件 | REQ-DP-005 |
+| 対応受入基準 | AC-DP-04 |
+| 種別 | 異常系 |
+| 前提条件 | なし |
+| 操作 | 1. `format_version: 1`・同一 id を持つ 2 レコードを含む `ImportPayload` を構築する / 2. `ImportValidator::validate(&payload, &HashSet::new())` を呼ぶ |
+| 期待結果 | `Err(ImportValidationError::DuplicateIdInFile { id })` かつ `id` が重複した ID 文字列と一致する |
+
+#### TC-UT-189: Redacted payload レコード → `RedactedPayload`
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-189 |
+| 対応要件 | REQ-DP-005 |
+| 対応受入基準 | AC-DP-03 |
+| 種別 | 異常系 |
+| 前提条件 | なし |
+| 操作 | 1. `format_version: 1`・`payload: {"kind": "redacted"}` を持つレコードを含む `ImportPayload` を JSON 文字列から構築する / 2. `ImportValidator::validate(&payload, &HashSet::new())` を呼ぶ |
+| 期待結果 | `Err(ImportValidationError::RedactedPayload { id })` かつ `id` が当該レコードの id と一致する |
+
+#### TC-UT-190: 既存 vault と ID 衝突 → `conflicting_ids` に格納される
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-190 |
+| 対応要件 | REQ-DP-005 |
+| 対応受入基準 | AC-DP-01 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `format_version: 1`・id=`"aaaaa"` の Plaintext レコードを含む `ImportPayload` を構築する / 2. `existing_ids = HashSet::from(["aaaaa".into()])` を用意する / 3. `ImportValidator::validate(&payload, &existing_ids)` を呼ぶ |
+| 期待結果 | `Ok(report)` / `report.conflicting_ids` に `"aaaaa"` が含まれる |
+
+#### TC-UT-191: `records` が空 → `EmptyImport` 警告を含む `Ok`
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-191 |
+| 対応要件 | REQ-DP-005 |
+| 対応受入基準 | AC-DP-01 |
+| 種別 | 境界値 |
+| 前提条件 | なし |
+| 操作 | 1. `format_version: 1`・`records: []` の `ImportPayload` を構築する / 2. `ImportValidator::validate(&payload, &HashSet::new())` を呼ぶ |
+| 期待結果 | `Ok(report)` / `report.warnings` に `ImportWarning::EmptyImport` が含まれる |
+
+#### TC-UT-192: バリデーション順序確認 — `format_version=999` + ID 重複 → `UnknownFormatVersion` 優先
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-192 |
+| 対応要件 | REQ-DP-005 |
+| 対応受入基準 | AC-DP-05 |
+| 種別 | 正常系（順序検証）|
+| 前提条件 | なし |
+| 操作 | 1. `format_version: 999`・同一 id を持つ 2 レコードを含む `ImportPayload` を構築する / 2. `ImportValidator::validate(&payload, &HashSet::new())` を呼ぶ |
+| 期待結果 | `Err(ImportValidationError::UnknownFormatVersion { found: 999 })`（`DuplicateIdInFile` ではなく）|
+
+#### TC-UT-193: バリデーション順序確認 — ID 重複 + Redacted payload → `DuplicateIdInFile` 優先
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-193 |
+| 対応要件 | REQ-DP-005 |
+| 対応受入基準 | AC-DP-04 |
+| 種別 | 正常系（順序検証）|
+| 前提条件 | なし |
+| 操作 | 1. `format_version: 1`・同一 id を持つ 2 レコード（うち 1 件が Redacted）を含む `ImportPayload` を構築する / 2. `ImportValidator::validate(&payload, &HashSet::new())` を呼ぶ |
+| 期待結果 | `Err(ImportValidationError::DuplicateIdInFile { id })`（`RedactedPayload` ではなく）|
+
+---
+
+### 5.5 `ImportValidationError::Display`（REQ-DP-006）
+
+配置: `crates/shikomi-core/src/portability/error.rs` `#[cfg(test)] mod tests`
+
+#### TC-UT-194: `RedactedPayload` の `Display` に record id が含まれる
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-194 |
+| 対応要件 | REQ-DP-006 |
+| 対応受入基準 | AC-DP-03 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `ImportValidationError::RedactedPayload { id: "test-id-123".into() }` を構築する / 2. `format!("{err}")` で Display 文字列を取得する |
+| 期待結果 | 文字列に `"test-id-123"` が含まれる（CLI エラーメッセージの `{reason}` 展開に必要）|
+
+---
+
+## 6. テストケース数サマリー
+
+| グループ | 対象 | TC 数 |
+|---------|------|-------|
+| 5.1 | `ExportRecordPayload::from_record` | 5（TC-UT-177〜181）|
+| 5.2 | `ExportRecord` フィールドマッピング | 2（TC-UT-182〜183）|
+| 5.3 | `ExportPayload` 構造 / serde ラウンドトリップ | 2（TC-UT-184〜185）|
+| 5.4 | `ImportValidator::validate` バリデーション順序 | 8（TC-UT-186〜193）|
+| 5.5 | `ImportValidationError::Display` | 1（TC-UT-194）|
+| **合計** | | **18** |
+
+結合テスト: **なし**（`basic-design.md §テスト戦略` の「IT: 該当なし — domain 型はファイル I/O を持たない」に従う）
+
+受入テスト: AC-DP-01〜05（Sub-A スコープ）の検証は上記 UT で全件カバーされる。E2E（CLI 操作）は Sub-B `cli/test-design.md` で実施する。

--- a/docs/features/data-portability/feature-spec.md
+++ b/docs/features/data-portability/feature-spec.md
@@ -1,0 +1,99 @@
+# feature-spec — data-portability
+
+<!-- feature: data-portability / Issue #135（Phase 2 export/import）/ Issue #140（Sub-A: domain）/ Issue #141（Sub-B: cli）-->
+<!-- 配置先: docs/features/data-portability/feature-spec.md -->
+<!-- 本ファイルは最初の sub-feature PR で凍結。以降の sub-feature PR は引用のみ -->
+
+## 1. 業務概要
+
+shikomi の vault データをファイル単位でエクスポート・インポートする機能を提供する。ユーザーが端末移行・バックアップ・別 vault への引越しを安全かつ確実に行えることが目的。
+
+スコープ: **ローカル export/import のみ**。クラウド同期は将来拡張（`nfr.md §6 Out of Scope` 参照）。
+
+本 feature は 2 Sub-issue に分割:
+
+- **Sub-A（Issue #140）**: domain — `ExportRecord` / `ImportRecord` 型・JSON シリアライゼーション形式・バリデーション
+- **Sub-B（Issue #141）**: cli — `export` / `import` サブコマンド・UseCase wiring・Presenter
+
+## 2. ユースケース
+
+### UC-DP-001: vault をファイルにエクスポートする
+
+| 項目 | 内容 |
+|------|------|
+| アクター | エンドユーザー（CLI 使用者）|
+| 事前条件 | daemon 起動済み（IPC 経路）または `--no-ipc` 指定済み。暗号化 vault の場合は vault がアンロック済み |
+| 基本フロー | ① `shikomi export --output <FILE>` を実行 ② CLI が `VaultRepository` 経由で全レコードを取得 ③ `Secret` kind のペイロードは `[REDACTED]`（既定）に置換して `ExportPayload` を構築 ④ JSON にシリアライズして `<FILE>` に書き込む ⑤ stdout に成功メッセージ（件数・出力先）を表示 |
+| 代替フロー A | `--export-secrets` フラグ指定時 → Secret kind のペイロードを平文で含める |
+| 代替フロー B | vault がロック済みの暗号化モード → `MSG-CLI-140` で exit 1 |
+| 代替フロー C | `<FILE>` が既に存在 → `MSG-CLI-141`（上書き確認）で exit 1（`--force` で上書き可）|
+| 事後条件 | `<FILE>` に有効な `ExportPayload` JSON が書き込まれている |
+
+### UC-DP-002: ファイルから vault にインポートする
+
+| 項目 | 内容 |
+|------|------|
+| アクター | エンドユーザー（CLI 使用者）|
+| 事前条件 | daemon 起動済みまたは `--no-ipc` 指定済み。`<FILE>` が有効な `ExportPayload` JSON |
+| 基本フロー | ① `shikomi import --input <FILE>` を実行 ② ファイルを読み込み・バリデーション ③ 既存レコードとの ID 衝突を確認 ④ `--on-conflict error`（既定）の場合、衝突あれば `MSG-CLI-142` で exit 1 ⑤ バリデーション通過後、`VaultRepository` 経由でレコードを追加 ⑥ stdout に成功メッセージ（追加件数・スキップ件数）を表示 |
+| 代替フロー A | `--on-conflict skip` → 衝突 ID はスキップして残りを追加 |
+| 代替フロー B | `--on-conflict overwrite` → 衝突 ID の既存レコードを置換 |
+| 代替フロー C | フォーマットバージョン不一致 → `MSG-CLI-143` で exit 1 |
+| 代替フロー D | `payload_redacted: true` のレコードを import → `MSG-CLI-144`（payload が空のレコードはインポート不可）で exit 1 |
+| 事後条件 | 指定ファイルの有効レコードが vault に追加・更新されている |
+
+## 3. 機能要件
+
+| ID | 要件 |
+|----|------|
+| R1-DP-01 | `shikomi export --output <FILE>` で vault の全レコードを JSON 形式でファイルに書き出す |
+| R1-DP-02 | `Secret` kind のペイロードは既定でリダクト（`payload_redacted: true`）する。`--export-secrets` フラグで平文 export を明示的に許可する |
+| R1-DP-03 | 暗号化 vault がロック済みの場合、export / import コマンドを拒否する（`MSG-CLI-140`）|
+| R1-DP-04 | export ファイルに `format_version: 1` を含め、将来のフォーマット変更に備える |
+| R1-DP-05 | `shikomi import --input <FILE>` で JSON ファイルを読み込み、バリデーション後に vault へ追加する |
+| R1-DP-06 | import 時の衝突戦略を `--on-conflict skip|overwrite|error` で指定可能にする（既定: `error`）|
+| R1-DP-07 | `payload_redacted: true` のレコードのインポートを拒否する（`MSG-CLI-144`）|
+| R1-DP-08 | export は `VaultRepository` trait 経由で実装し、IPC 経路（daemon）と SQLite 直結（`--no-ipc`）の両方で動作する |
+| R1-DP-09 | export / import の処理は `tempfile` を用いた atomic な書き込みで実装する（import の部分書き込み防止）|
+| R1-DP-10 | `hotkey` フィールドを export ファイルに含める（`null` または文字列）。import 時は hotkey フィールドも復元する |
+
+## 4. 非機能要件（本 feature スコープ）
+
+| 項目 | 要件 |
+|------|------|
+| セキュリティ | Secret kind の平文は `--export-secrets` 明示フラグなしでは export ファイルに含まれない |
+| 互換性 | `format_version: 1` の JSON ファイルは将来バージョンでも読み込み可能にする（フォーマットは後方互換）|
+| アトミック性 | import 中にクラッシュしても vault が壊れない（`tempfile` + rename による atomic commit）|
+| エラーメッセージ | 不正な JSON / 不正なフィールド値は具体的なフィールド名付きエラーで報告する（`MSG-CLI-143`）|
+
+## 5. 受入基準
+
+### Sub-A（Issue #140）: domain
+
+| ID | 基準 |
+|----|------|
+| AC-DP-01 | `ExportRecord` / `ExportPayload` が JSON にシリアライズ・デシリアライズできる |
+| AC-DP-02 | `Secret` kind のレコードが `payload_redacted: true` で export される（`--export-secrets` なし）|
+| AC-DP-03 | `payload_redacted: true` のレコードを `ImportValidator` に渡すと `ImportValidationError::RedactedPayload` が返る |
+| AC-DP-04 | 同一 ID を持つ 2 レコードを `ImportValidator` に渡すと `ImportValidationError::DuplicateId` が返る |
+| AC-DP-05 | `format_version: 999`（未知のバージョン）を `ImportValidator` に渡すと `ImportValidationError::UnknownFormatVersion` が返る |
+
+### Sub-B（Issue #141）: cli
+
+| ID | 基準 |
+|----|------|
+| AC-DP-06 | `shikomi export --output /tmp/test.json` が成功し、`format_version: 1` を含む有効な JSON が `/tmp/test.json` に書き込まれる |
+| AC-DP-07 | `shikomi import --input /tmp/test.json` が成功し、export 元と同じレコードが vault に存在する（round-trip）|
+| AC-DP-08 | `--export-secrets` なしで `shikomi export` した Secret kind のレコードが、`shikomi import` で拒否される（`MSG-CLI-144`）|
+| AC-DP-09 | `shikomi import --on-conflict skip` が、衝突レコードをスキップして残りを追加する |
+| AC-DP-10 | `shikomi import --input /tmp/test.json` を 2 回実行すると 2 回目は全件衝突で `MSG-CLI-142` が表示される（`--on-conflict error` 既定）|
+
+## 6. スコープ外
+
+| 項目 | 理由 |
+|------|------|
+| クラウド同期 | 単一障害点・セキュリティ境界複雑化（`nfr.md §6 Out of Scope`）|
+| CSV / YAML 形式 | YAGNI（JSON で十分。`format_version` で将来追加可能）|
+| 暗号化 vault のロック済み状態での export | 復号キーなしに export 不可。ロック解除を事前条件とする |
+| import 時の新規 ID 採番オプション | YAGNI（`--regenerate-ids` は将来拡張。ID 衝突は `--on-conflict` で対処）|
+| GUI からの export / import | `shikomi-gui` feature の後続スコープ |

--- a/docs/features/data-portability/feature-spec.md
+++ b/docs/features/data-portability/feature-spec.md
@@ -23,8 +23,8 @@ shikomi の vault データをファイル単位でエクスポート・イン�
 |------|------|
 | アクター | エンドユーザー（CLI 使用者）|
 | 事前条件 | daemon 起動済み（IPC 経路）または `--no-ipc` 指定済み。暗号化 vault の場合は vault がアンロック済み |
-| 基本フロー | ① `shikomi export --output <FILE>` を実行 ② CLI が `VaultRepository` 経由で全レコードを取得 ③ `Secret` kind のペイロードは `[REDACTED]`（既定）に置換して `ExportPayload` を構築 ④ JSON にシリアライズして `<FILE>` に書き込む ⑤ stdout に成功メッセージ（件数・出力先）を表示 |
-| 代替フロー A | `--export-secrets` フラグ指定時 → Secret kind のペイロードを平文で含める |
+| 基本フロー | ① `shikomi export --output <FILE>` を実行 ② CLI が `VaultRepository` 経由で全レコードを取得 ③ `Secret` kind のペイロードは `{"kind":"redacted"}` tagged union（既定）で表現した `ExportPayload` を構築 ④ JSON にシリアライズして `<FILE>` に `0600` パーミッションで書き込む ⑤ stdout に成功メッセージ（件数・出力先）を表示 |
+| 代替フロー A | `--export-secrets` フラグ指定時 → stderr に `MSG-CLI-145`（Secret 平文 export 警告）を出力してから Secret kind のペイロードを平文で含める |
 | 代替フロー B | vault がロック済みの暗号化モード → `MSG-CLI-140` で exit 1 |
 | 代替フロー C | `<FILE>` が既に存在 → `MSG-CLI-141`（上書き確認）で exit 1（`--force` で上書き可）|
 | 事後条件 | `<FILE>` に有効な `ExportPayload` JSON が書き込まれている |
@@ -39,7 +39,7 @@ shikomi の vault データをファイル単位でエクスポート・イン�
 | 代替フロー A | `--on-conflict skip` → 衝突 ID はスキップして残りを追加 |
 | 代替フロー B | `--on-conflict overwrite` → 衝突 ID の既存レコードを置換 |
 | 代替フロー C | フォーマットバージョン不一致 → `MSG-CLI-143` で exit 1 |
-| 代替フロー D | `payload_redacted: true` のレコードを import → `MSG-CLI-144`（payload が空のレコードはインポート不可）で exit 1 |
+| 代替フロー D | `{"kind":"redacted"}` payload のレコードを import → `MSG-CLI-144`（リダクト済みレコードはインポート不可）で exit 1 |
 | 事後条件 | 指定ファイルの有効レコードが vault に追加・更新されている |
 
 ## 3. 機能要件
@@ -47,12 +47,12 @@ shikomi の vault データをファイル単位でエクスポート・イン�
 | ID | 要件 |
 |----|------|
 | R1-DP-01 | `shikomi export --output <FILE>` で vault の全レコードを JSON 形式でファイルに書き出す |
-| R1-DP-02 | `Secret` kind のペイロードは既定でリダクト（`payload_redacted: true`）する。`--export-secrets` フラグで平文 export を明示的に許可する |
+| R1-DP-02 | `Secret` kind のペイロードは既定でリダクト（`{"kind":"redacted"}` tagged union）する。`--export-secrets` フラグで平文 export を明示的に許可する。`--export-secrets` 実行時は stderr に `MSG-CLI-145`（Secret 平文 export 警告）を必ず出力する（`--quiet` でも抑止不可）|
 | R1-DP-03 | 暗号化 vault がロック済みの場合、export / import コマンドを拒否する（`MSG-CLI-140`）|
 | R1-DP-04 | export ファイルに `format_version: 1` を含め、将来のフォーマット変更に備える |
 | R1-DP-05 | `shikomi import --input <FILE>` で JSON ファイルを読み込み、バリデーション後に vault へ追加する |
 | R1-DP-06 | import 時の衝突戦略を `--on-conflict skip|overwrite|error` で指定可能にする（既定: `error`）|
-| R1-DP-07 | `payload_redacted: true` のレコードのインポートを拒否する（`MSG-CLI-144`）|
+| R1-DP-07 | `{"kind":"redacted"}` payload を持つレコードのインポートを拒否する（`MSG-CLI-144`）|
 | R1-DP-08 | export は `VaultRepository` trait 経由で実装し、IPC 経路（daemon）と SQLite 直結（`--no-ipc`）の両方で動作する |
 | R1-DP-09 | export / import の処理は `tempfile` を用いた atomic な書き込みで実装する（import の部分書き込み防止）|
 | R1-DP-10 | `hotkey` フィールドを export ファイルに含める（`null` または文字列）。import 時は hotkey フィールドも復元する |
@@ -62,6 +62,8 @@ shikomi の vault データをファイル単位でエクスポート・イン�
 | 項目 | 要件 |
 |------|------|
 | セキュリティ | Secret kind の平文は `--export-secrets` 明示フラグなしでは export ファイルに含まれない |
+| ファイルパーミッション | export ファイルは `0600`（owner read/write のみ）で作成する。Unix 系は `tempfile::Builder::new().permissions(0o600)` で保証する |
+| --export-secrets 警告 | `--export-secrets` 実行時は `MSG-CLI-145` を stderr に出力する。誤操作による Secret 全漏洩を防ぐ最終ゲート |
 | 互換性 | `format_version: 1` の JSON ファイルは将来バージョンでも読み込み可能にする（フォーマットは後方互換）|
 | アトミック性 | import 中にクラッシュしても vault が壊れない（`tempfile` + rename による atomic commit）|
 | エラーメッセージ | 不正な JSON / 不正なフィールド値は具体的なフィールド名付きエラーで報告する（`MSG-CLI-143`）|
@@ -73,8 +75,8 @@ shikomi の vault データをファイル単位でエクスポート・イン�
 | ID | 基準 |
 |----|------|
 | AC-DP-01 | `ExportRecord` / `ExportPayload` が JSON にシリアライズ・デシリアライズできる |
-| AC-DP-02 | `Secret` kind のレコードが `payload_redacted: true` で export される（`--export-secrets` なし）|
-| AC-DP-03 | `payload_redacted: true` のレコードを `ImportValidator` に渡すと `ImportValidationError::RedactedPayload` が返る |
+| AC-DP-02 | `Secret` kind のレコードが `{"kind":"redacted"}` tagged union で export される（`--export-secrets` なし）|
+| AC-DP-03 | `{"kind":"redacted"}` payload を持つレコードを `ImportValidator` に渡すと `ImportValidationError::RedactedPayload` が返る |
 | AC-DP-04 | 同一 ID を持つ 2 レコードを `ImportValidator` に渡すと `ImportValidationError::DuplicateId` が返る |
 | AC-DP-05 | `format_version: 999`（未知のバージョン）を `ImportValidator` に渡すと `ImportValidationError::UnknownFormatVersion` が返る |
 


### PR DESCRIPTION
## 概要

Issue #135 `feat(shikomi-cli): export / import CLI サブコマンド` の工程2（設計書）。
Sub-A（Issue #140）スコープの設計書を新規作成。

## 作成ファイル

| ファイル | 役割 |
|---------|------|
| `docs/features/data-portability/feature-spec.md` | 階層2: 業務仕様・ユースケース・機能要件・受入基準 |
| `docs/features/data-portability/domain/basic-design.md` | 階層3: モジュール契約（REQ-DP-001〜006）|
| `docs/features/data-portability/domain/detailed-design.md` | 階層3: 変更対象ファイル・型設計・セキュリティ |

## 主要設計決定

1. **Secret リダクション**: `kind == "secret"` のペイロードは既定でリダクト。tagged union `{ "kind": "redacted" }` を採用（sentinel 文字列衝突の構造的排除）
2. **`format_version: 1`**: JSON ルートに必須フィールドとして含め、将来のスキーマ変更に対応
3. **`ImportValidator`**: バリデーション責務を単一クラスに集約（UnknownFormatVersion / DuplicateIdInFile / RedactedPayload）
4. **`DataPortabilityError` は CLI UseCase 層**: domain に I/O エラーを持ち込まない
5. **`portability` モジュールを `shikomi-core` に新設**: `serde`/`serde_json` は既存依存のため追加 Cargo.toml 変更なし

## 関連 Issue

- 親: #135
- Sub-A: #140（本 PR スコープ）
- Sub-B: #141（次 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)