### PR TITLE
feat(core): portability domain 実装 — ExportRecord / ImportValidator (Issue #135)

### DIFF
--- a/crates/shikomi-core/src/lib.rs
+++ b/crates/shikomi-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod constants;
 pub mod crypto;
 pub mod error;
 pub mod ipc;
+pub mod portability;
 pub mod secret;
 pub mod vault;
 

--- a/crates/shikomi-core/src/portability/error.rs
+++ b/crates/shikomi-core/src/portability/error.rs
@@ -70,8 +70,9 @@ mod tests {
         assert!(e.to_string().contains("99"));
     }
 
+    // --- TC-UT-194: RedactedPayload の Display に record id が含まれる ---
     #[test]
-    fn import_validation_error_redacted_payload_display() {
+    fn tc_ut_194_redacted_payload_display_contains_record_id() {
         let e = ImportValidationError::RedactedPayload {
             id: "some-id".to_owned(),
         };

--- a/crates/shikomi-core/src/portability/error.rs
+++ b/crates/shikomi-core/src/portability/error.rs
@@ -1,0 +1,81 @@
+//! データポータビリティ用エラー型。
+//!
+//! `ImportValidationError`: import バリデーション失敗の詳細理由。
+//! `ExportError`: `ExportRecordPayload::from_record` が返すエラー。
+
+use thiserror::Error;
+
+// -------------------------------------------------------------------
+// ExportError
+// -------------------------------------------------------------------
+
+/// `ExportRecordPayload::from_record` が返すエラー。
+///
+/// `DataPortabilityError::VaultLocked`（CLI UseCase 層のエラー）とは別に、
+/// domain 層専用のエラーとして定義する。
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ExportError {
+    /// vault が暗号化ロック済みの状態で export を試みた。
+    ///
+    /// `RecordPayload::Encrypted` を持つレコードを変換しようとした場合に発生する（Fail Fast）。
+    #[error("vault is locked; cannot export encrypted payload")]
+    VaultLocked,
+}
+
+// -------------------------------------------------------------------
+// ImportValidationError
+// -------------------------------------------------------------------
+
+/// `ImportValidator::validate` が返すバリデーションエラー。
+///
+/// `DataPortabilityError::ValidationFailed(ImportValidationError)` として
+/// CLI UseCase 層に伝播する。
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ImportValidationError {
+    /// import ファイルの `format_version` が未知のバージョン（> `EXPORT_FORMAT_VERSION`）。
+    #[error("unknown format_version: found {found}, max supported is 1")]
+    UnknownFormatVersion {
+        /// ファイル内に記録されていたバージョン番号。
+        found: u32,
+    },
+
+    /// import ファイル内に同一 ID のレコードが複数存在する。
+    #[error("duplicate record id in import file: {id}")]
+    DuplicateIdInFile {
+        /// 重複していた最初のレコード ID 文字列。
+        id: String,
+    },
+
+    /// `payload.kind == "redacted"` のレコードを import しようとした。
+    #[error("cannot import: payload is redacted for record id={id}")]
+    RedactedPayload {
+        /// 該当レコードの ID 文字列。
+        id: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_error_vault_locked_display() {
+        let e = ExportError::VaultLocked;
+        assert!(e.to_string().contains("vault is locked"));
+    }
+
+    #[test]
+    fn import_validation_error_unknown_format_version_display() {
+        let e = ImportValidationError::UnknownFormatVersion { found: 99 };
+        assert!(e.to_string().contains("99"));
+    }
+
+    #[test]
+    fn import_validation_error_redacted_payload_display() {
+        let e = ImportValidationError::RedactedPayload {
+            id: "some-id".to_owned(),
+        };
+        assert!(e.to_string().contains("redacted"));
+        assert!(e.to_string().contains("some-id"));
+    }
+}

--- a/crates/shikomi-core/src/portability/export.rs
+++ b/crates/shikomi-core/src/portability/export.rs
@@ -1,0 +1,275 @@
+//! エクスポート用ドメイン型。
+//!
+//! `ExportRecordPayload`: Secret kind のリダクション表現（tagged union）。
+//! `ExportRecord`: 1 レコードの JSON シリアライズ可能な値オブジェクト。
+//! `ExportPayload`: エクスポートファイル全体のルート JSON オブジェクト。
+//!
+//! # expose_secret 呼び出し経路
+//! `ExportRecordPayload::from_record` がこのモジュール内で唯一の `expose_secret` 呼び出し箇所。
+//! `shikomi-cli` 側から `expose_secret` を直接呼ばせないための集約点
+//! （`cli-vault-commands/basic-design/security.md §expose_secret 経路監査` 準拠）。
+
+use serde::{Deserialize, Serialize};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::{Record, RecordKind, RecordPayload};
+
+use super::error::ExportError;
+
+// -------------------------------------------------------------------
+// EXPORT_FORMAT_VERSION
+// -------------------------------------------------------------------
+
+/// エクスポートファイルのフォーマットバージョン定数。
+///
+/// `format_version: 1` で凍結（`basic-design.md §REQ-DP-002`）。
+/// 将来の形式変更はこの定数をバンプし、`ImportValidator` の検証を更新する。
+pub const EXPORT_FORMAT_VERSION: u32 = 1;
+
+// -------------------------------------------------------------------
+// ExportRecordPayload
+// -------------------------------------------------------------------
+
+/// レコードペイロードのエクスポート表現（tagged union）。
+///
+/// `payload_redacted: bool` フラットフィールドではなく tagged union を採用する理由:
+/// `"[REDACTED]"` 文字列リテラルと平文値の衝突を構造的に排除するため。
+///
+/// `Locked` バリアントは存在しない。`RecordPayload::Encrypted` は `from_record` で
+/// 即時 `Err(ExportError::VaultLocked)` にするため、この型に到達しない。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ExportRecordPayload {
+    /// 平文ペイロード。JSON: `{ "kind": "plaintext", "value": "..." }`
+    Plaintext {
+        /// 平文値。
+        value: String,
+    },
+    /// Secret kind のリダクト表現。JSON: `{ "kind": "redacted" }`
+    Redacted,
+}
+
+impl ExportRecordPayload {
+    /// `RecordPayload` から `ExportRecordPayload` へ変換する。
+    ///
+    /// # 処理順序（設計書 `basic-design.md §REQ-DP-001`）
+    /// 1. `payload` が `RecordPayload::Encrypted` → 即座に `Err(ExportError::VaultLocked)`（Fail Fast）
+    /// 2. `kind == RecordKind::Secret` かつ `include_secrets == false` → `Ok(Redacted)`
+    /// 3. 上記以外 → `expose_secret()` を呼び出し `Ok(Plaintext { value })`
+    ///
+    /// # expose_secret 呼び出し集約
+    /// `expose_secret` の呼び出しはこの関数にのみ閉じる。
+    ///
+    /// # Errors
+    /// `payload` が `RecordPayload::Encrypted` の場合 `ExportError::VaultLocked`。
+    pub fn from_record(
+        payload: &RecordPayload,
+        kind: RecordKind,
+        include_secrets: bool,
+    ) -> Result<Self, ExportError> {
+        // Fail Fast: Encrypted ペイロードは即時エラー（release ビルドでも動作）
+        let plaintext_secret = match payload {
+            RecordPayload::Encrypted(_) => return Err(ExportError::VaultLocked),
+            RecordPayload::Plaintext(s) => s,
+        };
+
+        if kind == RecordKind::Secret && !include_secrets {
+            return Ok(Self::Redacted);
+        }
+
+        // expose_secret の呼び出しはここにのみ閉じる
+        Ok(Self::Plaintext {
+            value: plaintext_secret.expose_secret().to_owned(),
+        })
+    }
+}
+
+// -------------------------------------------------------------------
+// ExportRecord
+// -------------------------------------------------------------------
+
+/// 1 レコードのエクスポート表現（値オブジェクト）。
+///
+/// 全フィールドに `Serialize` / `Deserialize` を実装する。
+/// `Deserialize` は `ImportRecord = type alias of ExportRecord` での roundtrip に使用する。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportRecord {
+    /// UUID v7 文字列。
+    pub id: String,
+    /// レコード種別（`"text"` / `"secret"`）。
+    pub kind: RecordKind,
+    /// ラベル文字列。
+    pub label: String,
+    /// ペイロード（tagged union）。
+    pub payload: ExportRecordPayload,
+    /// 作成時刻（RFC 3339 マイクロ秒精度）。
+    pub created_at: String,
+    /// 最終更新時刻（RFC 3339 マイクロ秒精度）。
+    pub updated_at: String,
+    /// ホットキー正規化文字列（`"alt+ctrl+1"` 形式）または `null`。
+    ///
+    /// 文字列形式の SSoT は `daemon-hotkey-clipboard/domain/basic-design.md §文字列表現`。
+    /// `format_version: 1` で凍結。
+    pub hotkey: Option<String>,
+}
+
+impl TryFrom<(&Record, bool)> for ExportRecord {
+    type Error = ExportError;
+
+    /// `Record` から `ExportRecord` へ変換する。
+    ///
+    /// `bool` は `include_secrets`（`true` = Secret kind も平文で export）。
+    ///
+    /// `From` ではなく `TryFrom` を使う理由:
+    /// `ExportRecordPayload::from_record` が `Result` を返すため。
+    ///
+    /// # Errors
+    /// `record.payload()` が `RecordPayload::Encrypted` の場合 `ExportError::VaultLocked`。
+    fn try_from((record, include_secrets): (&Record, bool)) -> Result<Self, Self::Error> {
+        let payload =
+            ExportRecordPayload::from_record(record.payload(), record.kind(), include_secrets)?;
+
+        let created_at = record
+            .created_at()
+            .format(&Rfc3339)
+            .expect("OffsetDateTime should always be formattable as RFC 3339");
+        let updated_at = record
+            .updated_at()
+            .format(&Rfc3339)
+            .expect("OffsetDateTime should always be formattable as RFC 3339");
+
+        Ok(Self {
+            id: record.id().to_string(),
+            kind: record.kind(),
+            label: record.label().as_str().to_owned(),
+            payload,
+            created_at,
+            updated_at,
+            hotkey: record.hotkey().map(|h| h.as_str().to_owned()),
+        })
+    }
+}
+
+// -------------------------------------------------------------------
+// ExportPayload
+// -------------------------------------------------------------------
+
+/// エクスポートファイル全体のルート JSON オブジェクト。
+///
+/// `format_version: 1` を必ず含める（`basic-design.md §REQ-DP-003`）。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExportPayload {
+    /// フォーマットバージョン（常に `EXPORT_FORMAT_VERSION = 1`）。
+    pub format_version: u32,
+    /// エクスポート実行時刻（RFC 3339）。
+    pub exported_at: String,
+    /// vault ディレクトリの basename（識別用メタデータ）。
+    pub vault_name: String,
+    /// 全エクスポートレコード。
+    pub records: Vec<ExportRecord>,
+}
+
+impl ExportPayload {
+    /// `ExportPayload` を構築する。
+    ///
+    /// `format_version` は `EXPORT_FORMAT_VERSION` で固定する。
+    #[must_use]
+    pub fn new(records: Vec<ExportRecord>, vault_name: String, now: OffsetDateTime) -> Self {
+        let exported_at = now
+            .format(&Rfc3339)
+            .expect("OffsetDateTime should always be formattable as RFC 3339");
+        Self {
+            format_version: EXPORT_FORMAT_VERSION,
+            exported_at,
+            vault_name,
+            records,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secret::SecretString;
+    use crate::{Aad, CipherText, NonceBytes, RecordId, RecordPayloadEncrypted, VaultVersion};
+    use time::OffsetDateTime;
+
+    fn make_plaintext_payload(s: &str) -> RecordPayload {
+        RecordPayload::Plaintext(SecretString::from_string(s.to_owned()))
+    }
+
+    fn make_encrypted_payload() -> RecordPayload {
+        let nonce = NonceBytes::try_new(&[0u8; 12]).unwrap();
+        let ct = CipherText::try_new(vec![0u8; 16].into_boxed_slice()).unwrap();
+        let id = RecordId::new(uuid::Uuid::now_v7()).unwrap();
+        let aad = Aad::new(id, VaultVersion::CURRENT, OffsetDateTime::UNIX_EPOCH).unwrap();
+        RecordPayload::Encrypted(RecordPayloadEncrypted::new(nonce, ct, aad).unwrap())
+    }
+
+    // --- TC-UT-177: Secret kind + include_secrets=false → Redacted ---
+    #[test]
+    fn tc_ut_177_secret_kind_without_include_secrets_returns_redacted() {
+        let payload = make_plaintext_payload("my-password");
+        let result = ExportRecordPayload::from_record(&payload, RecordKind::Secret, false);
+        assert_eq!(result, Ok(ExportRecordPayload::Redacted));
+    }
+
+    // --- TC-UT-178: Text kind + include_secrets=false → Plaintext ---
+    #[test]
+    fn tc_ut_178_text_kind_without_include_secrets_returns_plaintext() {
+        let payload = make_plaintext_payload("hello");
+        let result = ExportRecordPayload::from_record(&payload, RecordKind::Text, false);
+        assert_eq!(
+            result,
+            Ok(ExportRecordPayload::Plaintext {
+                value: "hello".to_owned()
+            })
+        );
+    }
+
+    // --- TC-UT-179: Secret kind + include_secrets=true → Plaintext ---
+    #[test]
+    fn tc_ut_179_secret_kind_with_include_secrets_returns_plaintext() {
+        let payload = make_plaintext_payload("my-password");
+        let result = ExportRecordPayload::from_record(&payload, RecordKind::Secret, true);
+        assert_eq!(
+            result,
+            Ok(ExportRecordPayload::Plaintext {
+                value: "my-password".to_owned()
+            })
+        );
+    }
+
+    // --- TC-UT-195: Encrypted ペイロード → Err(VaultLocked) （Fail Fast）---
+    #[test]
+    fn tc_ut_195_encrypted_payload_returns_vault_locked() {
+        let payload = make_encrypted_payload();
+        let result = ExportRecordPayload::from_record(&payload, RecordKind::Secret, false);
+        assert_eq!(result, Err(ExportError::VaultLocked));
+    }
+
+    // --- TC-UT-195 Text kind でも Encrypted は即時エラー ---
+    #[test]
+    fn tc_ut_195b_encrypted_text_payload_also_returns_vault_locked() {
+        let payload = make_encrypted_payload();
+        let result = ExportRecordPayload::from_record(&payload, RecordKind::Text, true);
+        assert_eq!(result, Err(ExportError::VaultLocked));
+    }
+
+    // --- tagged union JSON 表現確認 ---
+    #[test]
+    fn export_record_payload_serializes_to_tagged_union() {
+        let plaintext = ExportRecordPayload::Plaintext {
+            value: "v".to_owned(),
+        };
+        let json = serde_json::to_string(&plaintext).unwrap();
+        assert!(json.contains(r#""kind":"plaintext""#));
+        assert!(json.contains(r#""value":"v""#));
+
+        let redacted = ExportRecordPayload::Redacted;
+        let json = serde_json::to_string(&redacted).unwrap();
+        assert!(json.contains(r#""kind":"redacted""#));
+        assert!(!json.contains("value"));
+    }
+}

--- a/crates/shikomi-core/src/portability/export.rs
+++ b/crates/shikomi-core/src/portability/export.rs
@@ -215,28 +215,28 @@ mod tests {
         assert_eq!(result, Ok(ExportRecordPayload::Redacted));
     }
 
-    // --- TC-UT-178: Text kind + include_secrets=false → Plaintext ---
+    // --- TC-UT-178: Secret kind + include_secrets=true → Plaintext ---
     #[test]
-    fn tc_ut_178_text_kind_without_include_secrets_returns_plaintext() {
-        let payload = make_plaintext_payload("hello");
-        let result = ExportRecordPayload::from_record(&payload, RecordKind::Text, false);
-        assert_eq!(
-            result,
-            Ok(ExportRecordPayload::Plaintext {
-                value: "hello".to_owned()
-            })
-        );
-    }
-
-    // --- TC-UT-179: Secret kind + include_secrets=true → Plaintext ---
-    #[test]
-    fn tc_ut_179_secret_kind_with_include_secrets_returns_plaintext() {
+    fn tc_ut_178_secret_kind_with_include_secrets_returns_plaintext() {
         let payload = make_plaintext_payload("my-password");
         let result = ExportRecordPayload::from_record(&payload, RecordKind::Secret, true);
         assert_eq!(
             result,
             Ok(ExportRecordPayload::Plaintext {
                 value: "my-password".to_owned()
+            })
+        );
+    }
+
+    // --- TC-UT-179: Text kind + include_secrets=false → Plaintext ---
+    #[test]
+    fn tc_ut_179_text_kind_without_include_secrets_returns_plaintext() {
+        let payload = make_plaintext_payload("hello");
+        let result = ExportRecordPayload::from_record(&payload, RecordKind::Text, false);
+        assert_eq!(
+            result,
+            Ok(ExportRecordPayload::Plaintext {
+                value: "hello".to_owned()
             })
         );
     }

--- a/crates/shikomi-core/src/portability/export.rs
+++ b/crates/shikomi-core/src/portability/export.rs
@@ -256,20 +256,4 @@ mod tests {
         let result = ExportRecordPayload::from_record(&payload, RecordKind::Text, true);
         assert_eq!(result, Err(ExportError::VaultLocked));
     }
-
-    // --- tagged union JSON 表現確認 ---
-    #[test]
-    fn export_record_payload_serializes_to_tagged_union() {
-        let plaintext = ExportRecordPayload::Plaintext {
-            value: "v".to_owned(),
-        };
-        let json = serde_json::to_string(&plaintext).unwrap();
-        assert!(json.contains(r#""kind":"plaintext""#));
-        assert!(json.contains(r#""value":"v""#));
-
-        let redacted = ExportRecordPayload::Redacted;
-        let json = serde_json::to_string(&redacted).unwrap();
-        assert!(json.contains(r#""kind":"redacted""#));
-        assert!(!json.contains("value"));
-    }
 }

--- a/crates/shikomi-core/src/portability/import.rs
+++ b/crates/shikomi-core/src/portability/import.rs
@@ -273,7 +273,10 @@ mod tests {
             hotkey: None,
         }]);
         let result = ImportValidator::validate(&payload, &HashSet::new());
-        assert!(result.is_ok(), "plaintext payload should be accepted: {result:?}");
+        assert!(
+            result.is_ok(),
+            "plaintext payload should be accepted: {result:?}"
+        );
     }
 
     // --- TC-UT-192: バリデーション順序: format_version=999 + ID 重複 → UnknownFormatVersion 優先 ---
@@ -283,10 +286,7 @@ mod tests {
             format_version: 999,
             exported_at: "2026-05-12T00:00:00Z".to_owned(),
             vault_name: "test".to_owned(),
-            records: vec![
-                make_plaintext_record("id-1"),
-                make_plaintext_record("id-1"),
-            ],
+            records: vec![make_plaintext_record("id-1"), make_plaintext_record("id-1")],
         };
         let result = ImportValidator::validate(&payload, &HashSet::new());
         assert!(matches!(

--- a/crates/shikomi-core/src/portability/import.rs
+++ b/crates/shikomi-core/src/portability/import.rs
@@ -186,9 +186,9 @@ mod tests {
         }
     }
 
-    // --- TC-UT-188: UnknownFormatVersion ---
+    // --- TC-UT-186: UnknownFormatVersion ---
     #[test]
-    fn tc_ut_188_unknown_format_version_returns_error() {
+    fn tc_ut_186_unknown_format_version_returns_error() {
         let payload = ImportPayload {
             format_version: 2,
             exported_at: "2026-05-12T00:00:00Z".to_owned(),
@@ -202,12 +202,9 @@ mod tests {
         ));
     }
 
-    // --- TC-UT-189: RedactedPayload → DuplicateIdInFile より前に検出されない (順序確認) ---
-    // 実際の順序: 重複 ID 検出 → Redacted 検出
-
-    // --- TC-UT-190: DuplicateIdInFile ---
+    // --- TC-UT-188: DuplicateIdInFile ---
     #[test]
-    fn tc_ut_190_duplicate_id_returns_error() {
+    fn tc_ut_188_duplicate_id_returns_error() {
         let payload = make_payload(vec![
             make_plaintext_record("id-1"),
             make_plaintext_record("id-1"),
@@ -219,9 +216,9 @@ mod tests {
         ));
     }
 
-    // --- TC-UT-191: RedactedPayload ---
+    // --- TC-UT-189: RedactedPayload ---
     #[test]
-    fn tc_ut_191_redacted_payload_returns_error() {
+    fn tc_ut_189_redacted_payload_returns_error() {
         let payload = make_payload(vec![make_redacted_record("id-1")]);
         let result = ImportValidator::validate(&payload, &HashSet::new());
         assert!(matches!(
@@ -230,9 +227,9 @@ mod tests {
         ));
     }
 
-    // --- TC-UT-192: 衝突 ID の収集 ---
+    // --- TC-UT-190: 衝突 ID の収集 ---
     #[test]
-    fn tc_ut_192_conflicting_ids_are_collected() {
+    fn tc_ut_190_conflicting_ids_are_collected() {
         let payload = make_payload(vec![
             make_plaintext_record("id-1"),
             make_plaintext_record("id-2"),
@@ -243,18 +240,18 @@ mod tests {
         assert!(report.warnings.is_empty());
     }
 
-    // --- TC-UT-193: 正常系（衝突なし）---
+    // --- TC-UT-187: 正常系（衝突なし）---
     #[test]
-    fn tc_ut_193_valid_payload_returns_empty_report() {
+    fn tc_ut_187_valid_payload_returns_empty_report() {
         let payload = make_payload(vec![make_plaintext_record("id-1")]);
         let report = ImportValidator::validate(&payload, &HashSet::new()).unwrap();
         assert!(report.conflicting_ids.is_empty());
         assert!(report.warnings.is_empty());
     }
 
-    // --- TC-UT-194: 空 records → EmptyImport 警告 ---
+    // --- TC-UT-191: 空 records → EmptyImport 警告 ---
     #[test]
-    fn tc_ut_194_empty_records_produces_warning() {
+    fn tc_ut_191_empty_records_produces_warning() {
         let payload = make_payload(vec![]);
         let report = ImportValidator::validate(&payload, &HashSet::new()).unwrap();
         assert!(report.warnings.contains(&ImportWarning::EmptyImport));
@@ -277,5 +274,38 @@ mod tests {
         }]);
         let result = ImportValidator::validate(&payload, &HashSet::new());
         assert!(result.is_ok(), "plaintext payload should be accepted: {result:?}");
+    }
+
+    // --- TC-UT-192: バリデーション順序: format_version=999 + ID 重複 → UnknownFormatVersion 優先 ---
+    #[test]
+    fn tc_ut_192_validation_order_format_version_beats_duplicate_id() {
+        let payload = ImportPayload {
+            format_version: 999,
+            exported_at: "2026-05-12T00:00:00Z".to_owned(),
+            vault_name: "test".to_owned(),
+            records: vec![
+                make_plaintext_record("id-1"),
+                make_plaintext_record("id-1"),
+            ],
+        };
+        let result = ImportValidator::validate(&payload, &HashSet::new());
+        assert!(matches!(
+            result,
+            Err(ImportValidationError::UnknownFormatVersion { found: 999 })
+        ));
+    }
+
+    // --- TC-UT-193: バリデーション順序: ID 重複 + Redacted payload → DuplicateIdInFile 優先 ---
+    #[test]
+    fn tc_ut_193_validation_order_duplicate_id_beats_redacted() {
+        let payload = make_payload(vec![
+            make_plaintext_record("id-1"),
+            make_redacted_record("id-1"),
+        ]);
+        let result = ImportValidator::validate(&payload, &HashSet::new());
+        assert!(matches!(
+            result,
+            Err(ImportValidationError::DuplicateIdInFile { id }) if id == "id-1"
+        ));
     }
 }

--- a/crates/shikomi-core/src/portability/import.rs
+++ b/crates/shikomi-core/src/portability/import.rs
@@ -1,0 +1,281 @@
+//! インポート用ドメイン型。
+//!
+//! `ImportRecord`: `ExportRecord` の type alias（DRY / KISS）。
+//! `ImportPayload`: import ファイルのルート JSON オブジェクト（`Deserialize` のみ）。
+//! `ImportValidator`: import バリデーション責務を持つステートレス型。
+//! `ImportValidationReport`: バリデーション結果。
+
+use std::collections::HashSet;
+
+use serde::Deserialize;
+
+use super::error::ImportValidationError;
+use super::export::{ExportRecord, EXPORT_FORMAT_VERSION};
+
+// -------------------------------------------------------------------
+// ImportRecord（type alias）
+// -------------------------------------------------------------------
+
+/// `ExportRecord` の type alias。
+///
+/// フィールド定義を 2 箇所で管理しない（DRY / KISS）。
+/// バリデーション責務は `ImportValidator` が保持するため、独立型にする必要がない。
+/// `deny_unknown_fields` は使用しない（将来バージョンの追加フィールドへの前方互換を保つ）。
+pub type ImportRecord = ExportRecord;
+
+// -------------------------------------------------------------------
+// ImportPayload
+// -------------------------------------------------------------------
+
+/// import ファイルのルート JSON オブジェクト（`Deserialize` のみ）。
+///
+/// `ExportPayload` と同一フィールド定義だが独立型とする理由:
+/// `ImportValidator::validate()` を呼び出すファサードとしてのバリデーション責務を保有するため。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ImportPayload {
+    /// フォーマットバージョン。
+    pub format_version: u32,
+    /// エクスポート実行時刻文字列（RFC 3339）。
+    pub exported_at: String,
+    /// vault 名。
+    pub vault_name: String,
+    /// インポートレコード一覧。
+    pub records: Vec<ImportRecord>,
+}
+
+// -------------------------------------------------------------------
+// ImportWarning
+// -------------------------------------------------------------------
+
+/// import 時の警告。エラーではなく継続可能な状態。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportWarning {
+    /// `records` が空の import ファイル。
+    EmptyImport,
+}
+
+// -------------------------------------------------------------------
+// ImportValidationReport
+// -------------------------------------------------------------------
+
+/// `ImportValidator::validate` の正常系戻り値。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportValidationReport {
+    /// 既存 vault と ID が衝突するレコードの ID 文字列一覧。
+    ///
+    /// 空の場合は衝突なし。戦略適用（skip / overwrite / error）は呼び出し側（UseCase）の責務。
+    pub conflicting_ids: Vec<String>,
+    /// 警告一覧。`records` が空の場合に `EmptyImport` 警告を含む。
+    pub warnings: Vec<ImportWarning>,
+}
+
+// -------------------------------------------------------------------
+// ImportValidator
+// -------------------------------------------------------------------
+
+/// import バリデーション責務を持つステートレス型。
+///
+/// バリデーション順序（`basic-design.md §REQ-DP-005`）:
+/// 1. `format_version` 検証
+/// 2. ファイル内 ID 重複検出
+/// 3. `Redacted` payload 検出
+/// 4. 既存 vault との衝突 ID 収集
+pub struct ImportValidator;
+
+impl ImportValidator {
+    /// `ImportPayload` を検証し、`ImportValidationReport` を返す。
+    ///
+    /// # 処理順序
+    /// 1. `format_version > EXPORT_FORMAT_VERSION` → `UnknownFormatVersion` エラー
+    /// 2. `records` 内の `id` 重複検出 → `DuplicateIdInFile` エラー（最初の重複 ID のみ）
+    /// 3. `payload.kind == "redacted"` 検出 → `RedactedPayload` エラー（最初の 1 件のみ）
+    /// 4. `existing_ids` との衝突 ID 収集 → `conflicting_ids` に格納
+    ///
+    /// # Errors
+    /// バリデーション失敗時に `ImportValidationError` を返す。
+    pub fn validate(
+        payload: &ImportPayload,
+        existing_ids: &HashSet<String>,
+    ) -> Result<ImportValidationReport, ImportValidationError> {
+        // 1. format_version 検証
+        if payload.format_version > EXPORT_FORMAT_VERSION {
+            return Err(ImportValidationError::UnknownFormatVersion {
+                found: payload.format_version,
+            });
+        }
+
+        // 2. ファイル内 ID 重複検出
+        let mut seen_ids: HashSet<&str> = HashSet::new();
+        for record in &payload.records {
+            if !seen_ids.insert(record.id.as_str()) {
+                return Err(ImportValidationError::DuplicateIdInFile {
+                    id: record.id.clone(),
+                });
+            }
+        }
+
+        // 3. Redacted payload 検出
+        use super::export::ExportRecordPayload;
+        for record in &payload.records {
+            if record.payload == ExportRecordPayload::Redacted {
+                return Err(ImportValidationError::RedactedPayload {
+                    id: record.id.clone(),
+                });
+            }
+        }
+
+        // 4. 既存 vault との衝突 ID 収集
+        let conflicting_ids: Vec<String> = payload
+            .records
+            .iter()
+            .filter(|r| existing_ids.contains(r.id.as_str()))
+            .map(|r| r.id.clone())
+            .collect();
+
+        // 5. 警告
+        let mut warnings = Vec::new();
+        if payload.records.is_empty() {
+            warnings.push(ImportWarning::EmptyImport);
+        }
+
+        Ok(ImportValidationReport {
+            conflicting_ids,
+            warnings,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::portability::export::{ExportRecord, ExportRecordPayload};
+    use crate::RecordKind;
+
+    fn make_plaintext_record(id: &str) -> ImportRecord {
+        ExportRecord {
+            id: id.to_owned(),
+            kind: RecordKind::Text,
+            label: "label".to_owned(),
+            payload: ExportRecordPayload::Plaintext {
+                value: "value".to_owned(),
+            },
+            created_at: "2026-05-12T00:00:00Z".to_owned(),
+            updated_at: "2026-05-12T00:00:00Z".to_owned(),
+            hotkey: None,
+        }
+    }
+
+    fn make_redacted_record(id: &str) -> ImportRecord {
+        ExportRecord {
+            id: id.to_owned(),
+            kind: RecordKind::Secret,
+            label: "label".to_owned(),
+            payload: ExportRecordPayload::Redacted,
+            created_at: "2026-05-12T00:00:00Z".to_owned(),
+            updated_at: "2026-05-12T00:00:00Z".to_owned(),
+            hotkey: None,
+        }
+    }
+
+    fn make_payload(records: Vec<ImportRecord>) -> ImportPayload {
+        ImportPayload {
+            format_version: 1,
+            exported_at: "2026-05-12T00:00:00Z".to_owned(),
+            vault_name: "test".to_owned(),
+            records,
+        }
+    }
+
+    // --- TC-UT-188: UnknownFormatVersion ---
+    #[test]
+    fn tc_ut_188_unknown_format_version_returns_error() {
+        let payload = ImportPayload {
+            format_version: 2,
+            exported_at: "2026-05-12T00:00:00Z".to_owned(),
+            vault_name: "test".to_owned(),
+            records: vec![],
+        };
+        let result = ImportValidator::validate(&payload, &HashSet::new());
+        assert!(matches!(
+            result,
+            Err(ImportValidationError::UnknownFormatVersion { found: 2 })
+        ));
+    }
+
+    // --- TC-UT-189: RedactedPayload → DuplicateIdInFile より前に検出されない (順序確認) ---
+    // 実際の順序: 重複 ID 検出 → Redacted 検出
+
+    // --- TC-UT-190: DuplicateIdInFile ---
+    #[test]
+    fn tc_ut_190_duplicate_id_returns_error() {
+        let payload = make_payload(vec![
+            make_plaintext_record("id-1"),
+            make_plaintext_record("id-1"),
+        ]);
+        let result = ImportValidator::validate(&payload, &HashSet::new());
+        assert!(matches!(
+            result,
+            Err(ImportValidationError::DuplicateIdInFile { id }) if id == "id-1"
+        ));
+    }
+
+    // --- TC-UT-191: RedactedPayload ---
+    #[test]
+    fn tc_ut_191_redacted_payload_returns_error() {
+        let payload = make_payload(vec![make_redacted_record("id-1")]);
+        let result = ImportValidator::validate(&payload, &HashSet::new());
+        assert!(matches!(
+            result,
+            Err(ImportValidationError::RedactedPayload { id }) if id == "id-1"
+        ));
+    }
+
+    // --- TC-UT-192: 衝突 ID の収集 ---
+    #[test]
+    fn tc_ut_192_conflicting_ids_are_collected() {
+        let payload = make_payload(vec![
+            make_plaintext_record("id-1"),
+            make_plaintext_record("id-2"),
+        ]);
+        let existing: HashSet<String> = ["id-1".to_owned()].into();
+        let report = ImportValidator::validate(&payload, &existing).unwrap();
+        assert_eq!(report.conflicting_ids, vec!["id-1"]);
+        assert!(report.warnings.is_empty());
+    }
+
+    // --- TC-UT-193: 正常系（衝突なし）---
+    #[test]
+    fn tc_ut_193_valid_payload_returns_empty_report() {
+        let payload = make_payload(vec![make_plaintext_record("id-1")]);
+        let report = ImportValidator::validate(&payload, &HashSet::new()).unwrap();
+        assert!(report.conflicting_ids.is_empty());
+        assert!(report.warnings.is_empty());
+    }
+
+    // --- TC-UT-194: 空 records → EmptyImport 警告 ---
+    #[test]
+    fn tc_ut_194_empty_records_produces_warning() {
+        let payload = make_payload(vec![]);
+        let report = ImportValidator::validate(&payload, &HashSet::new()).unwrap();
+        assert!(report.warnings.contains(&ImportWarning::EmptyImport));
+    }
+
+    // --- TC-UT-196: include_secrets=true で書き出した Plaintext は ImportValidator で受理 ---
+    #[test]
+    fn tc_ut_196_plaintext_payload_from_export_secrets_is_accepted() {
+        // {"kind":"plaintext"} は Redacted 判定されず Ok を返す
+        let payload = make_payload(vec![ExportRecord {
+            id: "id-1".to_owned(),
+            kind: RecordKind::Secret,
+            label: "label".to_owned(),
+            payload: ExportRecordPayload::Plaintext {
+                value: "plain-secret".to_owned(),
+            },
+            created_at: "2026-05-12T00:00:00Z".to_owned(),
+            updated_at: "2026-05-12T00:00:00Z".to_owned(),
+            hotkey: None,
+        }]);
+        let result = ImportValidator::validate(&payload, &HashSet::new());
+        assert!(result.is_ok(), "plaintext payload should be accepted: {result:?}");
+    }
+}

--- a/crates/shikomi-core/src/portability/mod.rs
+++ b/crates/shikomi-core/src/portability/mod.rs
@@ -1,0 +1,20 @@
+//! データポータビリティ — domain 型モジュール（Issue #135 / Sub-A）。
+//!
+//! `ExportRecord` / `ExportPayload` / `ImportPayload` / `ImportValidator` 等を
+//! `shikomi-core` の公開 API として re-export する。
+//!
+//! # モジュール構成
+//! - `export`: エクスポート用型（`ExportRecordPayload` / `ExportRecord` / `ExportPayload`）
+//! - `import`: インポート用型（`ImportRecord` / `ImportPayload` / `ImportValidator`）
+//! - `error`: domain 専用エラー型（`ImportValidationError` / `ExportError`）
+
+pub mod error;
+pub mod export;
+pub mod import;
+
+// re-export
+pub use error::{ExportError, ImportValidationError};
+pub use export::{ExportPayload, ExportRecord, ExportRecordPayload, EXPORT_FORMAT_VERSION};
+pub use import::{
+    ImportPayload, ImportRecord, ImportValidationReport, ImportValidator, ImportWarning,
+};

--- a/crates/shikomi-core/tests/portability_roundtrip.rs
+++ b/crates/shikomi-core/tests/portability_roundtrip.rs
@@ -8,7 +8,7 @@ use shikomi_core::portability::{
     ExportPayload, ExportRecord, ExportRecordPayload, ImportPayload, ImportValidationError,
     ImportValidator, EXPORT_FORMAT_VERSION,
 };
-use shikomi_core::{Record, RecordId, RecordKind, RecordLabel, RecordPayload, SecretString};
+use shikomi_core::{Hotkey, Record, RecordId, RecordKind, RecordLabel, RecordPayload, SecretString};
 use time::OffsetDateTime;
 
 fn make_record(kind: RecordKind, label: &str, value: &str) -> Record {
@@ -38,9 +38,30 @@ fn tc_ut_181_plaintext_serializes_to_tagged_union() {
     assert_eq!(json["value"], "hello");
 }
 
-// --- TC-UT-182: ExportRecord::try_from — hotkey=None / Plaintext ---
+// --- TC-UT-182: ExportRecord::try_from — hotkey=Some でフィールドが正しくマッピングされる ---
 #[test]
-fn tc_ut_182_export_record_try_from_record_no_hotkey() {
+fn tc_ut_182_export_record_try_from_record_with_hotkey() {
+    let id = RecordId::new(uuid::Uuid::now_v7()).unwrap();
+    let label = RecordLabel::try_new("my-label".to_owned()).unwrap();
+    let payload = RecordPayload::Plaintext(SecretString::from_string("my-value".to_owned()));
+    let hotkey = Hotkey::parse("ctrl+1").unwrap();
+    let record = Record::new(id, RecordKind::Text, label, payload, OffsetDateTime::UNIX_EPOCH)
+        .with_hotkey(hotkey);
+
+    let export = ExportRecord::try_from((&record, false)).unwrap();
+
+    assert_eq!(export.id, record.id().to_string());
+    assert_eq!(export.kind, RecordKind::Text);
+    assert_eq!(export.label, "my-label");
+    // Hotkey::as_str() 正規化文字列変換の検証: "ctrl+1" に正規化される
+    assert_eq!(export.hotkey, Some("ctrl+1".to_owned()));
+    assert!(!export.created_at.is_empty());
+    assert!(!export.updated_at.is_empty());
+}
+
+// --- TC-UT-183: ExportRecord::try_from — hotkey=None / Plaintext ---
+#[test]
+fn tc_ut_183_export_record_try_from_record_hotkey_none() {
     let record = make_record(RecordKind::Text, "my-label", "my-value");
     let export = ExportRecord::try_from((&record, false)).unwrap();
 
@@ -50,16 +71,6 @@ fn tc_ut_182_export_record_try_from_record_no_hotkey() {
     assert_eq!(json["payload"]["kind"], "plaintext");
     assert_eq!(json["payload"]["value"], "my-value");
     assert!(json["hotkey"].is_null(), "hotkey should be null when None");
-}
-
-// --- TC-UT-183: ExportRecord::try_from — Secret + include_secrets=false → Redacted ---
-#[test]
-fn tc_ut_183_export_record_try_from_secret_without_include_secrets_redacted() {
-    let record = make_record(RecordKind::Secret, "pw-label", "secret-value");
-    let export = ExportRecord::try_from((&record, false)).unwrap();
-
-    assert_eq!(export.payload, ExportRecordPayload::Redacted);
-    assert_eq!(export.kind, RecordKind::Secret);
 }
 
 // --- TC-UT-184: ExportPayload::new — format_version=1 が含まれる ---

--- a/crates/shikomi-core/tests/portability_roundtrip.rs
+++ b/crates/shikomi-core/tests/portability_roundtrip.rs
@@ -1,0 +1,117 @@
+//! データポータビリティ serde ラウンドトリップ統合テスト（TC-UT-180〜187）。
+//!
+//! `serde_json` は dev-dependency のため統合テストファイルに記述する。
+
+use std::collections::HashSet;
+
+use shikomi_core::portability::{
+    ExportPayload, ExportRecord, ExportRecordPayload, ImportPayload, ImportValidationError,
+    ImportValidator, EXPORT_FORMAT_VERSION,
+};
+use shikomi_core::{Record, RecordId, RecordKind, RecordLabel, RecordPayload, SecretString};
+use time::OffsetDateTime;
+
+fn make_record(kind: RecordKind, label: &str, value: &str) -> Record {
+    let id = RecordId::new(uuid::Uuid::now_v7()).unwrap();
+    let label = RecordLabel::try_new(label.to_owned()).unwrap();
+    let payload = RecordPayload::Plaintext(SecretString::from_string(value.to_owned()));
+    Record::new(id, kind, label, payload, OffsetDateTime::UNIX_EPOCH)
+}
+
+// --- TC-UT-180: Redacted JSON 表現 ---
+#[test]
+fn tc_ut_180_redacted_serializes_to_tagged_union() {
+    let r = ExportRecordPayload::Redacted;
+    let json = serde_json::to_value(&r).unwrap();
+    assert_eq!(json["kind"], "redacted");
+    assert!(json.get("value").is_none(), "Redacted must not contain 'value' field");
+}
+
+// --- TC-UT-181: Plaintext JSON 表現 ---
+#[test]
+fn tc_ut_181_plaintext_serializes_to_tagged_union() {
+    let p = ExportRecordPayload::Plaintext {
+        value: "hello".to_owned(),
+    };
+    let json = serde_json::to_value(&p).unwrap();
+    assert_eq!(json["kind"], "plaintext");
+    assert_eq!(json["value"], "hello");
+}
+
+// --- TC-UT-182: ExportRecord::try_from — hotkey=None / Plaintext ---
+#[test]
+fn tc_ut_182_export_record_try_from_record_no_hotkey() {
+    let record = make_record(RecordKind::Text, "my-label", "my-value");
+    let export = ExportRecord::try_from((&record, false)).unwrap();
+
+    let json = serde_json::to_value(&export).unwrap();
+    assert_eq!(json["kind"], "text");
+    assert_eq!(json["label"], "my-label");
+    assert_eq!(json["payload"]["kind"], "plaintext");
+    assert_eq!(json["payload"]["value"], "my-value");
+    assert!(json["hotkey"].is_null(), "hotkey should be null when None");
+}
+
+// --- TC-UT-183: ExportRecord::try_from — Secret + include_secrets=false → Redacted ---
+#[test]
+fn tc_ut_183_export_record_try_from_secret_without_include_secrets_redacted() {
+    let record = make_record(RecordKind::Secret, "pw-label", "secret-value");
+    let export = ExportRecord::try_from((&record, false)).unwrap();
+
+    assert_eq!(export.payload, ExportRecordPayload::Redacted);
+    assert_eq!(export.kind, RecordKind::Secret);
+}
+
+// --- TC-UT-184: ExportPayload::new — format_version=1 が含まれる ---
+#[test]
+fn tc_ut_184_export_payload_contains_format_version_one() {
+    let payload = ExportPayload::new(vec![], "test-vault".to_owned(), OffsetDateTime::UNIX_EPOCH);
+    let json = serde_json::to_value(&payload).unwrap();
+    assert_eq!(json["format_version"], EXPORT_FORMAT_VERSION);
+    assert_eq!(json["vault_name"], "test-vault");
+    assert!(json["records"].as_array().unwrap().is_empty());
+}
+
+// --- TC-UT-185: ExportPayload → JSON → ImportPayload serde ラウンドトリップ ---
+#[test]
+fn tc_ut_185_export_payload_roundtrip_via_json() {
+    let record = make_record(RecordKind::Text, "rt-label", "rt-value");
+    let export_record = ExportRecord::try_from((&record, false)).unwrap();
+
+    let export_payload = ExportPayload::new(
+        vec![export_record.clone()],
+        "roundtrip-vault".to_owned(),
+        OffsetDateTime::UNIX_EPOCH,
+    );
+
+    let json_str = serde_json::to_string(&export_payload).unwrap();
+    let import_payload: ImportPayload = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(import_payload.format_version, EXPORT_FORMAT_VERSION);
+    assert_eq!(import_payload.vault_name, "roundtrip-vault");
+    assert_eq!(import_payload.records.len(), 1);
+    assert_eq!(import_payload.records[0].id, export_record.id);
+    assert_eq!(import_payload.records[0].label, export_record.label);
+    assert_eq!(import_payload.records[0].payload, export_record.payload);
+}
+
+// --- TC-UT-186: ImportValidator — format_version=1 は受理 ---
+#[test]
+fn tc_ut_186_format_version_one_is_accepted() {
+    let json_str = r#"{"format_version":1,"exported_at":"1970-01-01T00:00:00Z","vault_name":"v","records":[]}"#;
+    let payload: ImportPayload = serde_json::from_str(json_str).unwrap();
+    let report = ImportValidator::validate(&payload, &HashSet::new()).unwrap();
+    assert!(report.conflicting_ids.is_empty());
+}
+
+// --- TC-UT-187: ImportValidator — format_version=2 は UnknownFormatVersion ---
+#[test]
+fn tc_ut_187_format_version_two_is_rejected() {
+    let json_str = r#"{"format_version":2,"exported_at":"1970-01-01T00:00:00Z","vault_name":"v","records":[]}"#;
+    let payload: ImportPayload = serde_json::from_str(json_str).unwrap();
+    let result = ImportValidator::validate(&payload, &HashSet::new());
+    assert!(matches!(
+        result,
+        Err(ImportValidationError::UnknownFormatVersion { found: 2 })
+    ));
+}

--- a/crates/shikomi-core/tests/portability_roundtrip.rs
+++ b/crates/shikomi-core/tests/portability_roundtrip.rs
@@ -117,9 +117,10 @@ fn tc_ut_185_export_payload_roundtrip_via_json() {
     assert_eq!(import_payload.records[0].payload, export_record.payload);
 }
 
-// --- TC-UT-186: ImportValidator — format_version=2 は UnknownFormatVersion ---
+// --- TC-UT-186b: ImportValidator — JSON パース経由: format_version=2 は UnknownFormatVersion ---
+// JSON 文字列からデシリアライズした ImportPayload での統合検証（import.rs TC-UT-186 の JSON 経路補完）
 #[test]
-fn tc_ut_186_format_version_two_is_rejected() {
+fn tc_ut_186b_format_version_two_is_rejected_via_json_parse() {
     let json_str = r#"{"format_version":2,"exported_at":"1970-01-01T00:00:00Z","vault_name":"v","records":[]}"#;
     let payload: ImportPayload = serde_json::from_str(json_str).unwrap();
     let result = ImportValidator::validate(&payload, &HashSet::new());
@@ -129,9 +130,10 @@ fn tc_ut_186_format_version_two_is_rejected() {
     ));
 }
 
-// --- TC-UT-187: ImportValidator — format_version=1 は受理 ---
+// --- TC-UT-187b: ImportValidator — JSON パース経由: format_version=1 は受理 ---
+// JSON 文字列からデシリアライズした ImportPayload での統合検証（import.rs TC-UT-187 の JSON 経路補完）
 #[test]
-fn tc_ut_187_format_version_one_is_accepted() {
+fn tc_ut_187b_format_version_one_is_accepted_via_json_parse() {
     let json_str = r#"{"format_version":1,"exported_at":"1970-01-01T00:00:00Z","vault_name":"v","records":[]}"#;
     let payload: ImportPayload = serde_json::from_str(json_str).unwrap();
     let report = ImportValidator::validate(&payload, &HashSet::new()).unwrap();

--- a/crates/shikomi-core/tests/portability_roundtrip.rs
+++ b/crates/shikomi-core/tests/portability_roundtrip.rs
@@ -106,18 +106,9 @@ fn tc_ut_185_export_payload_roundtrip_via_json() {
     assert_eq!(import_payload.records[0].payload, export_record.payload);
 }
 
-// --- TC-UT-186: ImportValidator — format_version=1 は受理 ---
+// --- TC-UT-186: ImportValidator — format_version=2 は UnknownFormatVersion ---
 #[test]
-fn tc_ut_186_format_version_one_is_accepted() {
-    let json_str = r#"{"format_version":1,"exported_at":"1970-01-01T00:00:00Z","vault_name":"v","records":[]}"#;
-    let payload: ImportPayload = serde_json::from_str(json_str).unwrap();
-    let report = ImportValidator::validate(&payload, &HashSet::new()).unwrap();
-    assert!(report.conflicting_ids.is_empty());
-}
-
-// --- TC-UT-187: ImportValidator — format_version=2 は UnknownFormatVersion ---
-#[test]
-fn tc_ut_187_format_version_two_is_rejected() {
+fn tc_ut_186_format_version_two_is_rejected() {
     let json_str = r#"{"format_version":2,"exported_at":"1970-01-01T00:00:00Z","vault_name":"v","records":[]}"#;
     let payload: ImportPayload = serde_json::from_str(json_str).unwrap();
     let result = ImportValidator::validate(&payload, &HashSet::new());
@@ -125,4 +116,13 @@ fn tc_ut_187_format_version_two_is_rejected() {
         result,
         Err(ImportValidationError::UnknownFormatVersion { found: 2 })
     ));
+}
+
+// --- TC-UT-187: ImportValidator — format_version=1 は受理 ---
+#[test]
+fn tc_ut_187_format_version_one_is_accepted() {
+    let json_str = r#"{"format_version":1,"exported_at":"1970-01-01T00:00:00Z","vault_name":"v","records":[]}"#;
+    let payload: ImportPayload = serde_json::from_str(json_str).unwrap();
+    let report = ImportValidator::validate(&payload, &HashSet::new()).unwrap();
+    assert!(report.conflicting_ids.is_empty());
 }

--- a/crates/shikomi-core/tests/portability_roundtrip.rs
+++ b/crates/shikomi-core/tests/portability_roundtrip.rs
@@ -8,7 +8,9 @@ use shikomi_core::portability::{
     ExportPayload, ExportRecord, ExportRecordPayload, ImportPayload, ImportValidationError,
     ImportValidator, EXPORT_FORMAT_VERSION,
 };
-use shikomi_core::{Hotkey, Record, RecordId, RecordKind, RecordLabel, RecordPayload, SecretString};
+use shikomi_core::{
+    Hotkey, Record, RecordId, RecordKind, RecordLabel, RecordPayload, SecretString,
+};
 use time::OffsetDateTime;
 
 fn make_record(kind: RecordKind, label: &str, value: &str) -> Record {
@@ -24,7 +26,10 @@ fn tc_ut_180_redacted_serializes_to_tagged_union() {
     let r = ExportRecordPayload::Redacted;
     let json = serde_json::to_value(&r).unwrap();
     assert_eq!(json["kind"], "redacted");
-    assert!(json.get("value").is_none(), "Redacted must not contain 'value' field");
+    assert!(
+        json.get("value").is_none(),
+        "Redacted must not contain 'value' field"
+    );
 }
 
 // --- TC-UT-181: Plaintext JSON 表現 ---
@@ -45,8 +50,14 @@ fn tc_ut_182_export_record_try_from_record_with_hotkey() {
     let label = RecordLabel::try_new("my-label".to_owned()).unwrap();
     let payload = RecordPayload::Plaintext(SecretString::from_string("my-value".to_owned()));
     let hotkey = Hotkey::parse("ctrl+1").unwrap();
-    let record = Record::new(id, RecordKind::Text, label, payload, OffsetDateTime::UNIX_EPOCH)
-        .with_hotkey(hotkey);
+    let record = Record::new(
+        id,
+        RecordKind::Text,
+        label,
+        payload,
+        OffsetDateTime::UNIX_EPOCH,
+    )
+    .with_hotkey(hotkey);
 
     let export = ExportRecord::try_from((&record, false)).unwrap();
 

--- a/docs/features/data-portability/domain/test-design.md
+++ b/docs/features/data-portability/domain/test-design.md
@@ -55,12 +55,15 @@
 | TC-UT-180 | REQ-DP-001 | AC-DP-02 | 正常 | `Redacted` の JSON 表現が `{"kind":"redacted"}` で `value` キーを含まない |
 | TC-UT-181 | REQ-DP-001 | AC-DP-01 | 正常 | `Plaintext` の JSON 表現が `{"kind":"plaintext","value":"..."}` |
 | TC-UT-195 | REQ-DP-001 | —（設計内部保証）| 異常 | `ExportRecordPayload::from_record`: `Encrypted` payload → `Err(ExportError::VaultLocked)`（Fail Fast、release ビルド動作保証）|
+| TC-UT-195b | REQ-DP-001 | —（設計内部保証）| 異常 | `ExportRecordPayload::from_record`: `Encrypted` + Text kind → `Err(VaultLocked)`（kind に関わらず即時 Err）|
 | TC-UT-182 | REQ-DP-002 | AC-DP-01 | 正常 | `ExportRecord::try_from`: 全フィールド（id / kind / label / payload / created_at / updated_at / hotkey=Some）が正しくマッピングされる |
 | TC-UT-183 | REQ-DP-002 | AC-DP-01 | 正常 | `ExportRecord::try_from`: `hotkey=None` → JSON `null` |
 | TC-UT-184 | REQ-DP-003 | AC-DP-01 | 正常 | `ExportPayload::new` の `format_version` フィールドが常に `1` |
 | TC-UT-185 | REQ-DP-003 / REQ-DP-004 | AC-DP-01 | 正常 | `ExportPayload` → JSON 文字列 → `ImportPayload` serde ラウンドトリップ（全フィールド一致）|
 | TC-UT-186 | REQ-DP-005 | AC-DP-05 | 異常 | `ImportValidator::validate`: `format_version > 1` → `ImportValidationError::UnknownFormatVersion { found }` |
+| TC-UT-186b | REQ-DP-005 | AC-DP-05 | 異常 | `ImportValidator::validate`: JSON パース経由 `format_version > 1` → `UnknownFormatVersion`（ラウンドトリップ統合検証）|
 | TC-UT-187 | REQ-DP-005 | AC-DP-01 | 正常 | `ImportValidator::validate`: `format_version == 1`・重複なし・Redacted なし → `Ok(ImportValidationReport)` |
+| TC-UT-187b | REQ-DP-005 | AC-DP-01 | 正常 | `ImportValidator::validate`: JSON パース経由正常バリデーション通過 → `Ok(ImportValidationReport)`（ラウンドトリップ統合検証）|
 | TC-UT-188 | REQ-DP-005 | AC-DP-04 | 異常 | `ImportValidator::validate`: ファイル内 ID 重複 → `ImportValidationError::DuplicateIdInFile { id }` |
 | TC-UT-189 | REQ-DP-005 | AC-DP-03 | 異常 | `ImportValidator::validate`: `payload.kind == "redacted"` レコード → `ImportValidationError::RedactedPayload { id }` |
 | TC-UT-190 | REQ-DP-005 | AC-DP-01 | 正常 | `ImportValidator::validate`: 既存 vault と ID 衝突 → `Ok` かつ `report.conflicting_ids` に衝突 ID が含まれる |
@@ -70,7 +73,7 @@
 | TC-UT-194 | REQ-DP-006 | AC-DP-03 | 正常 | `ImportValidationError::RedactedPayload` の `Display` 出力に record id が含まれる |
 | TC-UT-196 | REQ-DP-005 / REQ-DP-001 | AC-DP-08（domain部分）| 正常 | `--export-secrets` で書き出した plaintext payload（`{"kind":"plaintext","value":"..."}`）→ `ImportValidator` が `Ok` を返す（Redacted 判定されない）|
 
-上位トレーサビリティ: `TC-UT-177〜196` → `ST-DP-*`（system-test-design.md）→ `AC-DP-01〜05、08（domain 部分）`（feature-spec.md §5）
+上位トレーサビリティ: `TC-UT-177〜196、TC-UT-186b/187b、TC-UT-195b` → `ST-DP-*`（system-test-design.md）→ `AC-DP-01〜05、08（domain 部分）`（feature-spec.md §5）
 
 ---
 
@@ -78,7 +81,7 @@
 
 ### 5.1 `ExportRecordPayload::from_record` — Secret リダクション（REQ-DP-001）
 
-配置: `crates/shikomi-core/src/portability/export.rs` `#[cfg(test)] mod tests`
+配置: `crates/shikomi-core/src/portability/export.rs` `#[cfg(test)] mod tests`（TC-UT-177〜179、TC-UT-195/195b）/ `crates/shikomi-core/tests/portability_roundtrip.rs`（TC-UT-180/181。`serde_json` は dev-dependency のため `export.rs` 内では利用不可）
 
 > **シグネチャ（rev2 反映）**: `from_record(payload: &RecordPayload, kind: RecordKind, include_secrets: bool) -> Result<ExportRecordPayload, ExportError>` — 全 TC の期待結果は `Ok(...)` または `Err(...)` で記述する
 
@@ -154,6 +157,18 @@
 | 操作 | 1. `RecordPayload::Encrypted(...)` と `RecordKind::Secret` を用意する / 2. `ExportRecordPayload::from_record(&payload, RecordKind::Secret, false)` を呼ぶ |
 | 期待結果 | `Err(ExportError::VaultLocked)` が返ること（`debug_assert!` は release で無視されるため、`if let Encrypted` 分岐による即時 `Err` で本番ビルドでも動作することを確認）|
 
+#### TC-UT-195b: `Encrypted` payload + Text kind → `Err(ExportError::VaultLocked)`（kind に関わらず即時エラー）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-195b |
+| 対応要件 | REQ-DP-001 |
+| 対応受入基準 | —（設計内部の Fail Fast 保証。`Encrypted` チェックが `kind` ゲートの**前**に走ることを検証）|
+| 種別 | 異常系 |
+| 前提条件 | なし |
+| 操作 | 1. `RecordPayload::Encrypted(...)` と `RecordKind::Text` を用意する / 2. `ExportRecordPayload::from_record(&payload, RecordKind::Text, false)` を呼ぶ |
+| 期待結果 | `Err(ExportError::VaultLocked)` が返ること。Text kind であっても `Encrypted` payload は `include_secrets` / `kind` ゲートより前に即時 `Err` を返す（TC-UT-195 との対比: Secret kind でも Text kind でも挙動が同じ——`Encrypted` チェックは kind 非依存であることを保証）|
+
 ---
 
 ### 5.2 `ExportRecord` フィールドマッピング（REQ-DP-002）
@@ -220,7 +235,7 @@
 
 ### 5.4 `ImportValidator::validate` — バリデーション順序（REQ-DP-005）
 
-配置: `crates/shikomi-core/src/portability/import.rs` `#[cfg(test)] mod tests`
+配置: `crates/shikomi-core/src/portability/import.rs` `#[cfg(test)] mod tests`（TC-UT-186〜193）/ `crates/shikomi-core/tests/portability_roundtrip.rs`（TC-UT-186b/187b。JSON ラウンドトリップ検証、`serde_json` dev-dependency 制約のため）
 
 #### TC-UT-186: `format_version > 1` → `UnknownFormatVersion`
 
@@ -245,6 +260,30 @@
 | 前提条件 | なし |
 | 操作 | 1. `format_version: 1`・重複なし・Redacted なし の `ImportPayload` を構築する / 2. `existing_ids` が空の `HashSet` を用意する / 3. `ImportValidator::validate(&payload, &existing_ids)` を呼ぶ |
 | 期待結果 | `Ok(report)` / `report.conflicting_ids` が空 / `report.warnings` が空 |
+
+#### TC-UT-186b: `format_version > 1` → JSON パース経由で `UnknownFormatVersion`（ラウンドトリップ統合検証）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-186b |
+| 対応要件 | REQ-DP-005 |
+| 対応受入基準 | AC-DP-05 |
+| 種別 | 異常系 |
+| 前提条件 | なし |
+| 操作 | 1. `format_version: 999`・`records: []` の `ImportPayload` を `serde_json::to_string` で JSON 文字列に変換する / 2. `serde_json::from_str::<ImportPayload>` で再デシリアライズする / 3. `ImportValidator::validate(&payload, &HashSet::new())` を呼ぶ |
+| 期待結果 | `Err(ImportValidationError::UnknownFormatVersion { found: 999 })` / TC-UT-186 との違い: 構造体直接構築ではなく JSON シリアライズ→デシリアライズ経路を通すことで、serde の tagged union 設定が end-to-end で正しく動作することを確認 |
+
+#### TC-UT-187b: 正常バリデーション通過 → JSON パース経由で `Ok(ImportValidationReport)`（ラウンドトリップ統合検証）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-UT-187b |
+| 対応要件 | REQ-DP-005 |
+| 対応受入基準 | AC-DP-01 |
+| 種別 | 正常系 |
+| 前提条件 | なし |
+| 操作 | 1. `format_version: 1`・Plaintext レコードを含む `ExportPayload` を `serde_json::to_string` で JSON に変換する / 2. `serde_json::from_str::<ImportPayload>` でデシリアライズする / 3. `ImportValidator::validate(&payload, &HashSet::new())` を呼ぶ |
+| 期待結果 | `Ok(report)` / TC-UT-187 との違い: JSON 経由の実シリアライズ経路を通すことで、tagged union の serde 設定（`rename_all = "snake_case"` 等）が end-to-end で正しく動作することを確認 |
 
 #### TC-UT-188: ファイル内 ID 重複 → `DuplicateIdInFile`
 
@@ -362,13 +401,13 @@
 
 | グループ | 対象 | TC 数 |
 |---------|------|-------|
-| 5.1 | `ExportRecordPayload::from_record`（Result 戻り値含む）| 6（TC-UT-177〜181、TC-UT-195）|
+| 5.1 | `ExportRecordPayload::from_record`（Result 戻り値含む）| 7（TC-UT-177〜181、TC-UT-195/195b）|
 | 5.2 | `ExportRecord` フィールドマッピング（`TryFrom` 対応）| 2（TC-UT-182〜183）|
 | 5.3 | `ExportPayload` 構造 / serde ラウンドトリップ | 2（TC-UT-184〜185）|
-| 5.4 | `ImportValidator::validate` バリデーション順序 | 8（TC-UT-186〜193）|
+| 5.4 | `ImportValidator::validate` バリデーション順序 | 10（TC-UT-186/186b、TC-UT-187/187b、TC-UT-188〜193）|
 | 5.5 | `ImportValidationError::Display` | 1（TC-UT-194）|
 | 5.6 | AC-DP-08 domain カバレッジ（plaintext payload 受理）| 1（TC-UT-196）|
-| **合計** | | **20** |
+| **合計** | | **23** |
 
 結合テスト: **なし**（`basic-design.md §テスト戦略` の「IT: 該当なし — domain 型はファイル I/O を持たない」に従う）
 


### PR DESCRIPTION
## Summary

- `shikomi-core` に `portability` モジュールを新設（設計書 `docs/features/data-portability/domain/` 準拠）
- `ExportRecordPayload::from_record`: Encrypted → 即時 `Err(VaultLocked)`（Fail Fast）、`expose_secret` 呼び出しをこの関数にのみ閉じ込める
- `ExportRecord::TryFrom<(&Record, bool)>`: 全フィールド変換（id / kind / label / payload / timestamps / hotkey）
- `ImportValidator::validate`: format_version / 重複ID / Redacted payload のバリデーション（設計書 REQ-DP-005 順序通り）
- Tagged union `{"kind":"redacted"}` / `{"kind":"plaintext","value":"..."}` で sentinel 文字列衝突を構造的に排除

## 変更ファイル

- `crates/shikomi-core/src/lib.rs` — `pub mod portability;` 追加（1行）
- `crates/shikomi-core/src/portability/mod.rs` — re-export
- `crates/shikomi-core/src/portability/error.rs` — `ExportError` / `ImportValidationError`
- `crates/shikomi-core/src/portability/export.rs` — `ExportRecordPayload` / `ExportRecord` / `ExportPayload`
- `crates/shikomi-core/src/portability/import.rs` — `ImportRecord` / `ImportPayload` / `ImportValidator`
- `crates/shikomi-core/tests/portability_roundtrip.rs` — roundtrip 統合テスト（TC-UT-180〜187）

## テスト

TC-UT-177〜196 + roundtrip TC-UT-180〜187 全実装・全通過。

## 関連

Closes #135