### PR TITLE
ci(release): GitHub Releases 配布パイプライン新規作成（Issue #136）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,13 @@ jobs:
       # gh release create に必要。最小権限原則: このジョブのみ write を付与
       contents: write
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4 as of 2026-05-11
+
+      - name: install Rust stable
+        # SBOM 生成（cargo-cyclonedx）のために Rust が必要。tauri-cli・Node.js は不要のため
+        # tauri-build-setup ではなく rust-toolchain アクションを直接使用（依存最小化）
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable as of 2026-05-11
+
       - name: download linux artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4 as of 2026-05-11
         with:
@@ -175,8 +182,17 @@ jobs:
           name: shikomi-installer-${{ github.ref_name }}-windows
           path: dist
 
+      - name: install cargo-cyclonedx
+        # 設計根拠: tech-stack.md §2.2（SBOM 行）— CycloneDX 1.5 形式をリリースに添付
+        run: cargo install --locked cargo-cyclonedx
+
+      - name: generate SBOM (CycloneDX 1.5)
+        # ワークスペース全体の依存グラフを bom.json として出力（供給チェーン透明性 / OWASP A08）
+        run: cargo cyclonedx --format json --all
+
       - name: create draft release
         # draft 経由: artifact アタッチ完了前に空の Release が外部公開されることを防ぐ（設計根拠: §2.2.1）
+        # --generate-notes: タグ間コミット・PR タイトルを GitHub が自動列挙（設計根拠: §2.2.1 リリースノート生成戦略）
         run: |
           gh release create "${{ github.ref_name }}" \
             --draft \
@@ -187,6 +203,8 @@ jobs:
 
       - name: generate SHA256SUMS
         # OWASP A08: ダウンロード後の整合性検証手段を提供（threat-model.md A08 対応）
+        # sed 's|.*/||' でパスを basename のみに正規化——ユーザが同一ディレクトリで
+        # sha256sum -c SHA256SUMS.txt を実行できるようにする（パス不一致による検証失敗を防ぐ）
         run: |
           cd dist
           find . -type f \( \
@@ -196,9 +214,11 @@ jobs:
             -o -name "*.dmg" \
             -o -name "*.msi" \
             -o -name "*.exe" \
-          \) | sort | xargs sha256sum > SHA256SUMS.txt
+          \) | sort | \
+            while IFS= read -r f; do sha256sum "$f" | sed 's|.*/||'; done \
+          > SHA256SUMS.txt
 
-      - name: upload artifacts and checksums to release
+      - name: upload artifacts, checksums, and SBOM to release
         run: |
           find dist -type f \( \
             -name "*.deb" \
@@ -209,6 +229,7 @@ jobs:
             -o -name "*.exe" \
           \) | sort | xargs gh release upload "${{ github.ref_name }}"
           gh release upload "${{ github.ref_name }}" dist/SHA256SUMS.txt
+          gh release upload "${{ github.ref_name }}" bom.json
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
             crates/shikomi-gui/target/release/bundle/deb/*.deb
             crates/shikomi-gui/target/release/bundle/rpm/*.rpm
             crates/shikomi-gui/target/release/bundle/appimage/*.AppImage
-          retention-days: 90
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # build-macos（macos-latest）
@@ -110,7 +110,7 @@ jobs:
         with:
           name: shikomi-installer-${{ github.ref_name }}-macos
           path: crates/shikomi-gui/target/release/bundle/dmg/*.dmg
-          retention-days: 90
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # build-windows（windows-latest）
@@ -143,7 +143,7 @@ jobs:
           path: |
             crates/shikomi-gui/target/release/bundle/msi/*.msi
             crates/shikomi-gui/target/release/bundle/nsis/*.exe
-          retention-days: 90
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # release-publish
@@ -184,7 +184,8 @@ jobs:
 
       - name: install cargo-cyclonedx
         # 設計根拠: tech-stack.md §2.2（SBOM 行）— CycloneDX 1.5 形式をリリースに添付
-        run: cargo install --locked cargo-cyclonedx
+        # @0.5.9: バージョン固定（OWASP A08: SBOM ツール自体のサプライチェーン穴を防ぐ）
+        run: cargo install --locked cargo-cyclonedx@0.5.9
 
       - name: generate SBOM (CycloneDX 1.5)
         # ワークスペース全体の依存グラフを bom.json として出力（供給チェーン透明性 / OWASP A08）
@@ -203,8 +204,11 @@ jobs:
 
       - name: generate SHA256SUMS
         # OWASP A08: ダウンロード後の整合性検証手段を提供（threat-model.md A08 対応）
-        # sed 's|.*/||' でパスを basename のみに正規化——ユーザが同一ディレクトリで
-        # sha256sum -c SHA256SUMS.txt を実行できるようにする（パス不一致による検証失敗を防ぐ）
+        # sed 's|  .*/|  |' で「2スペース＋パス」を「2スペース＋basename」に置換。
+        # sha256sum 出力形式: "HASH  ./path/to/file.deb"
+        # sed パターン: 2スペース + 任意パス(貪欲) + / → 2スペース のみ残す
+        # 結果: "HASH  file.deb" でハッシュを保持したまま basename 化——
+        # ユーザが同一ディレクトリで sha256sum -c SHA256SUMS.txt を実行できるようにする
         run: |
           cd dist
           find . -type f \( \
@@ -215,7 +219,7 @@ jobs:
             -o -name "*.msi" \
             -o -name "*.exe" \
           \) | sort | \
-            while IFS= read -r f; do sha256sum "$f" | sed 's|.*/||'; done \
+            while IFS= read -r f; do sha256sum "$f" | sed 's|  .*/|  |'; done \
           > SHA256SUMS.txt
 
       - name: upload artifacts, checksums, and SBOM to release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,219 @@
+# release.yml — GitHub Releases 配布パイプライン（Issue #136）
+# 設計根拠: docs/architecture/tech-stack.md §2.2.1
+#
+# トリガ: v[0-9]+.[0-9]+.[0-9]+ タグ push のみ
+# pre-release タグ（v1.0.0-alpha.1 等）は本ワークフロー対象外（将来 workflow_dispatch で手動対応）
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+# ワークフローデフォルト: read-only（最小権限原則）
+# contents: write は release-publish ジョブのみに限定付与
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # build-linux（ubuntu-22.04）
+  # ---------------------------------------------------------------------------
+  build-linux:
+    name: build-linux
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4 as of 2026-05-11
+
+      - name: tauri build setup
+        uses: ./.github/actions/tauri-build-setup
+
+      - name: install system libraries
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            libdbus-1-dev \
+            libssl-dev \
+            pkg-config
+
+      - name: tauri build (linux)
+        working-directory: crates/shikomi-gui
+        run: cargo tauri build --ci
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4 as of 2026-05-11
+        with:
+          name: shikomi-installer-${{ github.ref_name }}-linux
+          path: |
+            crates/shikomi-gui/target/release/bundle/deb/*.deb
+            crates/shikomi-gui/target/release/bundle/rpm/*.rpm
+            crates/shikomi-gui/target/release/bundle/appimage/*.AppImage
+          retention-days: 90
+
+  # ---------------------------------------------------------------------------
+  # build-macos（macos-latest）
+  # ---------------------------------------------------------------------------
+  build-macos:
+    name: build-macos
+    runs-on: macos-latest
+    timeout-minutes: 90
+    env:
+      # secrets context は step の if 式で使用不可のため job-level env に昇格（bundler.yml と同一パターン）
+      # 参照: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/contexts#context-availability
+      # MVP フェーズ: APPLE_CERTIFICATE 未設定時は unsigned ビルド（R18: Gatekeeper 警告は許容、Issue #130 で解消予定）
+      HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4 as of 2026-05-11
+
+      - name: tauri build setup
+        uses: ./.github/actions/tauri-build-setup
+
+      - name: import certificate to Keychain
+        # APPLE_CERTIFICATE 未設定時はスキップ（MVPフェーズ: コード署名なし許容、Issue #130）
+        if: env.HAS_APPLE_CERT == 'true'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          echo "$APPLE_CERTIFICATE" | base64 --decode > certificate.p12
+          security create-keychain -p "" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import certificate.p12 -k build.keychain \
+            -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s build.keychain
+
+      - name: tauri build (macos)
+        # APPLE_CERTIFICATE 未設定時は signing env を渡さず unsigned ビルド
+        working-directory: crates/shikomi-gui
+        env:
+          APPLE_ID: ${{ secrets.APPLE_CERTIFICATE != '' && secrets.APPLE_ID || '' }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_CERTIFICATE != '' && secrets.APPLE_ID_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_CERTIFICATE != '' && secrets.APPLE_TEAM_ID || '' }}
+        run: cargo tauri build --ci
+
+      - name: cleanup Keychain
+        # ビルド失敗時も実行（対称性保証）、Keychain 未作成時はスキップ
+        if: always() && env.HAS_APPLE_CERT == 'true'
+        run: |
+          security delete-keychain build.keychain
+          rm -f certificate.p12
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4 as of 2026-05-11
+        with:
+          name: shikomi-installer-${{ github.ref_name }}-macos
+          path: crates/shikomi-gui/target/release/bundle/dmg/*.dmg
+          retention-days: 90
+
+  # ---------------------------------------------------------------------------
+  # build-windows（windows-latest）
+  # ---------------------------------------------------------------------------
+  build-windows:
+    name: build-windows
+    runs-on: windows-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4 as of 2026-05-11
+
+      - name: tauri build setup
+        # save-cache: 'false' — Windows の rust-cache 保存ステップが tar/API エラーで失敗するため抑制（bundler.yml と同一パターン）
+        uses: ./.github/actions/tauri-build-setup
+        with:
+          save-cache: "false"
+
+      - name: tauri build (windows)
+        # MVP: コード署名なし（SmartScreen 警告許容）
+        working-directory: crates/shikomi-gui
+        run: cargo tauri build --ci
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4 as of 2026-05-11
+        with:
+          name: shikomi-installer-${{ github.ref_name }}-windows
+          path: |
+            crates/shikomi-gui/target/release/bundle/msi/*.msi
+            crates/shikomi-gui/target/release/bundle/nsis/*.exe
+          retention-days: 90
+
+  # ---------------------------------------------------------------------------
+  # release-publish
+  # 3 OS ビルド全成功後にのみ実行（Fail Fast / partial release 防止）
+  # ---------------------------------------------------------------------------
+  release-publish:
+    name: release-publish
+    runs-on: ubuntu-22.04
+    needs: [build-linux, build-macos, build-windows]
+    permissions:
+      # gh release create に必要。最小権限原則: このジョブのみ write を付与
+      contents: write
+    steps:
+      - name: download linux artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4 as of 2026-05-11
+        with:
+          name: shikomi-installer-${{ github.ref_name }}-linux
+          path: dist
+
+      - name: download macos artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4 as of 2026-05-11
+        with:
+          name: shikomi-installer-${{ github.ref_name }}-macos
+          path: dist
+
+      - name: download windows artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4 as of 2026-05-11
+        with:
+          name: shikomi-installer-${{ github.ref_name }}-windows
+          path: dist
+
+      - name: create draft release
+        # draft 経由: artifact アタッチ完了前に空の Release が外部公開されることを防ぐ（設計根拠: §2.2.1）
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --draft \
+            --title "${{ github.ref_name }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: generate SHA256SUMS
+        # OWASP A08: ダウンロード後の整合性検証手段を提供（threat-model.md A08 対応）
+        run: |
+          cd dist
+          find . -type f \( \
+            -name "*.deb" \
+            -o -name "*.rpm" \
+            -o -name "*.AppImage" \
+            -o -name "*.dmg" \
+            -o -name "*.msi" \
+            -o -name "*.exe" \
+          \) | sort | xargs sha256sum > SHA256SUMS.txt
+
+      - name: upload artifacts and checksums to release
+        run: |
+          find dist -type f \( \
+            -name "*.deb" \
+            -o -name "*.rpm" \
+            -o -name "*.AppImage" \
+            -o -name "*.dmg" \
+            -o -name "*.msi" \
+            -o -name "*.exe" \
+          \) | sort | xargs gh release upload "${{ github.ref_name }}"
+          gh release upload "${{ github.ref_name }}" dist/SHA256SUMS.txt
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: publish release
+        # draft → published: artifact アタッチ完了後に公開（設計根拠: §2.2.1）
+        run: gh release edit "${{ github.ref_name }}" --draft=false
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/docs/architecture/tech-stack.md
+++ b/docs/architecture/tech-stack.md
@@ -82,12 +82,42 @@ flowchart TB
 | バンドラー | `tauri-bundler` / `cargo-bundle` / 自前 | **`tauri-bundler` v2.8+** | Tauri v2 公式、3 OS 全インストーラ形式を同一 YAML (`tauri.conf.json`) から生成<br/>出典: https://v2.tauri.app/distribute/ |
 | Windows インストーラ | MSI (WiX v3) / NSIS / MSIX | **NSIS（主）+ MSI（任意）** | NSIS はクロスコンパイル可・単一で多言語、MSI は Windows ホスト必須・言語別分離。`winget` は両形式受容<br/>出典: https://v2.tauri.app/distribute/windows-installer/ |
 | Windows 署名 | OV / EV / 未署名 | **段階移行（当面 OV、評判構築後 EV 検討）** | SmartScreen 警告回避、EV は即時 reputation だが年額コスト高、OSS 初期は OV で運用後に移行検討<br/>出典: https://v2.tauri.app/distribute/sign/windows/ |
-| macOS 署名 | Developer ID + Notarization / Ad-hoc / 未署名 | **Developer ID + Notarization（必須）** | Notarization なしは Gatekeeper で「壊れている」と表示される UX 悪化、要件「技術知識不要」に反する<br/>出典: https://v2.tauri.app/distribute/sign/macos/ |
+| macOS 署名 | Developer ID + Notarization / Ad-hoc / 未署名 | **Developer ID + Notarization（MVP後、Issue #130 で追加予定）** | MVP段階では `APPLE_CERTIFICATE` シークレット未設定のため unsigned build を許容（`bundler.yml` / `release.yml` の `HAS_APPLE_CERT` ガードで制御）。unsigned 時は Gatekeeper の「壊れています」警告が発生——ユーザーはシステム設定 → プライバシーとセキュリティ → 許可ボタンで手動許可が必要。Issue #130 で署名追加後に secrets 設定のみで解消。製品リリース（非 MVP）では署名必須（`nfr.md §9` 署名要件）<br/>出典: https://v2.tauri.app/distribute/sign/macos/ |
 | Linux 配布形式 | AppImage / deb / rpm / Flatpak / Snap / tarball | **deb + rpm + AppImage（初期）、Flatpak は後続** | Ubuntu/Debian・Fedora/RHEL・distro 非依存の 3 本で主要ユーザをカバー。Flatpak は XDG Portal 前提でホットキー実装の再確認が必要なため MVP スコープ外<br/>出典: https://v2.tauri.app/distribute/appimage/ / debian/ / rpm/ |
 | 配布チャネル | GitHub Releases / winget / Homebrew / APT repo / snap store | **GitHub Releases（主）+ winget + Homebrew Cask（副）** | OSS 初期は GitHub Releases を SSoT、winget と Homebrew Cask は YAML マニフェスト更新のみで低コスト<br/>出典: https://github.com/microsoft/winget-pkgs |
 | CI/CD | GitHub Actions / CircleCI / 自前 | **GitHub Actions** | リポジトリ所在と同一、matrix build で Win/Mac/Linux ランナーを標準提供、`taiki-e/upload-rust-binary-action` 等のエコシステム |
 | 依存監査 | `cargo-audit` / `cargo-deny` / Dependabot | **`cargo-deny` + Dependabot** | `cargo-deny` でライセンス / advisory / 重複バージョン / 禁止 crate を CI で fail fast、Dependabot で自動 PR |
 | SBOM | `cargo-cyclonedx` / `syft` | **`cargo-cyclonedx`** | Rust ネイティブ、CycloneDX 1.5 形式をリリースに添付 |
+
+#### 2.2.1 リリースパイプライン設計判断テーブル（`release.yml`）
+
+`release.yml` は `bundler.yml`（PR CI）と完全に独立したワークフローとして実装する。各設計判断の根拠を以下に記録する。
+
+```mermaid
+flowchart TD
+    Tag["semver タグ push\n（v*.*.*）"]
+    Tag --> Linux["build-linux\nubuntu-latest"]
+    Tag --> macOS["build-macos\nmacos-latest"]
+    Tag --> Windows["build-windows\nwindows-latest"]
+    Linux --> Publish["release-publish\nneeds: [build-linux, build-macos, build-windows]"]
+    macOS --> Publish
+    Windows --> Publish
+    Publish --> Draft["gh release create --draft\n+ artifacts upload\n+ cargo cyclonedx（SBOM）\n+ SHA256SUMS.txt"]
+    Draft --> Published["gh release edit --draft=false"]
+```
+
+| 設計判断 | 採用方針 | 根拠 |
+|---------|---------|------|
+| `bundler.yml` 変更 | **変更なし**。`release.yml` を独立した新規ワークフローとして追加 | PR CI（`bundler.yml`）と release pipeline は責務が異なる。同一ファイルに混在させると `on: push` トリガと `on: tags` トリガが競合し、PR CI の安定性を損なう。Separation of Concerns |
+| macOS 署名スキップ | **`HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}` を job-level env に定義し `if: env.HAS_APPLE_CERT == 'true'` でスキップ** | GitHub Actions では `secrets` context は step の `if` 条件で直接参照不可（`secrets` は `env` / `with` のみ）。job-level env に boolean 文字列として展開してから条件評価する必要がある<br/>出典: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#about-expressions |
+| draft → published フロー | **`gh release create --draft` でドラフト作成 → artifacts アップロード → `gh release edit --draft=false` で公開** | artifacts アップロード前に公開すると「空リリース」がユーザに露出する。draft 段階で全アップロードを完了してから公開することで UX 悪化を防止<br/>出典: https://cli.github.com/manual/gh_release_create |
+| `permissions: contents: write` | **release-publish job にのみ付与** | 最小権限の原則（OWASP A01）。build-* jobs は artifacts の upload のみで write 権限不要 |
+| タグパターン | **`v[0-9]+.[0-9]+.[0-9]+`**（SemVer 厳格） | プレリリース suffix（`-alpha`, `-rc`）を意図せず publish させないための防衛設計。pre-release は別途 `--prerelease` フラグ付きワークフローを追加する |
+| artifact 保持期間 | **`retention-days: 1`** | release-publish job が完了すれば GitHub Releases に永続保存されるため、一時 artifact の長期保持は不要。ストレージコスト最小化 |
+| `release-publish` needs | **`needs: [build-linux, build-macos, build-windows]`** | 3 OS ビルドが全て成功した場合のみ publish する。一部 OS のビルド失敗で不完全なリリースが公開されることを防止（Fail Fast / 部分リリース防止） |
+| SHA256 整合性検証 | **`sha256sum` でバイナリ名のみ（パス除去）を記録した `SHA256SUMS.txt` を添付** | ユーザが `sha256sum -c SHA256SUMS.txt` で検証できるよう、ファイル名のみ記録する。フルパスが含まれると `sha256sum -c` がパスミスで失敗する（OWASP A08: Software and Data Integrity Failures）<br/>出典: https://man7.org/linux/man-pages/man1/sha256sum.1.html |
+| タグ push 認可 | **GitHub Repository Rules で `v*.*.*` パターンへの push を maintainer ロール以上に制限** | 悪意ある contributor による偽 tag push でリリースパイプラインが誤発動するサプライチェーン攻撃を防止<br/>出典: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets |
+| リリースノート生成戦略 | **`gh release create --generate-notes` で自動生成** | タグ間のコミット・PR タイトルを GitHub が自動列挙する。手動編集の運用負担を排除しつつ、リリースマネージャーは GitHub UI から事後編集も可能。MVP 期間は技術的 PR タイトルがそのまま表示される制約あり（「feat(cli): data-portability Sub-B」等）、正式リリース時は手動 CHANGELOG 編集を検討。CHANGELOG.md との二重管理は回避（CHANGELOG.md は別 Issue でフォーマット策定）<br/>出典: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes |
 
 ### 2.3 クラウド・サーバ系項目（該当なし）
 


### PR DESCRIPTION
## Summary

- `.github/workflows/release.yml` を新規作成（Issue #136）
- トリガ: `v[0-9]+.[0-9]+.[0-9]+` タグ push のみ（pre-release タグは対象外）
- 3 OS 並列ビルド (`build-linux` / `build-macos` / `build-windows`) + `release-publish` の 4 ジョブ構成
- `release-publish` は `needs: [build-linux, build-macos, build-windows]` — 1 OS でも失敗すれば Release 非作成（Fail Fast / partial release 防止）
- `contents: write` は `release-publish` ジョブのみに限定付与（最小権限原則）
- macOS 署名: `HAS_APPLE_CERT` job-level env guard（R18、`bundler.yml` と同一パターン）
- draft → published フロー: artifact アタッチ完了前の空 Release 外部公開を防止
- `SHA256SUMS.txt` 生成 → Release 添付（OWASP A08: ダウンロード後整合性検証手段）

## Design Reference

`docs/architecture/tech-stack.md §2.2.1`

## Closes

Closes #136