### PR TITLE
docs(test-design): system-test-design.md §1 配置欄を現状に更新（Issue #139）

### DIFF
--- a/docs/features/daemon-default-mode/system-test-design.md
+++ b/docs/features/daemon-default-mode/system-test-design.md
@@ -14,7 +14,7 @@
 | テストレベル | システムテスト（subprocess 起動によるブラックボックス。E2E の一歩手前。IT / UT より粗粒度）|
 | 実行環境 | CI 3 OS matrix（Linux / macOS / Windows）|
 | テストフレームワーク | `assert_cmd` + `predicates`（`shikomi-cli` / `shikomi-daemon` 共に）|
-| 配置 | `crates/shikomi-cli/tests/st_default_mode*.rs`（Sub-A）/ Sub-B は別 PR で追加 |
+| 配置 | `crates/shikomi-cli/tests/st_default_mode*.rs`（Sub-A）/ Sub-B は Issue #127 / PR #133 で追加済み |
 
 ## 2. 対応受入基準
 

--- a/docs/features/daemon-default-mode/system-test-design.md
+++ b/docs/features/daemon-default-mode/system-test-design.md
@@ -14,7 +14,7 @@
 | テストレベル | システムテスト（subprocess 起動によるブラックボックス。E2E の一歩手前。IT / UT より粗粒度）|
 | 実行環境 | CI 3 OS matrix（Linux / macOS / Windows）|
 | テストフレームワーク | `assert_cmd` + `predicates`（`shikomi-cli` / `shikomi-daemon` 共に）|
-| 配置 | `crates/shikomi-cli/tests/st_default_mode*.rs`（Sub-A）/ Sub-B は Issue #127 / PR #133 で追加済み |
+| 配置 | `crates/shikomi-cli/tests/e2e_sc_ddm_001.rs`（Sub-A: SC-DDM-001）/ `crates/shikomi-cli/tests/e2e_sc_ddm_002.rs`（Sub-B: SC-DDM-002、Issue #127 / PR #133 で追加済み）/ `crates/shikomi-cli/tests/it_cli_default_mode.rs`（integration）|
 
 ## 2. 対応受入基準
 


### PR DESCRIPTION
## Summary

- `docs/features/daemon-default-mode/system-test-design.md §1` の配置欄を修正
- 「Sub-B は別 PR で追加」→「Sub-B は Issue #127 / PR #133 で追加済み」
- PR #133（daemon OS 自動起動実装）が main にマージ済みのため設計書の記述を実態に合わせる（Boy Scout Rule）

## Closes

Closes #139