### PR TITLE
feat(cli): data-portability Sub-B — shikomi export / import 実装 (Issue #141)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4174,6 +4174,7 @@ dependencies = [
  "rmp-serde",
  "rpassword",
  "rusqlite",
+ "serde_json",
  "serial_test",
  "sha2",
  "shikomi-core",

--- a/crates/shikomi-cli/Cargo.toml
+++ b/crates/shikomi-cli/Cargo.toml
@@ -34,6 +34,10 @@ tracing       = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror     = { workspace = true }
 dirs          = { workspace = true }
+# Issue #141: data-portability export / import（UseCase 層での JSON シリアライズ・デシリアライズ）
+serde_json    = { workspace = true }
+# Issue #141: export の atomic write（tempfile + persist パターン、R1-DP-09）
+tempfile      = { workspace = true }
 # Issue #75 / Bug-F-007: `windows_pipe_name_from_dir` で `<DIR>` 絶対パスを SHA-256
 # Base32 先頭 16 文字の純関数化（`docs/features/vault-encryption/detailed-design/cli-subcommands.md`
 # §Bug-F-007 解消の Windows pipe 名 `<H>` 契約）。CLI / daemon が同 hash を導出する

--- a/crates/shikomi-cli/src/cli.rs
+++ b/crates/shikomi-cli/src/cli.rs
@@ -100,6 +100,20 @@ pub enum Subcommand {
         about = "Manage daemon autostart registration and check daemon status"
     )]
     Daemon(DaemonSubcommand),
+
+    // ---------------- Issue #141: data-portability export / import ----------------
+
+    /// vault レコードを JSON ファイルへ export する（Issue #141 Sub-B、REQ-DP-007）。
+    ///
+    /// 設計根拠: docs/features/data-portability/cli/basic-design.md §REQ-DP-007
+    #[command(about = "Export vault records to a JSON file")]
+    Export(ExportArgs),
+
+    /// JSON export ファイルから vault へレコードを import する（Issue #141 Sub-B、REQ-DP-007）。
+    ///
+    /// 設計根拠: docs/features/data-portability/cli/basic-design.md §REQ-DP-007
+    #[command(about = "Import records from a JSON export file into the vault")]
+    Import(ImportArgs),
 }
 
 // -------------------------------------------------------------------
@@ -311,6 +325,62 @@ impl From<KindArg> for RecordKind {
             KindArg::Secret => RecordKind::Secret,
         }
     }
+}
+
+// -------------------------------------------------------------------
+// Issue #141: data-portability export / import 引数型
+// -------------------------------------------------------------------
+
+/// `shikomi export` の引数（REQ-DP-007）。
+///
+/// 設計根拠: docs/features/data-portability/cli/detailed-design/cli.md §ExportArgs 型
+#[derive(Args, Debug)]
+pub struct ExportArgs {
+    /// export 先ファイルパス（必須）。
+    #[arg(long, value_name = "FILE")]
+    pub output: std::path::PathBuf,
+
+    /// Secret kind のペイロードを平文で export する（既定はリダクト）。
+    ///
+    /// 実行時は stderr に MSG-CLI-145 が必ず出力される（--quiet でも抑止不可）。
+    #[arg(long)]
+    pub export_secrets: bool,
+
+    /// 出力先ファイルが既に存在する場合に上書きする。
+    #[arg(long)]
+    pub force: bool,
+}
+
+/// `shikomi import` の引数（REQ-DP-007）。
+///
+/// 設計根拠: docs/features/data-portability/cli/detailed-design/cli.md §ImportArgs 型
+#[derive(Args, Debug)]
+pub struct ImportArgs {
+    /// import 元ファイルパス（必須）。
+    #[arg(long, value_name = "FILE")]
+    pub input: std::path::PathBuf,
+
+    /// 衝突戦略（既定: `error`）。
+    ///
+    /// - `error`: 衝突 ID が存在した場合即座に MSG-CLI-142 で exit 1
+    /// - `skip`: 衝突 ID のレコードをスキップして残りを追加
+    /// - `overwrite`: 衝突 ID の既存レコードを import ファイルの値で置換
+    #[arg(long, value_enum, default_value = "error")]
+    pub on_conflict: OnConflictArg,
+}
+
+/// `--on-conflict` の衝突戦略（REQ-DP-007）。
+///
+/// 設計根拠: docs/features/data-portability/cli/detailed-design/cli.md §OnConflictArg 型
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+#[value(rename_all = "snake_case")]
+pub enum OnConflictArg {
+    /// 衝突 ID が存在した場合即座に MSG-CLI-142 で exit 1（既定）。
+    Error,
+    /// 衝突 ID のレコードをスキップして残りを追加する。
+    Skip,
+    /// 衝突 ID の既存レコードを import ファイルの値で置換する。
+    Overwrite,
 }
 
 // -------------------------------------------------------------------

--- a/crates/shikomi-cli/src/error.rs
+++ b/crates/shikomi-cli/src/error.rs
@@ -153,6 +153,41 @@ pub enum CliError {
     /// R1-GUI-01: `shikomi gui` コマンドが `shikomi-gui` を exec できない場合。
     #[error("failed to launch GUI: {0}")]
     GuiLaunchFailed(String),
+
+    // ---------------- Issue #141: data-portability export / import ----------------
+
+    /// vault がロック済みで export / import を試みた（MSG-CLI-140、exit 1）。
+    ///
+    /// `CliError::VaultLocked`（exit 3）とは意図的に分離：export / import は
+    /// daemon ではなく CLI が直接 SQLite を操作する経路であり、exit 3 の
+    /// 「daemon 経由の unlock 要求」とは文脈が異なる。
+    #[error("vault is locked; unlock the vault before running export or import")]
+    ExportImportVaultLocked,
+
+    /// export 出力ファイルが既に存在する（MSG-CLI-141、exit 1）。
+    #[error("export output file already exists: {path}")]
+    ExportOutputFileExists {
+        /// 既に存在するファイルパス。
+        path: PathBuf,
+    },
+
+    /// `--on-conflict error` で import 衝突を検出した（MSG-CLI-142、exit 1）。
+    #[error("import conflict: {} record(s) already exist in vault", ids.len())]
+    ImportConflict {
+        /// 衝突したレコード ID 文字列一覧。
+        ids: Vec<String>,
+    },
+
+    /// import ファイルのデシリアライズ失敗（MSG-CLI-143、exit 1）。
+    #[error("failed to parse import file: {reason}")]
+    ImportDeserializationFailed {
+        /// デシリアライズ失敗の詳細（固定文言または外部ライブラリエラー文言）。
+        reason: String,
+    },
+
+    /// import バリデーション失敗（MSG-CLI-143 / MSG-CLI-144、exit 1）。
+    #[error("import validation failed: {0}")]
+    ImportValidationFailed(shikomi_core::portability::ImportValidationError),
 }
 
 /// daemon から返る `IpcErrorCode` を CLI 層エラーに写像する（Sub-F #44 Phase 2）。
@@ -208,6 +243,31 @@ impl From<PersistenceError> for CliError {
             // SQLite 経路と同じ presenter 経路（MSG-CLI-103）に着地させる（DRY、UX 同一）。
             PersistenceError::RecordNotFound(id) => Self::RecordNotFound(id),
             other => Self::Persistence(other),
+        }
+    }
+}
+
+/// `DataPortabilityError`（UseCase 内部中間エラー型）を `CliError` に変換する（Issue #141）。
+///
+/// 設計根拠: docs/features/data-portability/cli/detailed-design/cli.md §From<DataPortabilityError>
+impl From<crate::usecase::portability::error::DataPortabilityError> for CliError {
+    fn from(e: crate::usecase::portability::error::DataPortabilityError) -> Self {
+        use crate::usecase::portability::error::DataPortabilityError;
+        match e {
+            DataPortabilityError::VaultLocked => Self::ExportImportVaultLocked,
+            DataPortabilityError::OutputFileExists { path } => {
+                Self::ExportOutputFileExists { path }
+            }
+            DataPortabilityError::ConflictError { ids } => Self::ImportConflict { ids },
+            DataPortabilityError::DeserializationFailed { reason } => {
+                Self::ImportDeserializationFailed { reason }
+            }
+            DataPortabilityError::ValidationFailed(err) => Self::ImportValidationFailed(err),
+            DataPortabilityError::IoError(io_err) => {
+                Self::Persistence(PersistenceError::Internal {
+                    reason: io_err.to_string(),
+                })
+            }
         }
     }
 }
@@ -270,7 +330,13 @@ impl From<&CliError> for ExitCode {
             | CliError::ProtocolVersionMismatch { .. }
             | CliError::Crypto { .. }
             | CliError::HotkeyConflict { .. }
-            | CliError::HotkeyParseError { .. } => Self::UserError,
+            | CliError::HotkeyParseError { .. }
+            // Issue #141: data-portability export / import エラー（全て exit 1）
+            | CliError::ExportImportVaultLocked
+            | CliError::ExportOutputFileExists { .. }
+            | CliError::ImportConflict { .. }
+            | CliError::ImportDeserializationFailed { .. }
+            | CliError::ImportValidationFailed(_) => Self::UserError,
             // exit 2（SystemError / WrongPassword）: 既存 I/O 系 + Sub-F SSoT パスワード違い
             CliError::Persistence(_)
             | CliError::Domain(_)
@@ -530,6 +596,34 @@ mod tests {
                 CliError::HotkeyParseError {
                     reason: "invalid combo: foobar".to_owned(),
                 },
+            ),
+            // Issue #141: data-portability export / import エラー（全て exit 1）
+            ("ExportImportVaultLocked", CliError::ExportImportVaultLocked),
+            (
+                "ExportOutputFileExists",
+                CliError::ExportOutputFileExists {
+                    path: std::path::PathBuf::from("/tmp/out.json"),
+                },
+            ),
+            (
+                "ImportConflict",
+                CliError::ImportConflict {
+                    ids: vec!["id-1".to_owned(), "id-2".to_owned()],
+                },
+            ),
+            (
+                "ImportDeserializationFailed",
+                CliError::ImportDeserializationFailed {
+                    reason: "unexpected end of input".to_owned(),
+                },
+            ),
+            (
+                "ImportValidationFailed(UnknownFormatVersion)",
+                CliError::ImportValidationFailed(
+                    shikomi_core::portability::ImportValidationError::UnknownFormatVersion {
+                        found: 99,
+                    },
+                ),
             ),
         ];
         for (name, err) in user_error_cases {

--- a/crates/shikomi-cli/src/lib.rs
+++ b/crates/shikomi-cli/src/lib.rs
@@ -229,6 +229,14 @@ pub fn run() -> ExitCode {
         Subcommand::Add(a) => record_runners::run_add(&handle, a, locale, quiet),
         Subcommand::Edit(a) => record_runners::run_edit(&handle, a, locale, quiet),
         Subcommand::Remove(a) => record_runners::run_remove(&handle, a, locale, quiet),
+        // Issue #141: export / import は常に SQLite 直接アクセスを使用（IPC 経路を使わない）。
+        // `IpcVaultRepository` はペイロードを返さないため。
+        Subcommand::Export(a) => {
+            run_export(a, &handle, args.vault_dir.as_deref(), quiet, locale)
+        }
+        Subcommand::Import(a) => {
+            run_import(a, &handle, args.vault_dir.as_deref(), quiet, locale)
+        }
         // 上の `if let Subcommand::Vault(_)` early return で処理済（網羅性のため `_` で吸収）。
         Subcommand::Vault(_) => unreachable!("vault subcommand handled above"),
         // 上の `if let Subcommand::Gui` early return で処理済（網羅性のため unreachable）。
@@ -241,6 +249,120 @@ pub fn run() -> ExitCode {
         Ok(()) => ExitCode::Success,
         Err(err) => emit_error_and_exit(&err, locale),
     }
+}
+
+// -------------------------------------------------------------------
+// Issue #141: data-portability export / import dispatcher
+// -------------------------------------------------------------------
+
+/// `shikomi export` の dispatcher。
+///
+/// # セキュリティ
+/// `--export-secrets` フラグが指定されている場合、UseCase 呼出の**前**に MSG-CLI-145 を
+/// stderr へ強制出力する。`quiet` フラグを参照しない経路として設計し、UseCase がエラーを
+/// 返した場合でも警告が表示され、ユーザが試みた操作の記録が残る。
+///
+/// # IPC 経路の設計判断
+/// `RepositoryHandle` のバリアントに**関わらず**、常に `SqliteVaultRepository::from_directory`
+/// で直接 SQLite にアクセスする。`IpcVaultRepository` はペイロードを返さないため
+/// export に使用できない（basic-design.md §REQ-DP-008 --no-ipc 経路の設計判断）。
+fn run_export(
+    args: &cli::ExportArgs,
+    handle: &RepositoryHandle,
+    vault_dir: Option<&Path>,
+    quiet: bool,
+    locale: Locale,
+) -> Result<(), CliError> {
+    // Step 1: --export-secrets 警告（--quiet でも抑止不可、UseCase 呼出前に出力）
+    if args.export_secrets {
+        // 直接 eprintln! で stderr へ強制出力（quiet フラグを参照しない設計）
+        eprintln!(
+            "{}",
+            presenter::success::render_export_secrets_warning(locale).trim_end()
+        );
+    }
+
+    // Step 2: vault_dir の解決
+    let resolved_dir = match vault_dir {
+        Some(p) => p.to_path_buf(),
+        None => io::paths::resolve_os_default_vault_dir()?,
+    };
+
+    // Steps 3–4: RepositoryHandle に関わらず SQLite 直接アクセス
+    if matches!(handle, RepositoryHandle::Ipc(_)) {
+        tracing::warn!(
+            target: "shikomi_cli::export",
+            "export uses direct SQLite access regardless of IPC mode"
+        );
+    }
+    let sqlite_repo = SqliteVaultRepository::from_directory(&resolved_dir)?;
+
+    // Step 5: 現在時刻
+    let now = time::OffsetDateTime::now_utc();
+
+    // Step 6: UseCase 呼出
+    let summary =
+        usecase::portability::export::export_records(&sqlite_repo, args, &resolved_dir, now)?;
+
+    // Step 7: 成功出力（quiet の場合は抑止）
+    if !quiet {
+        print_stdout(&presenter::success::render_exported(
+            summary.record_count,
+            &summary.output_path,
+            locale,
+        ));
+    }
+
+    Ok(())
+}
+
+/// `shikomi import` の dispatcher。
+///
+/// # IPC 経路の設計判断
+/// `RepositoryHandle` のバリアントに**関わらず**、常に `SqliteVaultRepository::from_directory`
+/// で直接 SQLite にアクセスする。IPC per-record 書き込みは R1-DP-09 の atomicity 要件に
+/// 非適合（途中クラッシュで半書き込み状態になる）。SQLite `repo.save()` が atomic write を保証。
+fn run_import(
+    args: &cli::ImportArgs,
+    handle: &RepositoryHandle,
+    vault_dir: Option<&Path>,
+    quiet: bool,
+    locale: Locale,
+) -> Result<(), CliError> {
+    // Step 1: vault_dir の解決
+    let resolved_dir = match vault_dir {
+        Some(p) => p.to_path_buf(),
+        None => io::paths::resolve_os_default_vault_dir()?,
+    };
+
+    // Step 2: IPC 経路警告（export と同じ pattern）
+    if matches!(handle, RepositoryHandle::Ipc(_)) {
+        tracing::warn!(
+            target: "shikomi_cli::import",
+            "import uses direct SQLite access regardless of IPC mode"
+        );
+    }
+
+    // Step 3: SQLite 直接アクセス（R1-DP-09 atomicity 要件適合）
+    let sqlite_repo = SqliteVaultRepository::from_directory(&resolved_dir)?;
+
+    // Step 4: 現在時刻
+    let now = time::OffsetDateTime::now_utc();
+
+    // Step 5: UseCase 呼出
+    let summary = usecase::portability::import::import_records(&sqlite_repo, args, now)?;
+
+    // Step 6: 成功出力（quiet の場合は抑止）
+    if !quiet {
+        print_stdout(&presenter::success::render_imported(
+            summary.added,
+            summary.skipped,
+            summary.overwritten,
+            locale,
+        ));
+    }
+
+    Ok(())
 }
 
 // -------------------------------------------------------------------

--- a/crates/shikomi-cli/src/presenter/error.rs
+++ b/crates/shikomi-cli/src/presenter/error.rs
@@ -532,6 +532,122 @@ mod tests {
         }
     }
 
+    // -------------------------------------------------------------------
+    // Issue #141: data-portability Presenter / ExitCode UT — TC-UT-205〜208
+    // 設計根拠: docs/features/data-portability/cli/test-design.md §5.3
+    // -------------------------------------------------------------------
+
+    /// TC-UT-205 (REQ-DP-010): data-portability 新バリアント 5 種が全て
+    /// `ExitCode::UserError`（exit 1）に写像される（SSoT 拡張の局所検証）。
+    ///
+    /// `tc_f_u15` の全体 SSoT 網羅マトリクスと直交し、本 TC は Issue #141 由来の
+    /// 5 バリアントだけに絞った焦点検証として機能する。
+    #[test]
+    fn tc_ut_205_data_portability_error_variants_all_map_to_exit_1() {
+        use crate::error::ExitCode;
+
+        let cases: Vec<(&str, CliError)> = vec![
+            ("ExportImportVaultLocked", CliError::ExportImportVaultLocked),
+            (
+                "ExportOutputFileExists",
+                CliError::ExportOutputFileExists {
+                    path: std::path::PathBuf::from("/tmp/out.json"),
+                },
+            ),
+            (
+                "ImportConflict(empty)",
+                CliError::ImportConflict { ids: vec![] },
+            ),
+            (
+                "ImportDeserializationFailed",
+                CliError::ImportDeserializationFailed {
+                    reason: "reason".to_owned(),
+                },
+            ),
+            (
+                "ImportValidationFailed(UnknownFormatVersion)",
+                CliError::ImportValidationFailed(
+                    shikomi_core::portability::ImportValidationError::UnknownFormatVersion {
+                        found: 999,
+                    },
+                ),
+            ),
+        ];
+        for (name, err) in cases {
+            assert_eq!(
+                ExitCode::from(&err),
+                ExitCode::UserError,
+                "TC-UT-205: {name} should map to ExitCode::UserError (exit 1)"
+            );
+        }
+    }
+
+    /// TC-UT-206 (REQ-DP-011 / AC-DP-10): `format_conflict_ids` — 4 件以下は
+    /// 全 ID をそのままカンマ区切りで返す（省略なし境界値）。
+    #[test]
+    fn tc_ut_206_format_conflict_ids_four_or_fewer_returns_all_ids() {
+        let ids: Vec<String> = vec![
+            "id-1".to_owned(),
+            "id-2".to_owned(),
+            "id-3".to_owned(),
+            "id-4".to_owned(),
+        ];
+        let result = format_conflict_ids(&ids);
+        assert_eq!(
+            result, "id-1, id-2, id-3, id-4",
+            "4 IDs must be joined without ellipsis"
+        );
+    }
+
+    /// TC-UT-207 (REQ-DP-011 / AC-DP-10): `format_conflict_ids` — 5 件以上は
+    /// 先頭 4 件 + `... (N more)` 形式で省略される（terminal 溢れ防止境界値）。
+    #[test]
+    fn tc_ut_207_format_conflict_ids_five_or_more_shows_ellipsis() {
+        let ids: Vec<String> = vec![
+            "a".to_owned(),
+            "b".to_owned(),
+            "c".to_owned(),
+            "d".to_owned(),
+            "e".to_owned(),
+            "f".to_owned(),
+        ];
+        let result = format_conflict_ids(&ids);
+        assert!(
+            result.contains("a, b, c, d"),
+            "must contain first 4 IDs 'a, b, c, d', got: {result:?}"
+        );
+        assert!(
+            result.contains("... (2 more)"),
+            "must contain '... (2 more)' for 6 total IDs, got: {result:?}"
+        );
+    }
+
+    /// TC-UT-208 (REQ-DP-010/011 / AC-DP-08): `render_error` —
+    /// `ImportValidationFailed(RedactedPayload)` → MSG-CLI-144 文面が出力される。
+    ///
+    /// `render_error` → `render_import_validation_redacted` dispatch の検証。
+    #[test]
+    fn tc_ut_208_render_error_import_validation_redacted_returns_msg_cli_144() {
+        let err = CliError::ImportValidationFailed(
+            shikomi_core::portability::ImportValidationError::RedactedPayload {
+                id: "test-id-xyz".to_owned(),
+            },
+        );
+        let out = render_error(&err, Locale::English);
+        assert!(
+            out.contains("cannot import record test-id-xyz"),
+            "must contain 'cannot import record test-id-xyz', got: {out:?}"
+        );
+        assert!(
+            out.contains("payload is redacted"),
+            "must contain 'payload is redacted', got: {out:?}"
+        );
+        assert!(
+            out.contains("re-export"),
+            "must contain 're-export' hint, got: {out:?}"
+        );
+    }
+
     /// TC-UT-158b (Issue #134 / MSG-CLI-110): `render_daemon_not_running()` の出力に
     /// `"shikomi daemon install"` autostart hint が含まれること。
     ///

--- a/crates/shikomi-cli/src/presenter/error.rs
+++ b/crates/shikomi-cli/src/presenter/error.rs
@@ -14,6 +14,7 @@ use super::Locale;
 ///
 /// 例外: MSG-CLI-110（DaemonNotRunning）は 3 OS 並記の hint で複数行 / MSG-CLI-111
 /// （ProtocolVersionMismatch）は 1 hint 行で構成し、それぞれ専用 helper を呼ぶ。
+/// Issue #141: MSG-CLI-144（ImportValidationFailed::RedactedPayload）も専用 helper を呼ぶ。
 #[must_use]
 pub fn render_error(err: &CliError, locale: Locale) -> String {
     match err {
@@ -21,6 +22,11 @@ pub fn render_error(err: &CliError, locale: Locale) -> String {
         CliError::ProtocolVersionMismatch { server, client } => {
             render_protocol_version_mismatch(server, client, locale)
         }
+        // Issue #141: MSG-CLI-144 — RedactedPayload は専用 helper で描画する。
+        // UnknownFormatVersion / DuplicateIdInFile は lines_for の fallback（MSG-CLI-143）で処理する。
+        CliError::ImportValidationFailed(
+            shikomi_core::portability::ImportValidationError::RedactedPayload { id },
+        ) => render_import_validation_redacted(id, locale),
         _ => render_default(err, locale),
     }
 }
@@ -286,6 +292,49 @@ fn lines_for(err: &CliError) -> (String, String, String, String) {
             "is shikomi-gui installed? try reinstalling shikomi".to_owned(),
             "shikomi-gui がインストールされているか確認してください".to_owned(),
         ),
+        // Issue #141: data-portability export / import エラー文言（MSG-CLI-140〜143）
+        CliError::ExportImportVaultLocked => lit(
+            "vault is locked; unlock the vault before running export or import",
+            "vault がロックされています。export / import の前に vault のロックを解除してください",
+            "run `shikomi vault unlock` first",
+            "先に `shikomi vault unlock` を実行してください",
+        ),
+        CliError::ExportOutputFileExists { path } => (
+            format!("export output file already exists: {}", path.display()),
+            format!("export 先ファイルが既に存在します: {}", path.display()),
+            "pass --force to overwrite, or choose a different --output path".to_owned(),
+            "上書きする場合は --force を指定するか、別の --output パスを指定してください".to_owned(),
+        ),
+        CliError::ImportConflict { ids } => {
+            let display = format_conflict_ids(ids);
+            (
+                format!("import conflict: {} record(s) already exist in vault (ids: {display})", ids.len()),
+                format!("import 衝突: {} 件のレコードが vault に既に存在します（ID: {display}）", ids.len()),
+                "use --on-conflict skip to skip conflicting records, or --on-conflict overwrite to replace them".to_owned(),
+                "--on-conflict skip で衝突レコードをスキップするか、--on-conflict overwrite で上書きしてください".to_owned(),
+            )
+        }
+        CliError::ImportDeserializationFailed { reason } => (
+            format!("failed to parse import file: {reason}"),
+            format!("import ファイルの解析に失敗しました: {reason}"),
+            "verify the file is a valid shikomi export (format_version must be 1)".to_owned(),
+            "ファイルが有効な shikomi export ファイルであることを確認してください（format_version は 1 である必要があります）".to_owned(),
+        ),
+        // `RedactedPayload` は `render_error` 側の専用 helper で処理済のため、
+        // `lines_for` には到達しない契約。万一到達した場合のコンパイル時網羅性のため記述する。
+        CliError::ImportValidationFailed(err) => {
+            debug_assert!(
+                false,
+                "ImportValidationFailed(RedactedPayload) should be rendered by render_import_validation_redacted; \
+                 other variants fall through to lines_for"
+            );
+            (
+                format!("failed to parse import file: {err}"),
+                format!("import ファイルの解析に失敗しました: {err}"),
+                "verify the file is a valid shikomi export (format_version must be 1)".to_owned(),
+                "ファイルが有効な shikomi export ファイルであることを確認してください（format_version は 1 である必要があります）".to_owned(),
+            )
+        }
     }
 }
 
@@ -321,6 +370,43 @@ fn render_persistence_lines(pe: &PersistenceError) -> (String, String, String, S
             "パーミッションを確認して再実行してください".to_owned(),
         ),
     }
+}
+
+// -------------------------------------------------------------------
+// Issue #141: data-portability private helpers
+// -------------------------------------------------------------------
+
+/// 衝突 ID 一覧を最大 4 件 + 省略で整形する。
+///
+/// 4 件以下: `ids.join(", ")`
+/// 5 件以上: `"id1, id2, id3, id4, ... (N more)"` 形式（terminal 溢れ防止）
+fn format_conflict_ids(ids: &[String]) -> String {
+    if ids.len() <= 4 {
+        ids.join(", ")
+    } else {
+        let head = ids[..4].join(", ");
+        format!("{head}, ... ({} more)", ids.len() - 4)
+    }
+}
+
+/// MSG-CLI-144: `ImportValidationFailed(RedactedPayload)` の専用 render helper。
+///
+/// `render_error` から dispatch される。リダクトペイロードを含むレコードの
+/// import 試行に対し、`--export-secrets` 付き再 export を案内する。
+fn render_import_validation_redacted(id: &str, locale: Locale) -> String {
+    let mut out = format!("error: cannot import record {id}: payload is redacted\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!("error: レコード {id} を import できません: ペイロードがリダクトされています\n"));
+    }
+    out.push_str(
+        "hint: re-export the source vault with --export-secrets, then import the new file\n",
+    );
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(
+            "hint: ソース vault を --export-secrets 付きで再 export し、新しいファイルを import してください\n",
+        );
+    }
+    out
 }
 
 // -------------------------------------------------------------------

--- a/crates/shikomi-cli/src/presenter/success.rs
+++ b/crates/shikomi-cli/src/presenter/success.rs
@@ -414,7 +414,533 @@ mod tests {
         assert!(twice.contains("warning:"));
     }
 
-    /// TC-F-U12 (EC-F12 / C-19): 24 語表示経路で **`SerializableSecretBytes` の lossy_string
+    // -------------------------------------------------------------------
+    // Issue #141: data-portability Presenter UT — TC-UT-201〜204
+    // 設計根拠: docs/features/data-portability/cli/test-design.md §5.3
+    // -------------------------------------------------------------------
+
+    /// TC-UT-201 (REQ-DP-011 / AC-DP-06): `render_exported` English locale に
+    /// 件数・パスが含まれる。
+    #[test]
+    fn tc_ut_201_render_exported_english_contains_record_count_and_path() {
+        let rendered = render_exported(3, std::path::Path::new("/tmp/out.json"), Locale::English);
+        assert!(
+            rendered.contains("exported 3 record(s)"),
+            "must contain 'exported 3 record(s)', got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("/tmp/out.json"),
+            "must contain output path '/tmp/out.json', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-202 (REQ-DP-011 / AC-DP-06): `render_exported` JapaneseEn locale に
+    /// 日本語文が含まれる。
+    #[test]
+    fn tc_ut_202_render_exported_japanese_en_contains_japanese_text() {
+        let rendered =
+            render_exported(3, std::path::Path::new("/tmp/out.json"), Locale::JapaneseEn);
+        assert!(
+            rendered.contains("export しました"),
+            "JapaneseEn must contain 'export しました', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-203 (REQ-DP-011 / AC-DP-07): `render_imported` の added / skipped / overwritten
+    /// 各カウンタが文字列に反映される。
+    #[test]
+    fn tc_ut_203_render_imported_all_counters_reflected_in_output() {
+        let rendered = render_imported(2, 1, 3, Locale::English);
+        assert!(
+            rendered.contains("imported 2 record(s)"),
+            "must contain 'imported 2 record(s)', got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("skipped 1"),
+            "must contain 'skipped 1', got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("overwritten 3"),
+            "must contain 'overwritten 3', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-204 (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` に
+    /// `"warning: --export-secrets is set"` と `"store the export file securely"` が含まれる
+    /// （MSG-CLI-145 の両行を機械検証する）。
+    #[test]
+    fn tc_ut_204_render_export_secrets_warning_contains_required_message() {
+        let rendered = render_export_secrets_warning(Locale::English);
+        assert!(
+            rendered.contains("warning: --export-secrets is set"),
+            "must contain 'warning: --export-secrets is set', got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("store the export file securely"),
+            "must contain 'store the export file securely', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212 (REQ-DP-011 / AC-DP-06): `render_exported` English locale は
+    /// 日本語文字を一切含まない（BUG-002 同型回帰保証）。
+    #[test]
+    fn tc_ut_212_render_exported_english_does_not_contain_japanese() {
+        let rendered = render_exported(1, std::path::Path::new("/tmp/x.json"), Locale::English);
+        assert!(
+            rendered.is_ascii(),
+            "English render_exported should be ASCII-only, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212b (REQ-DP-011 / AC-DP-07): `render_imported` English locale は
+    /// 日本語文字を一切含まない（BUG-002 同型回帰保証）。
+    #[test]
+    fn tc_ut_212b_render_imported_english_does_not_contain_japanese() {
+        let rendered = render_imported(0, 0, 0, Locale::English);
+        assert!(
+            rendered.is_ascii(),
+            "English render_imported should be ASCII-only, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212c (REQ-DP-011 / AC-DP-06): `render_exported` JapaneseEn locale は
+    /// English 行と日本語行の両方を含む（バイリンガル出力保証）。
+    #[test]
+    fn tc_ut_212c_render_exported_japanese_en_contains_both_english_and_japanese() {
+        let rendered =
+            render_exported(5, std::path::Path::new("/tmp/v.json"), Locale::JapaneseEn);
+        assert!(
+            rendered.contains("exported 5 record(s)"),
+            "JapaneseEn must also contain English line, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("export しました"),
+            "JapaneseEn must contain Japanese line, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212d (REQ-DP-011 / AC-DP-07): `render_imported` JapaneseEn locale は
+    /// English 行と日本語行の両方を含む（バイリンガル出力保証）。
+    #[test]
+    fn tc_ut_212d_render_imported_japanese_en_contains_both_english_and_japanese() {
+        let rendered = render_imported(3, 0, 1, Locale::JapaneseEn);
+        assert!(
+            rendered.contains("imported 3 record(s)"),
+            "JapaneseEn must also contain English line, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("件を追加しました"),
+            "JapaneseEn must contain Japanese line, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212e (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` JapaneseEn locale は
+    /// 日本語警告行も含む（バイリンガル保証）。
+    #[test]
+    fn tc_ut_212e_render_export_secrets_warning_japanese_en_contains_both() {
+        let rendered = render_export_secrets_warning(Locale::JapaneseEn);
+        assert!(
+            rendered.contains("warning: --export-secrets is set"),
+            "JapaneseEn must contain English warning, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("--export-secrets が指定されています"),
+            "JapaneseEn must contain Japanese warning, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212f (REQ-DP-011 / AC-DP-07): `render_imported` — 0件・0スキップ・0上書きでも
+    /// 正常に動作する（ゼロカウンタの境界値検証）。
+    #[test]
+    fn tc_ut_212f_render_imported_all_zero_counters_is_valid() {
+        let rendered = render_imported(0, 0, 0, Locale::English);
+        assert!(
+            rendered.contains("imported 0 record(s)"),
+            "must handle zero counts gracefully, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("skipped 0"),
+            "must contain 'skipped 0', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212g (REQ-DP-011 / AC-DP-06): `render_exported` — 0件 export でも
+    /// 正常に動作する（ゼロカウンタ境界値）。
+    #[test]
+    fn tc_ut_212g_render_exported_zero_records_is_valid() {
+        let rendered = render_exported(0, std::path::Path::new("/tmp/empty.json"), Locale::English);
+        assert!(
+            rendered.contains("exported 0 record(s)"),
+            "must handle zero record count gracefully, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212h (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` は
+    /// 1 行以上返す（空文字列でない保証）。
+    #[test]
+    fn tc_ut_212h_render_export_secrets_warning_is_not_empty() {
+        let rendered = render_export_secrets_warning(Locale::English);
+        assert!(!rendered.is_empty(), "warning must not be empty string");
+        assert!(
+            rendered.ends_with('\n'),
+            "warning must end with newline for consistent eprintln! handling"
+        );
+    }
+
+    /// TC-UT-212i (REQ-DP-011): `render_exported` は末尾改行で終わる（eprintln! 整合保証）。
+    #[test]
+    fn tc_ut_212i_render_exported_ends_with_newline() {
+        let rendered = render_exported(1, std::path::Path::new("/x"), Locale::English);
+        assert!(
+            rendered.ends_with('\n'),
+            "render_exported should end with newline, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212j (REQ-DP-011): `render_imported` は末尾改行で終わる（eprintln! 整合保証）。
+    #[test]
+    fn tc_ut_212j_render_imported_ends_with_newline() {
+        let rendered = render_imported(1, 0, 0, Locale::English);
+        assert!(
+            rendered.ends_with('\n'),
+            "render_imported should end with newline, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212k (REQ-DP-011 / AC-DP-07): `render_imported` は overwritten カウンタを
+    /// 含む（上書き件数の確認可能性保証）。
+    #[test]
+    fn tc_ut_212k_render_imported_includes_overwritten_count() {
+        let rendered = render_imported(0, 0, 5, Locale::English);
+        assert!(
+            rendered.contains("overwritten 5"),
+            "must contain 'overwritten 5', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212l (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` は
+    /// `"delete it when no longer needed"` を含む（ファイル削除案内保証）。
+    #[test]
+    fn tc_ut_212l_render_export_secrets_warning_contains_delete_hint() {
+        let rendered = render_export_secrets_warning(Locale::English);
+        assert!(
+            rendered.contains("delete it when no longer needed"),
+            "must contain delete hint, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212m (REQ-DP-011 / AC-DP-06): `render_exported` の出力パスは
+    /// `output_path.display()` 文字列そのもの（パス変換の忠実性保証）。
+    #[test]
+    fn tc_ut_212m_render_exported_uses_display_path_verbatim() {
+        use std::path::PathBuf;
+        let p = PathBuf::from("/custom/dir/backup.json");
+        let rendered = render_exported(7, &p, Locale::English);
+        assert!(
+            rendered.contains("/custom/dir/backup.json"),
+            "must contain the exact path string, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212n (REQ-DP-011 / AC-DP-07): `render_imported` — added と skipped と overwritten が
+    /// 全て同時に 0 より大きい場合でも正しくフォーマットされる（複合カウンタ境界値）。
+    #[test]
+    fn tc_ut_212n_render_imported_all_nonzero_counters_formatted_correctly() {
+        let rendered = render_imported(10, 3, 2, Locale::English);
+        assert!(
+            rendered.contains("imported 10 record(s)"),
+            "must show added count 10, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("skipped 3"),
+            "must show skipped 3, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("overwritten 2"),
+            "must show overwritten 2, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212o (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` の警告は
+    /// 「plaintext」キーワードを含む（平文書き出しの明示性保証）。
+    #[test]
+    fn tc_ut_212o_render_export_secrets_warning_mentions_plaintext() {
+        let rendered = render_export_secrets_warning(Locale::English);
+        assert!(
+            rendered.contains("plaintext"),
+            "warning must explicitly mention 'plaintext', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212p (REQ-DP-011): `render_exported` は `usize::MAX` のような大きな件数も
+    /// パニックしない（整数オーバーフロー防止 / Display パス保証）。
+    #[test]
+    fn tc_ut_212p_render_exported_large_count_does_not_panic() {
+        // パニックしないことを確認するだけ（値の厳密な検証は不要）。
+        let _ = render_exported(usize::MAX, std::path::Path::new("/tmp/large.json"), Locale::English);
+    }
+
+    /// TC-UT-212q (REQ-DP-011 / AC-DP-07): `render_imported` は `usize::MAX` のような
+    /// 大きなカウンタでもパニックしない（整数オーバーフロー防止）。
+    #[test]
+    fn tc_ut_212q_render_imported_large_counters_do_not_panic() {
+        let _ = render_imported(usize::MAX, usize::MAX, usize::MAX, Locale::English);
+    }
+
+    /// TC-UT-212r (REQ-DP-011 / AC-DP-06): `render_exported` 出力の 1 行目は
+    /// `"exported N record(s)"` で始まる（stdout 出力の最初行フォーマット保証）。
+    #[test]
+    fn tc_ut_212r_render_exported_first_line_starts_with_exported() {
+        let rendered = render_exported(2, std::path::Path::new("/tmp/r.json"), Locale::English);
+        let first_line = rendered.lines().next().unwrap_or("");
+        assert!(
+            first_line.starts_with("exported"),
+            "first line must start with 'exported', got: {first_line:?}"
+        );
+    }
+
+    /// TC-UT-212s (REQ-DP-011 / AC-DP-07): `render_imported` 出力の 1 行目は
+    /// `"imported N record(s)"` で始まる（stdout 出力の最初行フォーマット保証）。
+    #[test]
+    fn tc_ut_212s_render_imported_first_line_starts_with_imported() {
+        let rendered = render_imported(4, 0, 0, Locale::English);
+        let first_line = rendered.lines().next().unwrap_or("");
+        assert!(
+            first_line.starts_with("imported"),
+            "first line must start with 'imported', got: {first_line:?}"
+        );
+    }
+
+    /// TC-UT-212t (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` の各行は
+    /// `"warning: "` で始まる（MSG-CLI-145 フォーマット整合）。
+    #[test]
+    fn tc_ut_212t_render_export_secrets_warning_all_lines_start_with_warning_prefix() {
+        let rendered = render_export_secrets_warning(Locale::English);
+        for line in rendered.lines() {
+            assert!(
+                line.starts_with("warning:"),
+                "each line must start with 'warning:', got: {line:?}"
+            );
+        }
+    }
+
+    /// TC-UT-212u (REQ-DP-011): `render_exported` English locale は正確に 1 行（改行 1 個）。
+    #[test]
+    fn tc_ut_212u_render_exported_english_has_exactly_one_line() {
+        let rendered = render_exported(1, std::path::Path::new("/tmp/u.json"), Locale::English);
+        assert_eq!(
+            rendered.matches('\n').count(),
+            1,
+            "English render_exported should produce exactly 1 line, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212v (REQ-DP-011): `render_exported` JapaneseEn locale は正確に 2 行（改行 2 個）。
+    #[test]
+    fn tc_ut_212v_render_exported_japanese_en_has_exactly_two_lines() {
+        let rendered =
+            render_exported(1, std::path::Path::new("/tmp/v.json"), Locale::JapaneseEn);
+        assert_eq!(
+            rendered.matches('\n').count(),
+            2,
+            "JapaneseEn render_exported should produce exactly 2 lines, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212w (REQ-DP-011): `render_imported` English locale は正確に 1 行。
+    #[test]
+    fn tc_ut_212w_render_imported_english_has_exactly_one_line() {
+        let rendered = render_imported(1, 0, 0, Locale::English);
+        assert_eq!(
+            rendered.matches('\n').count(),
+            1,
+            "English render_imported should produce exactly 1 line, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212x (REQ-DP-011): `render_imported` JapaneseEn locale は正確に 2 行。
+    #[test]
+    fn tc_ut_212x_render_imported_japanese_en_has_exactly_two_lines() {
+        let rendered = render_imported(1, 0, 0, Locale::JapaneseEn);
+        assert_eq!(
+            rendered.matches('\n').count(),
+            2,
+            "JapaneseEn render_imported should produce exactly 2 lines, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212y (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` English locale は
+    /// 正確に 2 行（MSG-CLI-145 の 2 行構造保証）。
+    #[test]
+    fn tc_ut_212y_render_export_secrets_warning_english_has_exactly_two_lines() {
+        let rendered = render_export_secrets_warning(Locale::English);
+        assert_eq!(
+            rendered.matches('\n').count(),
+            2,
+            "English render_export_secrets_warning should produce exactly 2 lines, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212z (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` JapaneseEn locale は
+    /// 正確に 4 行（英語 2 行 + 日本語 2 行）。
+    #[test]
+    fn tc_ut_212z_render_export_secrets_warning_japanese_en_has_exactly_four_lines() {
+        let rendered = render_export_secrets_warning(Locale::JapaneseEn);
+        assert_eq!(
+            rendered.matches('\n').count(),
+            4,
+            "JapaneseEn render_export_secrets_warning should produce exactly 4 lines, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212c (REQ-DP-011 / AC-DP-06): `render_exported` は件数と
+    /// パスを両方同一出力に含む（2 情報の同時存在保証）。
+    #[allow(dead_code)] // 上で同名定義済みのため、将来クリーンアップ対象
+    fn _tc_ut_212c_duplicate_guard() {}
+
+    /// TC-UT-212aa (REQ-DP-011 / AC-DP-07): `render_imported` JapaneseEn locale は
+    /// `"スキップ"` キーワードを含む（skipped の日本語表記保証）。
+    #[test]
+    fn tc_ut_212aa_render_imported_japanese_en_contains_skip_japanese() {
+        let rendered = render_imported(0, 2, 0, Locale::JapaneseEn);
+        assert!(
+            rendered.contains("スキップ"),
+            "JapaneseEn must contain 'スキップ' for skipped count, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212ab (REQ-DP-011 / AC-DP-07): `render_imported` JapaneseEn locale は
+    /// `"上書き"` キーワードを含む（overwritten の日本語表記保証）。
+    #[test]
+    fn tc_ut_212ab_render_imported_japanese_en_contains_overwrite_japanese() {
+        let rendered = render_imported(0, 0, 3, Locale::JapaneseEn);
+        assert!(
+            rendered.contains("上書き"),
+            "JapaneseEn must contain '上書き' for overwritten count, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212ac (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` JapaneseEn は
+    /// `"エクスポートファイルを安全に保管"` を含む（日本語版セキュリティ案内保証）。
+    #[test]
+    fn tc_ut_212ac_render_export_secrets_warning_japanese_en_contains_secure_storage_hint() {
+        let rendered = render_export_secrets_warning(Locale::JapaneseEn);
+        assert!(
+            rendered.contains("エクスポートファイルを安全に保管"),
+            "JapaneseEn must contain Japanese secure storage hint, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212ad (REQ-DP-011 / AC-DP-06): `render_exported` 出力に `"to "` が含まれ、
+    /// パスへの「書き込み先」が明示される（UX 保証）。
+    #[test]
+    fn tc_ut_212ad_render_exported_contains_preposition_to() {
+        let rendered = render_exported(1, std::path::Path::new("/tmp/ad.json"), Locale::English);
+        assert!(
+            rendered.contains(" to "),
+            "must contain ' to ' as preposition before path, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212ae (REQ-DP-011): `render_imported` の出力に `"("` と `")"` が含まれ、
+    /// skipped / overwritten がカッコ書きで括られるフォーマットが維持される。
+    #[test]
+    fn tc_ut_212ae_render_imported_parenthesized_secondary_counts() {
+        let rendered = render_imported(1, 0, 0, Locale::English);
+        assert!(
+            rendered.contains('(') && rendered.contains(')'),
+            "skipped/overwritten counts must be parenthesized, got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212af (REQ-DP-011 / AC-DP-06): `render_exported` 出力中のパス文字列は
+    /// OS 規定の区切り文字（`/` または `\`）を含む（プラットフォーム別パス表記整合）。
+    #[test]
+    fn tc_ut_212af_render_exported_path_contains_separator() {
+        use std::path::MAIN_SEPARATOR;
+        let p = std::path::PathBuf::from(format!("{sep}tmp{sep}af.json", sep = MAIN_SEPARATOR));
+        let rendered = render_exported(1, &p, Locale::English);
+        assert!(
+            rendered.contains(MAIN_SEPARATOR),
+            "rendered output must contain path separator '{MAIN_SEPARATOR}', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212ag (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` は
+    /// `"secret"` という単語を含む（Secret の平文漏洩リスクの可視化保証）。
+    #[test]
+    fn tc_ut_212ag_render_export_secrets_warning_mentions_secret() {
+        let rendered = render_export_secrets_warning(Locale::English);
+        assert!(
+            rendered.contains("secret"),
+            "warning must mention 'secret', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-F-U04 / TC-UT-F-U12 の配置注 — 以下は既存テストが担当するため省略。
+    ///
+    /// TC-UT-212c (re-use guard) — TC-F-U04 / TC-F-U12 は上で実装済み。
+    /// TC-UT-201〜212 以上 by Issue #141 Sub-B PR #145。
+
+    /// TC-UT-212ah (REQ-DP-011 / AC-DP-07): `render_imported` の 1 件追加 / 0 スキップ /
+    /// 0 上書き という最も一般的な正常ケースで `"imported 1 record(s)"` が返る
+    /// （ラウンドトリップ受入基準 AC-DP-07 の文面整合）。
+    #[test]
+    fn tc_ut_212ah_render_imported_typical_single_add_output_is_correct() {
+        let rendered = render_imported(1, 0, 0, Locale::English);
+        assert!(
+            rendered.contains("imported 1 record(s)"),
+            "typical import output must contain 'imported 1 record(s)', got: {rendered:?}"
+        );
+        // skipped / overwritten は 0 でも括弧内に表示される
+        assert!(
+            rendered.contains("skipped 0"),
+            "typical output must contain 'skipped 0', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212ai (REQ-DP-011 / AC-DP-06): `render_exported` の 1 件 export が
+    /// `"exported 1 record(s)"` を返す（最も一般的な受入基準文面整合）。
+    #[test]
+    fn tc_ut_212ai_render_exported_typical_single_record_output_is_correct() {
+        let rendered = render_exported(1, std::path::Path::new("/tmp/ai.json"), Locale::English);
+        assert!(
+            rendered.contains("exported 1 record(s)"),
+            "typical export output must contain 'exported 1 record(s)', got: {rendered:?}"
+        );
+    }
+
+    /// TC-UT-212aj (REQ-DP-011 / R1-DP-02): `render_export_secrets_warning` の
+    /// JapaneseEn ロケールは `"Secret"` と `"平文"` の両方を含む
+    /// （Secret 種別と平文書き出しの日本語での明示保証）。
+    #[test]
+    fn tc_ut_212aj_render_export_secrets_warning_japanese_en_mentions_secret_and_plaintext_japanese() {
+        let rendered = render_export_secrets_warning(Locale::JapaneseEn);
+        assert!(
+            rendered.contains("Secret"),
+            "JapaneseEn must mention 'Secret', got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("平文"),
+            "JapaneseEn must mention '平文', got: {rendered:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // 以下は既存テスト（Sub-F #44 Phase 6 / TC-F-U04 / TC-F-U12）
+    // -------------------------------------------------------------------
+
+    /// TC-UT-212z2 — 注記: 上記 TC-UT-212y / TC-UT-212z とは独立して、
+    /// TC-UT-212aj 以後のテストが追加される可能性がある（Issue #141 以降の Sub-C 等）。
+    /// 番号は TC-UT-213〜 を使用すること。
+
+    /// TC-UT-212z3 (配置確認): 本 tests モジュールの末尾マーカ。
+    /// TC-UT-201〜212aj が Issue #141 Sub-B (PR #145) で追加されたことを articulate する。
+
+    /// TC-UT-212c (REQ-DP-011 / AC-DP-06): `render_exported` は件数と
+    /// TC-UT-212 〜 TC-UT-212aj: 全 Issue #141 data-portability Presenter UT 追加完了。
+
+    /// TC-UT-F-U12 (EC-F12 / C-19): 24 語表示経路で **`SerializableSecretBytes` の lossy_string
     /// 経由表示が呼出側の Vec<SerializableSecretBytes> 所有権を維持し、scope 終了時の
     /// `Drop` (= secrecy crate 経由 `zeroize`) を確実に発火させる**構造の機械検証。
     ///

--- a/crates/shikomi-cli/src/presenter/success.rs
+++ b/crates/shikomi-cli/src/presenter/success.rs
@@ -266,6 +266,64 @@ pub fn render_autostart_uninstalled(locale: Locale) -> String {
     out
 }
 
+// -------------------------------------------------------------------
+// Issue #141: data-portability export / import 成功文言（MSG-CLI-140 / MSG-CLI-145）
+//
+// 設計根拠: docs/features/data-portability/cli/detailed-design/presenter.md
+// §render_exported / §render_imported / §render_export_secrets_warning
+// -------------------------------------------------------------------
+
+/// `shikomi export` 成功文言（MSG-CLI-140 相当）。
+///
+/// `quiet == true` の場合は呼出側（`run_export`）で呼ばない（presenter 層は quiet 非関与）。
+#[must_use]
+pub fn render_exported(record_count: usize, output_path: &std::path::Path, locale: Locale) -> String {
+    let path_str = output_path.display();
+    let mut out = format!("exported {record_count} record(s) to {path_str}\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!("{record_count} 件のレコードを {path_str} に export しました\n"));
+    }
+    out
+}
+
+/// `shikomi import` 成功文言。
+///
+/// `quiet == true` の場合は呼出側（`run_import`）で呼ばない（presenter 層は quiet 非関与）。
+#[must_use]
+pub fn render_imported(added: usize, skipped: usize, overwritten: usize, locale: Locale) -> String {
+    let mut out = format!("imported {added} record(s) (skipped {skipped}, overwritten {overwritten})\n");
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(&format!(
+            "{added} 件を追加しました（スキップ: {skipped} 件、上書き: {overwritten} 件）\n"
+        ));
+    }
+    out
+}
+
+/// `--export-secrets` 指定時の警告文言（MSG-CLI-145）。
+///
+/// `--quiet` でも抑止不可。呼出側（`run_export`）は `quiet` フラグを確認せずに
+/// 直接 `eprintln!` で stderr へ出力する（設計書 §セキュリティ考慮 参照）。
+/// 本関数はロケール別文言の生成責務のみを担う。
+#[must_use]
+pub fn render_export_secrets_warning(locale: Locale) -> String {
+    let mut out = String::from(
+        "warning: --export-secrets is set; secret values will be written to the export file in plaintext\n",
+    );
+    out.push_str(
+        "warning: store the export file securely and delete it when no longer needed\n",
+    );
+    if matches!(locale, Locale::JapaneseEn) {
+        out.push_str(
+            "warning: --export-secrets が指定されています。Secret の値が平文でエクスポートファイルに書き込まれます\n",
+        );
+        out.push_str(
+            "warning: エクスポートファイルを安全に保管し、不要になったら削除してください\n",
+        );
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/shikomi-cli/src/usecase/mod.rs
+++ b/crates/shikomi-cli/src/usecase/mod.rs
@@ -10,5 +10,6 @@
 pub mod add;
 pub mod edit;
 pub mod list;
+pub mod portability;
 pub mod remove;
 pub mod vault;

--- a/crates/shikomi-cli/src/usecase/portability/error.rs
+++ b/crates/shikomi-cli/src/usecase/portability/error.rs
@@ -1,0 +1,66 @@
+//! データポータビリティ UseCase 内部エラー型。
+//!
+//! `DataPortabilityError` は UseCase 層の中間エラー型。
+//! `From<DataPortabilityError> for CliError` で CLI エラーへ変換される
+//! (`crates/shikomi-cli/src/error.rs §From<DataPortabilityError>` 参照)。
+//!
+//! 設計根拠: docs/features/data-portability/cli/detailed-design/usecase.md
+//! §`usecase/portability/error.rs` の設計詳細
+
+use std::path::PathBuf;
+
+use shikomi_core::portability::ImportValidationError;
+use thiserror::Error;
+
+// -------------------------------------------------------------------
+// DataPortabilityError
+// -------------------------------------------------------------------
+
+/// データポータビリティ UseCase 内部エラー型。
+///
+/// `From<DataPortabilityError> for CliError` (error.rs §Issue #141) で
+/// 最終的な `CliError` に変換される。
+#[derive(Debug, Error)]
+pub enum DataPortabilityError {
+    /// vault が暗号化ロック済みの状態で export / import を試みた。
+    ///
+    /// `SqliteVaultRepository::load()` が `ProtectionMode::Encrypted` を検出した場合、
+    /// または `ExportError::VaultLocked` が伝播した場合に発生する。
+    #[error("vault is locked")]
+    VaultLocked,
+
+    /// export 先ファイルが既に存在し `--force` 未指定。
+    #[error("export output file already exists: {path}")]
+    OutputFileExists {
+        /// 既に存在する export 先ファイルパス。
+        path: PathBuf,
+    },
+
+    /// `--on-conflict error` で衝突 ID を検出した。
+    #[error("import conflict: {} record(s) already exist in vault", ids.len())]
+    ConflictError {
+        /// 衝突したレコード ID 文字列一覧。
+        ids: Vec<String>,
+    },
+
+    /// `serde_json::from_reader` 等のデシリアライズ失敗。
+    #[error("failed to parse import file: {reason}")]
+    DeserializationFailed {
+        /// デシリアライズ失敗の詳細（外部ライブラリのエラー文言）。
+        reason: String,
+    },
+
+    /// `ImportValidator::validate` 失敗。
+    #[error("import validation failed: {0}")]
+    ValidationFailed(ImportValidationError),
+
+    /// ファイル I/O エラー（`tempfile` 操作 / `persist` 失敗を含む）。
+    #[error("io error: {0}")]
+    IoError(std::io::Error),
+}
+
+impl From<std::io::Error> for DataPortabilityError {
+    fn from(e: std::io::Error) -> Self {
+        Self::IoError(e)
+    }
+}

--- a/crates/shikomi-cli/src/usecase/portability/export.rs
+++ b/crates/shikomi-cli/src/usecase/portability/export.rs
@@ -1,0 +1,176 @@
+//! `export_records` UseCase — vault レコードを JSON ファイルへ export する。
+//!
+//! 設計根拠: docs/features/data-portability/cli/detailed-design/usecase.md
+//! §`usecase/portability/export.rs` の設計詳細
+//!
+//! # セキュリティ考慮
+//! - export ファイルのパーミッション: Unix では `tempfile::Builder::permissions(0o600)`。
+//! - atomic write: `tempfile` + `persist` で書き込みの完全性を保証（R1-DP-09）。
+//! - Encrypted ペイロード: `vault.protection_mode() == Encrypted` を即時検出して Fail Fast。
+
+use std::ffi::OsStr;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use shikomi_core::portability::{ExportPayload, ExportRecord};
+use shikomi_core::{ProtectionMode};
+use shikomi_infra::persistence::VaultRepository;
+use time::OffsetDateTime;
+
+use crate::cli::ExportArgs;
+use crate::error::CliError;
+
+use super::error::DataPortabilityError;
+
+// -------------------------------------------------------------------
+// ExportSummary
+// -------------------------------------------------------------------
+
+/// `export_records` の正常系戻り値。
+pub struct ExportSummary {
+    /// export したレコード件数（vault 不存在時は 0）。
+    pub record_count: usize,
+    /// 実際に書き込んだファイルパス。
+    pub output_path: PathBuf,
+}
+
+// -------------------------------------------------------------------
+// export_records
+// -------------------------------------------------------------------
+
+/// vault レコードを JSON ファイルへ export する UseCase 関数。
+///
+/// 設計根拠: docs/features/data-portability/cli/detailed-design/usecase.md §`export_records` 関数
+///
+/// # 処理順序
+/// 1. 出力ファイル既存確認（`--force` 未指定時はエラー）
+/// 2. vault 不存在確認（0 件 export として正常終了）
+/// 3. vault 読み込み（`EncryptionUnsupported` → `ExportImportVaultLocked`）
+/// 4. `ProtectionMode::Encrypted` 確認
+/// 5. 全レコード取得
+/// 6. `ExportRecord::try_from` 変換
+/// 7. vault_name 構築
+/// 8. `ExportPayload` 構築
+/// 9. JSON シリアライズ
+/// 10. 親ディレクトリ取得
+/// 11. tempfile 構築（Unix: 0o600 パーミッション）
+/// 12. JSON bytes 書き込み
+/// 13. `persist` で atomic rename
+/// 14. `ExportSummary` 返却
+///
+/// # Errors
+/// - `CliError::ExportOutputFileExists` — 出力ファイルが既に存在し `--force` 未指定
+/// - `CliError::ExportImportVaultLocked` — vault がロック済み
+/// - `CliError::Persistence` — I/O / SQLite エラー
+pub fn export_records(
+    repo: &dyn VaultRepository,
+    args: &ExportArgs,
+    vault_dir: &Path,
+    now: OffsetDateTime,
+) -> Result<ExportSummary, CliError> {
+    // Step 1: 出力ファイル既存確認
+    if args.output.exists() && !args.force {
+        return Err(DataPortabilityError::OutputFileExists {
+            path: args.output.clone(),
+        }
+        .into());
+    }
+
+    // Steps 2–6: vault 読み込みとレコード変換
+    let records_to_export: Vec<ExportRecord> = if !repo.exists()? {
+        // vault 不存在は 0 件 export（エラーではない）
+        vec![]
+    } else {
+        // Step 3: vault 読み込み（EncryptionUnsupported → VaultLocked に変換）
+        let vault = match repo.load() {
+            Ok(v) => v,
+            Err(e) => {
+                let cli_err = CliError::from(e);
+                return Err(match cli_err {
+                    CliError::EncryptionUnsupported => DataPortabilityError::VaultLocked.into(),
+                    other => other,
+                });
+            }
+        };
+
+        // Step 4: protection_mode 確認
+        if vault.protection_mode() == ProtectionMode::Encrypted {
+            return Err(DataPortabilityError::VaultLocked.into());
+        }
+
+        // Steps 5–6: 全レコードを ExportRecord に変換
+        vault
+            .records()
+            .iter()
+            .map(|record| {
+                ExportRecord::try_from((record, args.export_secrets)).map_err(|e| {
+                    use shikomi_core::portability::ExportError;
+                    match e {
+                        ExportError::VaultLocked => {
+                            CliError::from(DataPortabilityError::VaultLocked)
+                        }
+                    }
+                })
+            })
+            .collect::<Result<Vec<_>, CliError>>()?
+    };
+
+    // Step 7: vault_name 構築
+    let vault_name = vault_dir
+        .file_name()
+        .unwrap_or_else(|| OsStr::new("vault"))
+        .to_string_lossy()
+        .into_owned();
+
+    // Step 8: ExportPayload 構築
+    let record_count = records_to_export.len();
+    let payload = ExportPayload::new(records_to_export, vault_name, now);
+
+    // Step 9: JSON シリアライズ（Serialize の不変条件によりパニックは実用上起こらない）
+    let json =
+        serde_json::to_string_pretty(&payload).expect("ExportPayload is always serializable");
+
+    // Step 10: 親ディレクトリ取得
+    let parent = args.output.parent().unwrap_or_else(|| Path::new("."));
+
+    // Steps 11–13: tempfile 構築 → 書き込み → atomic persist
+    write_atomic(&json, parent, &args.output)?;
+
+    // Step 14: ExportSummary 返却
+    Ok(ExportSummary {
+        record_count,
+        output_path: args.output.clone(),
+    })
+}
+
+/// `json` を `output` パスへ atomic に書き込む。
+///
+/// Unix では `tempfile::Builder::permissions(0o600)` を設定してからファイルを作成し、
+/// `persist` で rename する（R1-DP-09 適合）。非 Unix ではパーミッション設定なし。
+fn write_atomic(json: &str, parent: &Path, output: &Path) -> Result<(), CliError> {
+    #[cfg(unix)]
+    let mut tmp_file = {
+        use std::fs::Permissions;
+        use std::os::unix::fs::PermissionsExt as _;
+        tempfile::Builder::new()
+            .permissions(Permissions::from_mode(0o600))
+            .tempfile_in(parent)
+            .map_err(DataPortabilityError::IoError)?
+    };
+
+    #[cfg(not(unix))]
+    let mut tmp_file = tempfile::Builder::new()
+        .tempfile_in(parent)
+        .map_err(DataPortabilityError::IoError)?;
+
+    tmp_file
+        .write_all(json.as_bytes())
+        .map_err(DataPortabilityError::IoError)?;
+
+    // `PersistError::error` フィールドが `io::Error`
+    tmp_file
+        .persist(output)
+        .map_err(|e| DataPortabilityError::IoError(e.error))?;
+
+    Ok(())
+}

--- a/crates/shikomi-cli/src/usecase/portability/import.rs
+++ b/crates/shikomi-cli/src/usecase/portability/import.rs
@@ -34,6 +34,7 @@ use super::error::DataPortabilityError;
 // -------------------------------------------------------------------
 
 /// `import_records` の正常系戻り値。
+#[derive(Debug)]
 pub struct ImportSummary {
     /// 新規追加したレコード件数。
     pub added: usize,

--- a/crates/shikomi-cli/src/usecase/portability/import.rs
+++ b/crates/shikomi-cli/src/usecase/portability/import.rs
@@ -1,0 +1,250 @@
+//! `import_records` UseCase — JSON ファイルから vault へレコードを import する。
+//!
+//! 設計根拠: docs/features/data-portability/cli/detailed-design/usecase.md
+//! §`usecase/portability/import.rs` の設計詳細
+//!
+//! # 設計判断: IPC 経路廃止・SQLite 一本化
+//! Import も export と同様に常に `SqliteVaultRepository` を使用する。
+//! IPC per-record `add_record()` は途中クラッシュで vault が半書き込み状態になり
+//! `R1-DP-09` の atomicity 要件に非適合。SQLite `repo.save()` が atomic write を保証する。
+//!
+//! # セキュリティ考慮
+//! - `serde_json::from_reader` によるストリーミングパース（OOM 防止、threat-model.md §7.5）
+//! - `repo.save()` による atomic write（R1-DP-09）
+//! - `import_record_to_domain` で `Redacted` ペイロードに到達した場合の `unreachable!`（告知的プログラミング）
+
+use std::collections::HashSet;
+
+use shikomi_core::portability::{ImportPayload, ImportValidator};
+use shikomi_core::portability::ExportRecordPayload;
+use shikomi_core::{
+    Hotkey, Record, RecordId, RecordLabel, RecordPayload, SecretString, VaultHeader, VaultVersion,
+};
+use shikomi_infra::persistence::VaultRepository;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::cli::{ImportArgs, OnConflictArg};
+use crate::error::CliError;
+
+use super::error::DataPortabilityError;
+
+// -------------------------------------------------------------------
+// ImportSummary
+// -------------------------------------------------------------------
+
+/// `import_records` の正常系戻り値。
+pub struct ImportSummary {
+    /// 新規追加したレコード件数。
+    pub added: usize,
+    /// 衝突により skip したレコード件数（`--on-conflict skip` 時のみ非ゼロ）。
+    pub skipped: usize,
+    /// 既存レコードを上書きしたレコード件数（`--on-conflict overwrite` 時のみ非ゼロ）。
+    pub overwritten: usize,
+}
+
+// -------------------------------------------------------------------
+// import_records
+// -------------------------------------------------------------------
+
+/// JSON ファイルから vault へレコードを import する UseCase 関数（単一 SQLite 経路）。
+///
+/// 設計根拠: docs/features/data-portability/cli/detailed-design/usecase.md §`import_records` 関数
+///
+/// # 処理順序
+/// 1. import ファイルを開く
+/// 2. `serde_json::from_reader` でストリーミングパース
+/// 3. vault の準備（存在すれば `load`、なければ `Vault::new`）
+/// 4. 既存 ID セット構築
+/// 5. `ImportValidator::validate`
+/// 6. `--on-conflict error` で衝突検出 → エラー
+/// 7. 各レコードを走査して add / skip / overwrite
+/// 8. `repo.save` で atomic write
+/// 9. `ImportSummary` 返却
+///
+/// # Errors
+/// - `CliError::ExportImportVaultLocked` — vault がロック済み
+/// - `CliError::ImportDeserializationFailed` — JSON パース失敗
+/// - `CliError::ImportConflict` — `--on-conflict error` で衝突検出
+/// - `CliError::ImportValidationFailed` — `ImportValidator::validate` 失敗
+/// - `CliError::Persistence` — I/O / SQLite エラー
+pub fn import_records(
+    repo: &dyn VaultRepository,
+    args: &ImportArgs,
+    now: OffsetDateTime,
+) -> Result<ImportSummary, CliError> {
+    // Step 1: ファイルを開く
+    let file =
+        std::fs::File::open(&args.input).map_err(DataPortabilityError::IoError)?;
+
+    // Step 2: ストリーミングパース（OOM 防止: read_to_string は使用しない、threat-model.md §7.5）
+    let payload: ImportPayload = serde_json::from_reader(file).map_err(|e| {
+        CliError::from(DataPortabilityError::DeserializationFailed {
+            reason: e.to_string(),
+        })
+    })?;
+
+    // Step 3: vault の準備
+    let mut vault = if repo.exists()? {
+        match repo.load() {
+            Ok(v) => v,
+            Err(e) => {
+                let cli_err = CliError::from(e);
+                return Err(match cli_err {
+                    CliError::EncryptionUnsupported => DataPortabilityError::VaultLocked.into(),
+                    other => other,
+                });
+            }
+        }
+    } else {
+        shikomi_core::Vault::new(
+            VaultHeader::new_plaintext(VaultVersion::CURRENT, now).map_err(CliError::Domain)?,
+        )
+    };
+
+    // Step 4: 既存 ID セット構築
+    let existing_ids: HashSet<String> =
+        vault.records().iter().map(|r| r.id().to_string()).collect();
+
+    // Step 5: ImportValidator::validate
+    let report = ImportValidator::validate(&payload, &existing_ids).map_err(|err| {
+        CliError::from(DataPortabilityError::ValidationFailed(err))
+    })?;
+
+    // Step 6: --on-conflict error で衝突検出
+    if args.on_conflict == OnConflictArg::Error && !report.conflicting_ids.is_empty() {
+        return Err(DataPortabilityError::ConflictError {
+            ids: report.conflicting_ids,
+        }
+        .into());
+    }
+
+    // Step 7: 各レコードを走査
+    let mut added: usize = 0;
+    let mut skipped: usize = 0;
+    let mut overwritten: usize = 0;
+
+    for record in &payload.records {
+        let is_conflicting = report.conflicting_ids.contains(&record.id);
+
+        if is_conflicting && args.on_conflict == OnConflictArg::Skip {
+            skipped += 1;
+            continue;
+        }
+
+        let domain_record = import_record_to_domain(record)?;
+
+        if is_conflicting && args.on_conflict == OnConflictArg::Overwrite {
+            vault
+                .remove_record(domain_record.id())
+                .map_err(CliError::Domain)?;
+            vault.add_record(domain_record).map_err(CliError::Domain)?;
+            overwritten += 1;
+        } else {
+            vault.add_record(domain_record).map_err(CliError::Domain)?;
+            added += 1;
+        }
+    }
+
+    // Step 8: atomic write（SqliteVaultRepository::save が tempfile + rename で保証、R1-DP-09 適合）
+    repo.save(&vault)?;
+
+    // Step 9: ImportSummary 返却
+    Ok(ImportSummary {
+        added,
+        skipped,
+        overwritten,
+    })
+}
+
+// -------------------------------------------------------------------
+// import_record_to_domain（private helper）
+// -------------------------------------------------------------------
+
+/// `ImportRecord` を domain の `Record` に変換する。
+///
+/// # 処理順序
+/// 1. UUID 文字列 → `uuid::Uuid` へパース
+/// 2. `RecordId::new`
+/// 3. `RecordLabel::try_new`
+/// 4. ペイロード変換（`Redacted` は `unreachable!`）
+/// 5. `created_at` RFC 3339 パース
+/// 6. `updated_at` RFC 3339 パース
+/// 7. `hotkey` パース
+/// 8. `Record::rehydrate`
+///
+/// # `unreachable!` の根拠
+/// `ImportValidator::validate` が `RedactedPayload` を `Err` として返すため、
+/// 本関数が呼ばれた時点でリダクトペイロードは除外済みの契約が成立している。
+/// `unreachable!` は告知的プログラミングによる二重安全網。
+///
+/// # Errors
+/// フィールドの解析失敗時に `CliError::ImportDeserializationFailed` を返す。
+fn import_record_to_domain(
+    r: &shikomi_core::portability::ImportRecord,
+) -> Result<Record, CliError> {
+    // Step 1: UUID パース
+    let uuid = uuid::Uuid::parse_str(&r.id).map_err(|e| CliError::ImportDeserializationFailed {
+        reason: format!("invalid record id '{}': {e}", r.id),
+    })?;
+
+    // Step 2: RecordId
+    let id = RecordId::new(uuid).map_err(|e| CliError::ImportDeserializationFailed {
+        reason: e.to_string(),
+    })?;
+
+    // Step 3: RecordLabel
+    let label =
+        RecordLabel::try_new(r.label.clone()).map_err(|e| CliError::ImportDeserializationFailed {
+            reason: format!("invalid label: {e}"),
+        })?;
+
+    // Step 4: ペイロード変換
+    let payload = match &r.payload {
+        ExportRecordPayload::Plaintext { value } => {
+            RecordPayload::Plaintext(SecretString::from_string(value.clone()))
+        }
+        ExportRecordPayload::Redacted => {
+            unreachable!(
+                "ImportValidator rejects Redacted payload; \
+                 import_record_to_domain must not be called for redacted records"
+            )
+        }
+    };
+
+    // Step 5: created_at パース
+    let created_at =
+        OffsetDateTime::parse(&r.created_at, &Rfc3339).map_err(|e| {
+            CliError::ImportDeserializationFailed {
+                reason: format!("invalid created_at '{}': {e}", r.created_at),
+            }
+        })?;
+
+    // Step 6: updated_at パース
+    let updated_at =
+        OffsetDateTime::parse(&r.updated_at, &Rfc3339).map_err(|e| {
+            CliError::ImportDeserializationFailed {
+                reason: format!("invalid updated_at '{}': {e}", r.updated_at),
+            }
+        })?;
+
+    // Step 7: hotkey パース
+    let hotkey = r
+        .hotkey
+        .as_deref()
+        .map(Hotkey::parse)
+        .transpose()
+        .map_err(|e| CliError::ImportDeserializationFailed {
+            reason: format!("invalid hotkey: {e}"),
+        })?;
+
+    // Step 8: Record::rehydrate（updated_at < created_at で DomainError::VaultConsistencyError）
+    let record =
+        Record::rehydrate(id, r.kind, label, payload, created_at, updated_at, hotkey).map_err(
+            |e| CliError::ImportDeserializationFailed {
+                reason: e.to_string(),
+            },
+        )?;
+
+    Ok(record)
+}

--- a/crates/shikomi-cli/src/usecase/portability/mod.rs
+++ b/crates/shikomi-cli/src/usecase/portability/mod.rs
@@ -1,0 +1,11 @@
+//! データポータビリティ UseCase 群（Issue #141 Sub-B）。
+//!
+//! - `error`: UseCase 内部中間エラー型 `DataPortabilityError`
+//! - `export`: `export_records` + `ExportSummary`
+//! - `import`: `import_records` + `ImportSummary`
+//!
+//! 設計根拠: docs/features/data-portability/cli/detailed-design/usecase.md
+
+pub mod error;
+pub mod export;
+pub mod import;

--- a/crates/shikomi-cli/tests/e2e_portability.rs
+++ b/crates/shikomi-cli/tests/e2e_portability.rs
@@ -1,0 +1,386 @@
+//! E2E テスト — `shikomi export` / `shikomi import`
+//!
+//! 対応 AC: AC-DP-06 / AC-DP-07 / AC-DP-08 / AC-DP-09 / AC-DP-10
+//! 対応 TC: TC-E2E-DP-001〜012
+//! 設計書: `docs/features/data-portability/cli/test-design.md §5.1`
+//! 対応 Issue: #141
+
+mod common;
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use common::tighten_perms_unix;
+
+// -------------------------------------------------------------------
+// ヘルパー
+// -------------------------------------------------------------------
+
+/// vault ディレクトリに `--no-ipc --vault-dir <dir>` を付与した Command を返す。
+fn shikomi(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("shikomi").expect("cargo_bin");
+    cmd.env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .arg("--no-ipc")
+        .arg("--vault-dir")
+        .arg(dir);
+    cmd
+}
+
+/// TempDir を作成して Unix パーミッションを 0700 に設定する。
+fn setup_vault_dir() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    tighten_perms_unix(dir.path());
+    dir
+}
+
+/// vault に Text レコードを 1 件追加する。成功が前提。
+fn add_text_record(dir: &Path, label: &str, value: &str) {
+    shikomi(dir)
+        .args([
+            "add",
+            "--kind",
+            "text",
+            "--label",
+            label,
+            "--value",
+            value,
+        ])
+        .assert()
+        .success();
+}
+
+/// vault に Secret レコードを 1 件追加する。
+fn add_secret_record(dir: &Path, label: &str, value: &str) {
+    shikomi(dir)
+        .args([
+            "add",
+            "--kind",
+            "secret",
+            "--label",
+            label,
+            "--value",
+            value,
+        ])
+        .assert()
+        .success();
+}
+
+/// vault から export して JSON ファイルパスを返す。成功が前提。
+fn export_vault(dir: &Path, out_path: &PathBuf) {
+    shikomi(dir)
+        .args(["export", "--output", out_path.to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-001: export 正常 — format_version:1 を含む JSON が書き込まれる
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_001_export_succeeds_and_writes_json_with_format_version_1() {
+    let dir = setup_vault_dir();
+    add_text_record(dir.path(), "my-label", "my-value");
+    let out = dir.path().join("out.json");
+
+    shikomi(dir.path())
+        .args(["export", "--output", out.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("exported 1 record(s)"));
+
+    // ファイルが存在し format_version:1 を含む
+    assert!(out.exists(), "export file should exist");
+    let content = std::fs::read_to_string(&out).unwrap();
+    assert!(
+        content.contains("\"format_version\": 1"),
+        "should contain format_version: 1, got: {content}"
+    );
+    // tagged union 構造
+    assert!(content.contains("\"kind\""), "should contain 'kind' key");
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-002: export → import ラウンドトリップ — 同一レコードが vault B に存在する
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_002_export_import_roundtrip_same_record_in_target_vault() {
+    // vault A
+    let dir_a = setup_vault_dir();
+    add_text_record(dir_a.path(), "roundtrip-label", "roundtrip-value");
+    let out = dir_a.path().join("export.json");
+    export_vault(dir_a.path(), &out);
+
+    // vault B（新規）
+    let dir_b = setup_vault_dir();
+    shikomi(dir_b.path())
+        .args(["import", "--input", out.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("imported 1 record(s)"));
+
+    // vault B の list でラベルが見える
+    shikomi(dir_b.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("roundtrip-label"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-003: --export-secrets なし export → import で MSG-CLI-144 exit 1
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_003_import_redacted_secret_record_exits_1_with_msg_cli_144() {
+    let dir = setup_vault_dir();
+    add_secret_record(dir.path(), "secret-label", "s3cr3t");
+    let out = dir.path().join("out.json");
+    // --export-secrets なし → Secret が {"kind":"redacted"} になる
+    export_vault(dir.path(), &out);
+
+    let dir_b = setup_vault_dir();
+    shikomi(dir_b.path())
+        .args(["import", "--input", out.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("cannot import record"))
+        .stderr(predicate::str::contains("payload is redacted"))
+        .stderr(predicate::str::contains("re-export"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-004: import --on-conflict skip — 衝突レコードをスキップする
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_004_import_on_conflict_skip_skips_conflicting_records() {
+    let dir = setup_vault_dir();
+    // A, B の 2 件追加
+    add_text_record(dir.path(), "label-a", "value-a");
+    add_text_record(dir.path(), "label-b", "value-b");
+    let out = dir.path().join("export.json");
+    export_vault(dir.path(), &out);
+
+    // 同じ vault に import --on-conflict skip（A, B は衝突のためスキップ）
+    shikomi(dir.path())
+        .args([
+            "import",
+            "--input",
+            out.to_str().unwrap(),
+            "--on-conflict",
+            "skip",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("skipped 2"))
+        .stdout(predicate::str::contains("imported 0 record(s)"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-005: 同一ファイルを 2 回 import — 2 回目に MSG-CLI-142 exit 1
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_005_second_import_all_conflict_exits_1_with_msg_cli_142() {
+    let dir_a = setup_vault_dir();
+    add_text_record(dir_a.path(), "conflict-label", "val");
+    let out = dir_a.path().join("export.json");
+    export_vault(dir_a.path(), &out);
+
+    let dir_b = setup_vault_dir();
+    // 1 回目: 成功
+    shikomi(dir_b.path())
+        .args(["import", "--input", out.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // 2 回目: 全件衝突 → MSG-CLI-142
+    shikomi(dir_b.path())
+        .args(["import", "--input", out.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("import conflict"))
+        .stderr(predicate::str::contains("already exist in vault"))
+        .stderr(predicate::str::contains("--on-conflict skip"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-006: vault ロック済み → export で MSG-CLI-140 exit 1
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_006_export_on_locked_vault_exits_1_with_msg_cli_140() {
+    let dir = setup_vault_dir();
+    // 暗号化 vault を作成（ロック済み）
+    common::fixtures::create_encrypted_vault(dir.path())
+        .expect("create_encrypted_vault");
+    let out = dir.path().join("out.json");
+
+    shikomi(dir.path())
+        .args(["export", "--output", out.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("vault is locked"))
+        .stderr(predicate::str::contains("unlock"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-007: --force なし + 出力先ファイル既存 → MSG-CLI-141 exit 1
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_007_export_existing_file_without_force_exits_1_with_msg_cli_141() {
+    let dir = setup_vault_dir();
+    add_text_record(dir.path(), "lbl", "val");
+    let out = dir.path().join("existing.json");
+    // 先に出力先ファイルを作成しておく
+    std::fs::write(&out, "{}").unwrap();
+
+    shikomi(dir.path())
+        .args(["export", "--output", out.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("export output file already exists"))
+        .stderr(predicate::str::contains("--force"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-008: --export-secrets + --quiet でも MSG-CLI-145 が stderr に出る
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_008_export_secrets_warning_not_suppressed_by_quiet() {
+    let dir = setup_vault_dir();
+    add_secret_record(dir.path(), "sec", "password");
+    let out = dir.path().join("out.json");
+
+    shikomi(dir.path())
+        .args([
+            "--quiet",
+            "export",
+            "--output",
+            out.to_str().unwrap(),
+            "--export-secrets",
+        ])
+        .assert()
+        .success()
+        // --quiet でも MSG-CLI-145 は stderr に出る
+        .stderr(predicate::str::contains("warning: --export-secrets is set"))
+        // --quiet なので stdout には成功メッセージが出ない
+        .stdout(predicate::str::is_empty());
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-009: import --on-conflict overwrite — 衝突レコードを上書きする
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_009_import_on_conflict_overwrite_replaces_existing_record() {
+    let dir = setup_vault_dir();
+    add_text_record(dir.path(), "ow-label", "old-value");
+    let out = dir.path().join("old.json");
+    export_vault(dir.path(), &out);
+
+    // 新しい値で別 vault に "old.json" の old-value を import overwirte
+    // 検証: 同じ vault でoverwriteした後 list で overwritten になること
+    // まず別の vault で import → list → "old-value" 確認
+    let dir_b = setup_vault_dir();
+    shikomi(dir_b.path())
+        .args(["import", "--input", out.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // 更新されたファイルを同じ vault B に --on-conflict overwrite で再 import
+    shikomi(dir_b.path())
+        .args([
+            "import",
+            "--input",
+            out.to_str().unwrap(),
+            "--on-conflict",
+            "overwrite",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("overwritten 1"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-010: 不正 JSON ファイル → import で MSG-CLI-143 exit 1
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_010_import_broken_json_exits_1_with_msg_cli_143() {
+    let dir = setup_vault_dir();
+    let broken = dir.path().join("broken.json");
+    std::fs::write(&broken, "{not valid json").unwrap();
+
+    shikomi(dir.path())
+        .args(["import", "--input", broken.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("failed to parse import file"))
+        .stderr(predicate::str::contains("format_version"));
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-011: --force + 出力先ファイル既存 → 上書き成功
+// -------------------------------------------------------------------
+
+#[test]
+fn tc_e2e_dp_011_export_with_force_overwrites_existing_file() {
+    let dir = setup_vault_dir();
+    add_text_record(dir.path(), "lbl", "val");
+    let out = dir.path().join("output.json");
+    // 旧ファイルを作成しておく
+    std::fs::write(&out, "old content").unwrap();
+
+    shikomi(dir.path())
+        .args(["export", "--output", out.to_str().unwrap(), "--force"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("exported"));
+
+    let content = std::fs::read_to_string(&out).unwrap();
+    assert!(
+        content.contains("\"format_version\": 1"),
+        "should be overwritten with valid JSON"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-E2E-DP-012: export ファイルのパーミッションが 0600（Unix のみ）
+// -------------------------------------------------------------------
+
+#[test]
+#[cfg(unix)]
+fn tc_e2e_dp_012_export_file_permission_is_0600_on_unix() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = setup_vault_dir();
+    add_text_record(dir.path(), "perm-test", "value");
+    let out = dir.path().join("perm_test.json");
+
+    shikomi(dir.path())
+        .args(["export", "--output", out.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let mode = std::fs::metadata(&out).unwrap().permissions().mode();
+    // 下位 9 ビットが 0o600 = rw------- であること
+    assert_eq!(
+        mode & 0o777,
+        0o600,
+        "export file should have 0600 permissions, got {mode:o}"
+    );
+}

--- a/crates/shikomi-cli/tests/it_usecase_portability.rs
+++ b/crates/shikomi-cli/tests/it_usecase_portability.rs
@@ -1,0 +1,174 @@
+//! 結合テスト — `usecase::portability::export_records` / `import_records`
+//!
+//! 対応 REQ: REQ-DP-008 / REQ-DP-009 / REQ-DP-010
+//! 対応 TC: TC-IT-DP-001〜004
+//! 設計書: `docs/features/data-portability/cli/test-design.md §5.2`
+//! 対応 Issue: #141
+
+mod common;
+
+use shikomi_cli::cli::{ExportArgs, ImportArgs, OnConflictArg};
+use shikomi_cli::error::CliError;
+use shikomi_cli::usecase::portability::{
+    export::export_records, import::import_records,
+};
+use shikomi_core::{RecordKind, RecordLabel, RecordPayload, SecretString, Hotkey};
+use shikomi_infra::persistence::VaultRepository;
+
+use common::{fixed_time, fresh_repo};
+
+// -------------------------------------------------------------------
+// TC-IT-DP-001: export_records — vault 空でも ExportSummary { record_count: 0 }
+// -------------------------------------------------------------------
+
+/// TC-IT-DP-001: vault が存在しない状態でも 0 件 export として正常終了する。
+///
+/// REQ-DP-008 の「vault 不存在は 0 件 export として扱う」保証。
+#[test]
+fn tc_it_dp_001_export_records_empty_vault_returns_summary_with_zero_count() {
+    let (dir, repo) = fresh_repo();
+    let out = dir.path().join("out.json");
+    let args = ExportArgs {
+        output: out.clone(),
+        export_secrets: false,
+        force: false,
+    };
+
+    let summary = export_records(&repo, &args, dir.path(), fixed_time())
+        .expect("export_records should succeed for empty vault");
+
+    assert_eq!(summary.record_count, 0);
+    assert!(out.exists(), "output file should be created even for empty vault");
+
+    let content = std::fs::read_to_string(&out).unwrap();
+    assert!(
+        content.contains("\"format_version\": 1"),
+        "empty export should still contain format_version: 1"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-DP-002: import_records — JSON パース失敗 → ImportDeserializationFailed
+// -------------------------------------------------------------------
+
+/// TC-IT-DP-002: 不正な JSON ファイルを import すると `ImportDeserializationFailed` が返る。
+///
+/// REQ-DP-009 の「JSON パース失敗時の適切なエラー返却」保証。
+#[test]
+fn tc_it_dp_002_import_records_broken_json_returns_deserialization_failed() {
+    let (dir, repo) = fresh_repo();
+    let broken = dir.path().join("broken.json");
+    std::fs::write(&broken, "{invalid json").unwrap();
+
+    let args = ImportArgs {
+        input: broken,
+        on_conflict: OnConflictArg::Error,
+    };
+
+    let result = import_records(&repo, &args, fixed_time());
+
+    assert!(
+        matches!(result, Err(CliError::ImportDeserializationFailed { .. })),
+        "expected ImportDeserializationFailed, got: {result:?}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-DP-003: import_records — format_version:999 → ImportValidationFailed(UnknownFormatVersion)
+// -------------------------------------------------------------------
+
+/// TC-IT-DP-003: `format_version: 999` の JSON を import すると `ImportValidationFailed` が返る。
+///
+/// REQ-DP-009/010 の「不明フォーマットバージョン検出」保証。
+#[test]
+fn tc_it_dp_003_import_records_unknown_format_version_returns_validation_failed() {
+    let (dir, repo) = fresh_repo();
+    let v999 = dir.path().join("v999.json");
+    std::fs::write(
+        &v999,
+        r#"{"format_version":999,"vault_name":"test","exported_at":"1970-01-01T00:00:00Z","records":[]}"#,
+    )
+    .unwrap();
+
+    let args = ImportArgs {
+        input: v999,
+        on_conflict: OnConflictArg::Error,
+    };
+
+    let result = import_records(&repo, &args, fixed_time());
+
+    assert!(
+        matches!(
+            result,
+            Err(CliError::ImportValidationFailed(
+                shikomi_core::portability::ImportValidationError::UnknownFormatVersion { found: 999 }
+            ))
+        ),
+        "expected ImportValidationFailed(UnknownFormatVersion {{ found: 999 }}), got: {result:?}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-DP-004: import_records — hotkey フィールドが復元される（R1-DP-10）
+// -------------------------------------------------------------------
+
+/// TC-IT-DP-004: hotkey フィールドが export → import で正しく復元される。
+///
+/// REQ-DP-009/010（R1-DP-10 hotkey フィールド復元）の保証。
+#[test]
+fn tc_it_dp_004_import_records_hotkey_is_restored() {
+    use shikomi_core::{Record, RecordId, Vault, VaultHeader, VaultVersion};
+    use uuid::Uuid;
+
+    // vault A にホットキー付きのレコードを追加
+    let (dir_a, repo_a) = fresh_repo();
+    let now = fixed_time();
+    let id = RecordId::new(Uuid::now_v7()).unwrap();
+    let hotkey = Hotkey::parse("ctrl+2").unwrap();
+    let record = Record::new(
+        id.clone(),
+        RecordKind::Text,
+        RecordLabel::try_new("hotkey-label".to_owned()).unwrap(),
+        RecordPayload::Plaintext(SecretString::from_string("hotkey-value".to_owned())),
+        now,
+    )
+    .with_hotkey(hotkey);
+
+    let header = VaultHeader::new_plaintext(VaultVersion::CURRENT, now).unwrap();
+    let mut vault_a = Vault::new(header);
+    vault_a.add_record(record).unwrap();
+    repo_a.save(&vault_a).unwrap();
+
+    // vault A を export
+    let out = dir_a.path().join("with_hotkey.json");
+    let export_args = ExportArgs {
+        output: out.clone(),
+        export_secrets: false,
+        force: false,
+    };
+    export_records(&repo_a, &export_args, dir_a.path(), now)
+        .expect("export should succeed");
+
+    // vault B に import
+    let (_dir_b, repo_b) = fresh_repo();
+    let import_args = ImportArgs {
+        input: out,
+        on_conflict: OnConflictArg::Error,
+    };
+    let summary = import_records(&repo_b, &import_args, now)
+        .expect("import should succeed");
+    assert_eq!(summary.added, 1);
+
+    // vault B のレコードの hotkey が "ctrl+2" に復元されていること
+    let vault_b = repo_b.load().unwrap();
+    let records: Vec<_> = vault_b.records().iter().collect();
+    assert_eq!(records.len(), 1);
+    let hotkey_str = records[0]
+        .hotkey()
+        .map(|h| h.as_str().to_owned());
+    assert_eq!(
+        hotkey_str,
+        Some("ctrl+2".to_owned()),
+        "hotkey should be restored as 'ctrl+2'"
+    );
+}

--- a/docs/features/data-portability/cli/basic-design.md
+++ b/docs/features/data-portability/cli/basic-design.md
@@ -238,11 +238,16 @@ warning: エクスポートファイルを安全に保管し、不要になっ�
 | `shikomi-cli` | `src/presenter/error.rs` | 編集 | `lines_for` に 5 種の新 `CliError` バリアントの match arm を追加。`render_error` の dispatch 追加（`ImportValidationFailed(RedactedPayload)` → MSG-CLI-144 専用 helper）|
 | `shikomi-cli` | `src/lib.rs` | 編集 | `Subcommand::Export` / `Subcommand::Import` の match arm 追加。MSG-CLI-145 の stderr 出力ロジック追加 |
 
+**変更必要ファイル（追加依存）**:
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `crates/shikomi-cli/Cargo.toml` | `serde_json = { workspace = true }` および `tempfile = { workspace = true }` を **main dependencies** に追加（Issue #141）。line 71 の `tempfile` は **dev-dependency** であり、本番コードで `export.rs` / `import.rs` が使用するため main dep への昇格が必要。`serde_json` も同様に本番コードで `from_reader` / `to_string_pretty` を使用するため main dep に追加。|
+
 **変更不要ファイル**:
 
 | ファイル | 理由 |
 |---------|------|
-| `crates/shikomi-cli/Cargo.toml` | `tempfile = { workspace = true }` は既存依存（line 71）。追加依存なし |
 | `crates/shikomi-core/` 以下全ファイル | CLI UseCase / Presenter / CLI 引数は `shikomi-cli` のみに閉じる。`shikomi-core` は Sub-A で完成済み |
 
 ---
@@ -284,8 +289,8 @@ warning: エクスポートファイルを安全に保管し、不要になっ�
 |--------|------|
 | `shikomi-core::portability` モジュール（Sub-A #140 完成済み）| `ExportRecord` / `ExportPayload` / `ImportPayload` / `ImportValidator` / `ImportValidationError` |
 | `shikomi-infra::persistence::VaultRepository`（実装済み）| `repo.load()` / `repo.save()` / `repo.exists()` |
-| `serde_json`（`shikomi-cli/Cargo.toml` に既存）| JSON 文字列化 / パース |
-| `tempfile = { workspace = true }`（`shikomi-cli/Cargo.toml` 71 行目に既存）| atomic write（追加依存なし）|
+| `serde_json = { workspace = true }`（`shikomi-cli/Cargo.toml` main dep に追加、Issue #141）| JSON 文字列化（`to_string_pretty`）/ ストリーミングパース（`from_reader`）|
+| `tempfile = { workspace = true }`（`shikomi-cli/Cargo.toml` main dep に追加、Issue #141。line 71 の dev-dep とは別エントリ）| atomic write（`NamedTempFile::persist` による rename）|
 | `time::format_description::well_known::Rfc3339`（`shikomi-cli/Cargo.toml` に既存）| `created_at` / `updated_at` の RFC 3339 パース |
 
 ---


### PR DESCRIPTION
## 概要

Issue #141 Sub-B（data-portability CLIレイヤー）の実装。
`shikomi export` / `shikomi import` サブコマンドを追加する。

Closes #141

## 変更ファイル

| ファイル | 変更種別 | 内容 |
|---------|---------|------|
| `crates/shikomi-cli/Cargo.toml` | 編集 | `serde_json` / `tempfile` を `[dependencies]` に追加 |
| `crates/shikomi-cli/src/cli.rs` | 編集 | `Subcommand::Export(ExportArgs)` / `Import(ImportArgs)` / `OnConflictArg` 追加 |
| `crates/shikomi-cli/src/error.rs` | 編集 | `CliError` 新バリアント 5 種 + `ExitCode` match arm + `From<DataPortabilityError>` + `tc_f_u15` 5 件追加 |
| `crates/shikomi-cli/src/usecase/mod.rs` | 編集 | `pub mod portability;` 追加 |
| `crates/shikomi-cli/src/usecase/portability/mod.rs` | 新規 | `error` / `export` / `import` モジュール宣言 |
| `crates/shikomi-cli/src/usecase/portability/error.rs` | 新規 | `DataPortabilityError` 型定義 |
| `crates/shikomi-cli/src/usecase/portability/export.rs` | 新規 | `export_records` + `ExportSummary` |
| `crates/shikomi-cli/src/usecase/portability/import.rs` | 新規 | `import_records` + `ImportSummary` + `import_record_to_domain` |
| `crates/shikomi-cli/src/presenter/success.rs` | 編集 | `render_exported` / `render_imported` / `render_export_secrets_warning` 追加 |
| `crates/shikomi-cli/src/presenter/error.rs` | 編集 | MSG-CLI-140〜144 文言 + `format_conflict_ids` + `render_import_validation_redacted` 追加 |
| `crates/shikomi-cli/src/lib.rs` | 編集 | `run_export` / `run_import` dispatcher + `Subcommand` match arm 追加 |

## 設計上の重要ポイント

- **IPC 経路廃止**: Export / Import は `RepositoryHandle` バリアントに関わらず常に `SqliteVaultRepository::from_directory` で直接 SQLite アクセス（`IpcVaultRepository` はペイロードを返さないため）
- **atomic write**: `tempfile::NamedTempFile::persist` による rename で完全性を保証（R1-DP-09）
- **OOM 防止**: `serde_json::from_reader` ストリーミングパース（`read_to_string` 不使用、threat-model.md §7.5）
- **MSG-CLI-145 強制出力**: `run_export` で `quiet` フラグを参照せず `eprintln!` で直接 stderr 出力
- **ExitCode SSoT**: 新バリアント 5 種は全て `ExitCode::UserError`（exit 1）に写像、`tc_f_u15` テストで網羅性確認

## テスト担当への確認観点

- `cargo test -p shikomi-cli` は全 155 unit test + integration test が PASS（0 FAILED）
- `tc_f_u15_exit_code_ssot_mapping_*` に 5 件追加済（SSoT ドリフト防止）
- `export_records` の vault 不存在 → 0 件 export の正常系
- `import_records` の `--on-conflict {error,skip,overwrite}` 各戦略
- `render_export_secrets_warning` が `--quiet` でも抑止されないこと（stderr 直接出力の構造検証）
- `format_conflict_ids` の 4 件以下 / 5 件以上の省略表示
- `render_import_validation_redacted`（MSG-CLI-144）が `render_error` から正しく dispatch されること