### PR TITLE
feat(portability): add SQLITE_BUSY handling for shikomi import (Issue #146)

### DIFF
--- a/crates/shikomi-cli/src/cli.rs
+++ b/crates/shikomi-cli/src/cli.rs
@@ -102,7 +102,6 @@ pub enum Subcommand {
     Daemon(DaemonSubcommand),
 
     // ---------------- Issue #141: data-portability export / import ----------------
-
     /// vault レコードを JSON ファイルへ export する（Issue #141 Sub-B、REQ-DP-007）。
     ///
     /// 設計根拠: docs/features/data-portability/cli/basic-design.md §REQ-DP-007

--- a/crates/shikomi-cli/src/error.rs
+++ b/crates/shikomi-cli/src/error.rs
@@ -720,4 +720,32 @@ mod tests {
         // 経路 (本 TC は `ExitCode::Success as u8 == 0` の SSoT 1 行を担保)。
         assert_eq!(ExitCode::Success as u8, 0, "SSoT exit 0 (Success)");
     }
+
+    // -------------------------------------------------------------------
+    // Issue #146: SQLITE_BUSY UT — TC-UT-209
+    // 設計根拠: docs/features/data-portability/cli/test-design/ut.md §TC-UT-209
+    // -------------------------------------------------------------------
+
+    /// TC-UT-209 (REQ-DP-010): `DataPortabilityError::VaultBusy` が
+    /// `CliError::ImportVaultBusy` に変換され、`ExitCode::UserError`（exit 1）に写像される。
+    ///
+    /// `From<DataPortabilityError> for CliError` の `VaultBusy → ImportVaultBusy` マッピングと
+    /// `ExitCode` SSoT の局所検証（Issue #146 設計内部保証）。
+    #[test]
+    fn tc_ut_209_data_portability_vault_busy_maps_to_import_vault_busy_with_exit_1() {
+        use crate::usecase::portability::error::DataPortabilityError;
+
+        let dp_err = DataPortabilityError::VaultBusy;
+        let cli_err = CliError::from(dp_err);
+
+        assert!(
+            matches!(cli_err, CliError::ImportVaultBusy),
+            "DataPortabilityError::VaultBusy should map to CliError::ImportVaultBusy, got: {cli_err:?}"
+        );
+        assert_eq!(
+            ExitCode::from(&cli_err) as u8,
+            1,
+            "CliError::ImportVaultBusy should map to ExitCode::UserError (exit 1)"
+        );
+    }
 }

--- a/crates/shikomi-cli/src/error.rs
+++ b/crates/shikomi-cli/src/error.rs
@@ -155,7 +155,6 @@ pub enum CliError {
     GuiLaunchFailed(String),
 
     // ---------------- Issue #141: data-portability export / import ----------------
-
     /// vault がロック済みで export / import を試みた（MSG-CLI-140、exit 1）。
     ///
     /// `CliError::VaultLocked`（exit 3）とは意図的に分離：export / import は
@@ -188,6 +187,12 @@ pub enum CliError {
     /// import バリデーション失敗（MSG-CLI-143 / MSG-CLI-144、exit 1）。
     #[error("import validation failed: {0}")]
     ImportValidationFailed(shikomi_core::portability::ImportValidationError),
+
+    /// import 実行時に SQLITE_BUSY が `busy_timeout 2000ms` 超過後も解消しない
+    /// （MSG-CLI-146、exit 1）。daemon 常駐中に vault.db を直接書き込む経路
+    /// （`import_records`）でのロック競合。
+    #[error("vault is in use by shikomi-daemon; import aborted after 2 seconds")]
+    ImportVaultBusy,
 }
 
 /// daemon から返る `IpcErrorCode` を CLI 層エラーに写像する（Sub-F #44 Phase 2）。
@@ -268,6 +273,8 @@ impl From<crate::usecase::portability::error::DataPortabilityError> for CliError
                     reason: io_err.to_string(),
                 })
             }
+            // Issue #146: VaultBusy → ImportVaultBusy（MSG-CLI-146、exit 1）
+            DataPortabilityError::VaultBusy => Self::ImportVaultBusy,
         }
     }
 }
@@ -336,7 +343,9 @@ impl From<&CliError> for ExitCode {
             | CliError::ExportOutputFileExists { .. }
             | CliError::ImportConflict { .. }
             | CliError::ImportDeserializationFailed { .. }
-            | CliError::ImportValidationFailed(_) => Self::UserError,
+            | CliError::ImportValidationFailed(_)
+            // Issue #146: SQLITE_BUSY（daemon 常駐中の vault ロック競合、exit 1）
+            | CliError::ImportVaultBusy => Self::UserError,
             // exit 2（SystemError / WrongPassword）: 既存 I/O 系 + Sub-F SSoT パスワード違い
             CliError::Persistence(_)
             | CliError::Domain(_)
@@ -625,6 +634,8 @@ mod tests {
                     },
                 ),
             ),
+            // Issue #146: SQLITE_BUSY（daemon 常駐中の vault ロック競合）→ exit 1
+            ("ImportVaultBusy", CliError::ImportVaultBusy),
         ];
         for (name, err) in user_error_cases {
             assert_eq!(

--- a/crates/shikomi-cli/src/lib.rs
+++ b/crates/shikomi-cli/src/lib.rs
@@ -231,12 +231,8 @@ pub fn run() -> ExitCode {
         Subcommand::Remove(a) => record_runners::run_remove(&handle, a, locale, quiet),
         // Issue #141: export / import は常に SQLite 直接アクセスを使用（IPC 経路を使わない）。
         // `IpcVaultRepository` はペイロードを返さないため。
-        Subcommand::Export(a) => {
-            run_export(a, &handle, args.vault_dir.as_deref(), quiet, locale)
-        }
-        Subcommand::Import(a) => {
-            run_import(a, &handle, args.vault_dir.as_deref(), quiet, locale)
-        }
+        Subcommand::Export(a) => run_export(a, &handle, args.vault_dir.as_deref(), quiet, locale),
+        Subcommand::Import(a) => run_import(a, &handle, args.vault_dir.as_deref(), quiet, locale),
         // 上の `if let Subcommand::Vault(_)` early return で処理済（網羅性のため `_` で吸収）。
         Subcommand::Vault(_) => unreachable!("vault subcommand handled above"),
         // 上の `if let Subcommand::Gui` early return で処理済（網羅性のため unreachable）。
@@ -344,7 +340,12 @@ fn run_import(
     }
 
     // Step 3: SQLite 直接アクセス（R1-DP-09 atomicity 要件適合）
-    let sqlite_repo = SqliteVaultRepository::from_directory(&resolved_dir)?;
+    // Issue #146: busy_timeout(2000ms) を設定して daemon のロック競合を吸収する。
+    // 2 秒超過後も SQLITE_BUSY が解消しない場合は DatabaseBusy → ImportVaultBusy（MSG-CLI-146）。
+    let sqlite_repo = SqliteVaultRepository::from_directory_with_busy_timeout(
+        &resolved_dir,
+        std::time::Duration::from_millis(2000),
+    )?;
 
     // Step 4: 現在時刻
     let now = time::OffsetDateTime::now_utc();

--- a/crates/shikomi-cli/src/presenter/error.rs
+++ b/crates/shikomi-cli/src/presenter/error.rs
@@ -320,6 +320,14 @@ fn lines_for(err: &CliError) -> (String, String, String, String) {
             "verify the file is a valid shikomi export (format_version must be 1)".to_owned(),
             "ファイルが有効な shikomi export ファイルであることを確認してください（format_version は 1 である必要があります）".to_owned(),
         ),
+        // Issue #146: MSG-CLI-146（ImportVaultBusy）— SQLITE_BUSY 超過後の daemon ロック競合
+        // 文面の SSoT: docs/features/data-portability/cli/detailed-design/presenter.md §ImportVaultBusy
+        CliError::ImportVaultBusy => lit(
+            "vault is in use by shikomi-daemon; import aborted after 2 seconds",
+            "vault が shikomi-daemon に使用されています。2 秒待機後に import を中断しました",
+            "stop shikomi-daemon, then retry (to disable autostart: shikomi daemon uninstall)",
+            "shikomi-daemon を停止してから再実行してください（自動起動の無効化: shikomi daemon uninstall）",
+        ),
         // `RedactedPayload` は `render_error` 側の専用 helper で処理済のため、
         // `lines_for` には到達しない契約。万一到達した場合のコンパイル時網羅性のため記述する。
         CliError::ImportValidationFailed(err) => {
@@ -396,7 +404,9 @@ fn format_conflict_ids(ids: &[String]) -> String {
 fn render_import_validation_redacted(id: &str, locale: Locale) -> String {
     let mut out = format!("error: cannot import record {id}: payload is redacted\n");
     if matches!(locale, Locale::JapaneseEn) {
-        out.push_str(&format!("error: レコード {id} を import できません: ペイロードがリダクトされています\n"));
+        out.push_str(&format!(
+            "error: レコード {id} を import できません: ペイロードがリダクトされています\n"
+        ));
     }
     out.push_str(
         "hint: re-export the source vault with --export-secrets, then import the new file\n",

--- a/crates/shikomi-cli/src/presenter/error.rs
+++ b/crates/shikomi-cli/src/presenter/error.rs
@@ -692,4 +692,34 @@ mod tests {
             "MSG-CLI-110 JapaneseEn must contain Japanese autostart hint: {rendered:?}"
         );
     }
+
+    // -------------------------------------------------------------------
+    // Issue #146: SQLITE_BUSY Presenter UT — TC-UT-210
+    // 設計根拠: docs/features/data-portability/cli/test-design/ut.md §TC-UT-210
+    // -------------------------------------------------------------------
+
+    /// TC-UT-210 (REQ-DP-010/011 / Issue #146 MSG-CLI-146 文面保証):
+    /// `render_error(&CliError::ImportVaultBusy, Locale::English)` が
+    /// MSG-CLI-146 の 3 要素を全て含む文字列を返す。
+    ///
+    /// 検証対象: `"vault is in use by shikomi-daemon"` (error 行) /
+    /// `"stop shikomi-daemon"` (hint 行) / `"shikomi daemon uninstall"` (hint 行末尾)。
+    #[test]
+    fn tc_ut_210_render_error_import_vault_busy_returns_msg_cli_146() {
+        let err = CliError::ImportVaultBusy;
+        let out = render_error(&err, Locale::English);
+
+        assert!(
+            out.contains("vault is in use by shikomi-daemon"),
+            "MSG-CLI-146 must contain 'vault is in use by shikomi-daemon', got: {out:?}"
+        );
+        assert!(
+            out.contains("stop shikomi-daemon"),
+            "MSG-CLI-146 must contain 'stop shikomi-daemon', got: {out:?}"
+        );
+        assert!(
+            out.contains("shikomi daemon uninstall"),
+            "MSG-CLI-146 must contain 'shikomi daemon uninstall', got: {out:?}"
+        );
+    }
 }

--- a/crates/shikomi-cli/src/presenter/success.rs
+++ b/crates/shikomi-cli/src/presenter/success.rs
@@ -277,11 +277,17 @@ pub fn render_autostart_uninstalled(locale: Locale) -> String {
 ///
 /// `quiet == true` の場合は呼出側（`run_export`）で呼ばない（presenter 層は quiet 非関与）。
 #[must_use]
-pub fn render_exported(record_count: usize, output_path: &std::path::Path, locale: Locale) -> String {
+pub fn render_exported(
+    record_count: usize,
+    output_path: &std::path::Path,
+    locale: Locale,
+) -> String {
     let path_str = output_path.display();
     let mut out = format!("exported {record_count} record(s) to {path_str}\n");
     if matches!(locale, Locale::JapaneseEn) {
-        out.push_str(&format!("{record_count} 件のレコードを {path_str} に export しました\n"));
+        out.push_str(&format!(
+            "{record_count} 件のレコードを {path_str} に export しました\n"
+        ));
     }
     out
 }
@@ -291,7 +297,8 @@ pub fn render_exported(record_count: usize, output_path: &std::path::Path, local
 /// `quiet == true` の場合は呼出側（`run_import`）で呼ばない（presenter 層は quiet 非関与）。
 #[must_use]
 pub fn render_imported(added: usize, skipped: usize, overwritten: usize, locale: Locale) -> String {
-    let mut out = format!("imported {added} record(s) (skipped {skipped}, overwritten {overwritten})\n");
+    let mut out =
+        format!("imported {added} record(s) (skipped {skipped}, overwritten {overwritten})\n");
     if matches!(locale, Locale::JapaneseEn) {
         out.push_str(&format!(
             "{added} 件を追加しました（スキップ: {skipped} 件、上書き: {overwritten} 件）\n"
@@ -310,9 +317,7 @@ pub fn render_export_secrets_warning(locale: Locale) -> String {
     let mut out = String::from(
         "warning: --export-secrets is set; secret values will be written to the export file in plaintext\n",
     );
-    out.push_str(
-        "warning: store the export file securely and delete it when no longer needed\n",
-    );
+    out.push_str("warning: store the export file securely and delete it when no longer needed\n");
     if matches!(locale, Locale::JapaneseEn) {
         out.push_str(
             "warning: --export-secrets が指定されています。Secret の値が平文でエクスポートファイルに書き込まれます\n",
@@ -507,8 +512,7 @@ mod tests {
     /// English 行と日本語行の両方を含む（バイリンガル出力保証）。
     #[test]
     fn tc_ut_212c_render_exported_japanese_en_contains_both_english_and_japanese() {
-        let rendered =
-            render_exported(5, std::path::Path::new("/tmp/v.json"), Locale::JapaneseEn);
+        let rendered = render_exported(5, std::path::Path::new("/tmp/v.json"), Locale::JapaneseEn);
         assert!(
             rendered.contains("exported 5 record(s)"),
             "JapaneseEn must also contain English line, got: {rendered:?}"
@@ -677,7 +681,11 @@ mod tests {
     #[test]
     fn tc_ut_212p_render_exported_large_count_does_not_panic() {
         // パニックしないことを確認するだけ（値の厳密な検証は不要）。
-        let _ = render_exported(usize::MAX, std::path::Path::new("/tmp/large.json"), Locale::English);
+        let _ = render_exported(
+            usize::MAX,
+            std::path::Path::new("/tmp/large.json"),
+            Locale::English,
+        );
     }
 
     /// TC-UT-212q (REQ-DP-011 / AC-DP-07): `render_imported` は `usize::MAX` のような
@@ -738,8 +746,7 @@ mod tests {
     /// TC-UT-212v (REQ-DP-011): `render_exported` JapaneseEn locale は正確に 2 行（改行 2 個）。
     #[test]
     fn tc_ut_212v_render_exported_japanese_en_has_exactly_two_lines() {
-        let rendered =
-            render_exported(1, std::path::Path::new("/tmp/v.json"), Locale::JapaneseEn);
+        let rendered = render_exported(1, std::path::Path::new("/tmp/v.json"), Locale::JapaneseEn);
         assert_eq!(
             rendered.matches('\n').count(),
             2,
@@ -914,7 +921,8 @@ mod tests {
     /// JapaneseEn ロケールは `"Secret"` と `"平文"` の両方を含む
     /// （Secret 種別と平文書き出しの日本語での明示保証）。
     #[test]
-    fn tc_ut_212aj_render_export_secrets_warning_japanese_en_mentions_secret_and_plaintext_japanese() {
+    fn tc_ut_212aj_render_export_secrets_warning_japanese_en_mentions_secret_and_plaintext_japanese(
+    ) {
         let rendered = render_export_secrets_warning(Locale::JapaneseEn);
         assert!(
             rendered.contains("Secret"),

--- a/crates/shikomi-cli/src/presenter/success.rs
+++ b/crates/shikomi-cli/src/presenter/success.rs
@@ -884,10 +884,10 @@ mod tests {
         );
     }
 
-    /// TC-UT-F-U04 / TC-UT-F-U12 の配置注 — 以下は既存テストが担当するため省略。
-    ///
-    /// TC-UT-212c (re-use guard) — TC-F-U04 / TC-F-U12 は上で実装済み。
-    /// TC-UT-201〜212 以上 by Issue #141 Sub-B PR #145。
+    // TC-UT-F-U04 / TC-UT-F-U12 の配置注 — 以下は既存テストが担当するため省略。
+    //
+    // TC-UT-212c (re-use guard) — TC-F-U04 / TC-F-U12 は上で実装済み。
+    // TC-UT-201〜212 以上 by Issue #141 Sub-B PR #145。
 
     /// TC-UT-212ah (REQ-DP-011 / AC-DP-07): `render_imported` の 1 件追加 / 0 スキップ /
     /// 0 上書き という最も一般的な正常ケースで `"imported 1 record(s)"` が返る
@@ -938,15 +938,15 @@ mod tests {
     // 以下は既存テスト（Sub-F #44 Phase 6 / TC-F-U04 / TC-F-U12）
     // -------------------------------------------------------------------
 
-    /// TC-UT-212z2 — 注記: 上記 TC-UT-212y / TC-UT-212z とは独立して、
-    /// TC-UT-212aj 以後のテストが追加される可能性がある（Issue #141 以降の Sub-C 等）。
-    /// 番号は TC-UT-213〜 を使用すること。
+    // TC-UT-212z2 — 注記: 上記 TC-UT-212y / TC-UT-212z とは独立して、
+    // TC-UT-212aj 以後のテストが追加される可能性がある（Issue #141 以降の Sub-C 等）。
+    // 番号は TC-UT-213〜 を使用すること。
 
-    /// TC-UT-212z3 (配置確認): 本 tests モジュールの末尾マーカ。
-    /// TC-UT-201〜212aj が Issue #141 Sub-B (PR #145) で追加されたことを articulate する。
+    // TC-UT-212z3 (配置確認): 本 tests モジュールの末尾マーカ。
+    // TC-UT-201〜212aj が Issue #141 Sub-B (PR #145) で追加されたことを articulate する。
 
-    /// TC-UT-212c (REQ-DP-011 / AC-DP-06): `render_exported` は件数と
-    /// TC-UT-212 〜 TC-UT-212aj: 全 Issue #141 data-portability Presenter UT 追加完了。
+    // TC-UT-212c (REQ-DP-011 / AC-DP-06): `render_exported` は件数と
+    // TC-UT-212 〜 TC-UT-212aj: 全 Issue #141 data-portability Presenter UT 追加完了。
 
     /// TC-UT-F-U12 (EC-F12 / C-19): 24 語表示経路で **`SerializableSecretBytes` の lossy_string
     /// 経由表示が呼出側の Vec<SerializableSecretBytes> 所有権を維持し、scope 終了時の

--- a/crates/shikomi-cli/src/usecase/portability/error.rs
+++ b/crates/shikomi-cli/src/usecase/portability/error.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 pub enum DataPortabilityError {
     /// vault が暗号化ロック済みの状態で export / import を試みた。
     ///
-    /// `SqliteVaultRepository::load()` が `ProtectionMode::Encrypted` を検出した場合、
+    /// `VaultRepository::load()` が `ProtectionMode::Encrypted` を検出した場合、
     /// または `ExportError::VaultLocked` が伝播した場合に発生する。
     #[error("vault is locked")]
     VaultLocked,

--- a/crates/shikomi-cli/src/usecase/portability/error.rs
+++ b/crates/shikomi-cli/src/usecase/portability/error.rs
@@ -57,6 +57,17 @@ pub enum DataPortabilityError {
     /// ファイル I/O エラー（`tempfile` 操作 / `persist` 失敗を含む）。
     #[error("io error: {0}")]
     IoError(std::io::Error),
+
+    /// `repo.save()` または `repo.load()` が `SQLITE_BUSY`（エラーコード 5）を
+    /// `busy_timeout 2000ms` 超過後も解消しない場合に発生する。
+    ///
+    /// `From<DataPortabilityError> for CliError` で `CliError::ImportVaultBusy`
+    /// （MSG-CLI-146）にマッピングされる。
+    ///
+    /// 設計根拠: docs/features/data-portability/cli/detailed-design/usecase.md
+    /// §SQLITE_BUSY の検出経路（Issue #146）
+    #[error("vault is busy (SQLITE_BUSY)")]
+    VaultBusy,
 }
 
 impl From<std::io::Error> for DataPortabilityError {

--- a/crates/shikomi-cli/src/usecase/portability/export.rs
+++ b/crates/shikomi-cli/src/usecase/portability/export.rs
@@ -13,7 +13,7 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use shikomi_core::portability::{ExportPayload, ExportRecord};
-use shikomi_core::{ProtectionMode};
+use shikomi_core::ProtectionMode;
 use shikomi_infra::persistence::VaultRepository;
 use time::OffsetDateTime;
 

--- a/crates/shikomi-cli/src/usecase/portability/import.rs
+++ b/crates/shikomi-cli/src/usecase/portability/import.rs
@@ -4,9 +4,9 @@
 //! §`usecase/portability/import.rs` の設計詳細
 //!
 //! # 設計判断: IPC 経路廃止・SQLite 一本化
-//! Import も export と同様に常に `SqliteVaultRepository` を使用する。
+//! Import も export と同様に常に `VaultRepository` を使用する。
 //! IPC per-record `add_record()` は途中クラッシュで vault が半書き込み状態になり
-//! `R1-DP-09` の atomicity 要件に非適合。SQLite `repo.save()` が atomic write を保証する。
+//! `R1-DP-09` の atomicity 要件に非適合。`repo.save()` が atomic write を保証する。
 //!
 //! # セキュリティ考慮
 //! - `serde_json::from_reader` によるストリーミングパース（OOM 防止、threat-model.md §7.5）
@@ -149,7 +149,7 @@ pub fn import_records(
         }
     }
 
-    // Step 8: atomic write（SqliteVaultRepository::save が tempfile + rename で保証、R1-DP-09 適合）
+    // Step 8: atomic write（tempfile + rename で保証、R1-DP-09 適合）
     // Issue #146: DatabaseBusy は VaultBusy に変換。その他の PersistenceError は従来通り伝播。
     repo.save(&vault).map_err(|e| -> CliError {
         match e {

--- a/crates/shikomi-cli/src/usecase/portability/import.rs
+++ b/crates/shikomi-cli/src/usecase/portability/import.rs
@@ -15,12 +15,12 @@
 
 use std::collections::HashSet;
 
-use shikomi_core::portability::{ImportPayload, ImportValidator};
 use shikomi_core::portability::ExportRecordPayload;
+use shikomi_core::portability::{ImportPayload, ImportValidator};
 use shikomi_core::{
     Hotkey, Record, RecordId, RecordLabel, RecordPayload, SecretString, VaultHeader, VaultVersion,
 };
-use shikomi_infra::persistence::VaultRepository;
+use shikomi_infra::persistence::{PersistenceError, VaultRepository};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
@@ -75,8 +75,7 @@ pub fn import_records(
     now: OffsetDateTime,
 ) -> Result<ImportSummary, CliError> {
     // Step 1: ファイルを開く
-    let file =
-        std::fs::File::open(&args.input).map_err(DataPortabilityError::IoError)?;
+    let file = std::fs::File::open(&args.input).map_err(DataPortabilityError::IoError)?;
 
     // Step 2: ストリーミングパース（OOM 防止: read_to_string は使用しない、threat-model.md §7.5）
     let payload: ImportPayload = serde_json::from_reader(file).map_err(|e| {
@@ -89,6 +88,10 @@ pub fn import_records(
     let mut vault = if repo.exists()? {
         match repo.load() {
             Ok(v) => v,
+            // Issue #146: SQLITE_BUSY（busy_timeout 2000ms 超過後も未解消）→ VaultBusy
+            Err(PersistenceError::DatabaseBusy) => {
+                return Err(DataPortabilityError::VaultBusy.into());
+            }
             Err(e) => {
                 let cli_err = CliError::from(e);
                 return Err(match cli_err {
@@ -108,9 +111,8 @@ pub fn import_records(
         vault.records().iter().map(|r| r.id().to_string()).collect();
 
     // Step 5: ImportValidator::validate
-    let report = ImportValidator::validate(&payload, &existing_ids).map_err(|err| {
-        CliError::from(DataPortabilityError::ValidationFailed(err))
-    })?;
+    let report = ImportValidator::validate(&payload, &existing_ids)
+        .map_err(|err| CliError::from(DataPortabilityError::ValidationFailed(err)))?;
 
     // Step 6: --on-conflict error で衝突検出
     if args.on_conflict == OnConflictArg::Error && !report.conflicting_ids.is_empty() {
@@ -148,7 +150,13 @@ pub fn import_records(
     }
 
     // Step 8: atomic write（SqliteVaultRepository::save が tempfile + rename で保証、R1-DP-09 適合）
-    repo.save(&vault)?;
+    // Issue #146: DatabaseBusy は VaultBusy に変換。その他の PersistenceError は従来通り伝播。
+    repo.save(&vault).map_err(|e| -> CliError {
+        match e {
+            PersistenceError::DatabaseBusy => DataPortabilityError::VaultBusy.into(),
+            other => other.into(),
+        }
+    })?;
 
     // Step 9: ImportSummary 返却
     Ok(ImportSummary {
@@ -195,10 +203,11 @@ fn import_record_to_domain(
     })?;
 
     // Step 3: RecordLabel
-    let label =
-        RecordLabel::try_new(r.label.clone()).map_err(|e| CliError::ImportDeserializationFailed {
+    let label = RecordLabel::try_new(r.label.clone()).map_err(|e| {
+        CliError::ImportDeserializationFailed {
             reason: format!("invalid label: {e}"),
-        })?;
+        }
+    })?;
 
     // Step 4: ペイロード変換
     let payload = match &r.payload {
@@ -214,20 +223,18 @@ fn import_record_to_domain(
     };
 
     // Step 5: created_at パース
-    let created_at =
-        OffsetDateTime::parse(&r.created_at, &Rfc3339).map_err(|e| {
-            CliError::ImportDeserializationFailed {
-                reason: format!("invalid created_at '{}': {e}", r.created_at),
-            }
-        })?;
+    let created_at = OffsetDateTime::parse(&r.created_at, &Rfc3339).map_err(|e| {
+        CliError::ImportDeserializationFailed {
+            reason: format!("invalid created_at '{}': {e}", r.created_at),
+        }
+    })?;
 
     // Step 6: updated_at パース
-    let updated_at =
-        OffsetDateTime::parse(&r.updated_at, &Rfc3339).map_err(|e| {
-            CliError::ImportDeserializationFailed {
-                reason: format!("invalid updated_at '{}': {e}", r.updated_at),
-            }
-        })?;
+    let updated_at = OffsetDateTime::parse(&r.updated_at, &Rfc3339).map_err(|e| {
+        CliError::ImportDeserializationFailed {
+            reason: format!("invalid updated_at '{}': {e}", r.updated_at),
+        }
+    })?;
 
     // Step 7: hotkey パース
     let hotkey = r
@@ -240,12 +247,10 @@ fn import_record_to_domain(
         })?;
 
     // Step 8: Record::rehydrate（updated_at < created_at で DomainError::VaultConsistencyError）
-    let record =
-        Record::rehydrate(id, r.kind, label, payload, created_at, updated_at, hotkey).map_err(
-            |e| CliError::ImportDeserializationFailed {
-                reason: e.to_string(),
-            },
-        )?;
+    let record = Record::rehydrate(id, r.kind, label, payload, created_at, updated_at, hotkey)
+        .map_err(|e| CliError::ImportDeserializationFailed {
+            reason: e.to_string(),
+        })?;
 
     Ok(record)
 }

--- a/crates/shikomi-cli/tests/e2e_portability.rs
+++ b/crates/shikomi-cli/tests/e2e_portability.rs
@@ -7,7 +7,7 @@
 
 mod common;
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use assert_cmd::Command;
 use predicates::prelude::*;

--- a/crates/shikomi-cli/tests/e2e_portability.rs
+++ b/crates/shikomi-cli/tests/e2e_portability.rs
@@ -40,15 +40,7 @@ fn setup_vault_dir() -> TempDir {
 /// vault に Text レコードを 1 件追加する。成功が前提。
 fn add_text_record(dir: &Path, label: &str, value: &str) {
     shikomi(dir)
-        .args([
-            "add",
-            "--kind",
-            "text",
-            "--label",
-            label,
-            "--value",
-            value,
-        ])
+        .args(["add", "--kind", "text", "--label", label, "--value", value])
         .assert()
         .success();
 }
@@ -57,13 +49,7 @@ fn add_text_record(dir: &Path, label: &str, value: &str) {
 fn add_secret_record(dir: &Path, label: &str, value: &str) {
     shikomi(dir)
         .args([
-            "add",
-            "--kind",
-            "secret",
-            "--label",
-            label,
-            "--value",
-            value,
+            "add", "--kind", "secret", "--label", label, "--value", value,
         ])
         .assert()
         .success();
@@ -220,8 +206,7 @@ fn tc_e2e_dp_005_second_import_all_conflict_exits_1_with_msg_cli_142() {
 fn tc_e2e_dp_006_export_on_locked_vault_exits_1_with_msg_cli_140() {
     let dir = setup_vault_dir();
     // 暗号化 vault を作成（ロック済み）
-    common::fixtures::create_encrypted_vault(dir.path())
-        .expect("create_encrypted_vault");
+    common::fixtures::create_encrypted_vault(dir.path()).expect("create_encrypted_vault");
     let out = dir.path().join("out.json");
 
     shikomi(dir.path())
@@ -250,7 +235,9 @@ fn tc_e2e_dp_007_export_existing_file_without_force_exits_1_with_msg_cli_141() {
         .assert()
         .failure()
         .code(1)
-        .stderr(predicate::str::contains("export output file already exists"))
+        .stderr(predicate::str::contains(
+            "export output file already exists",
+        ))
         .stderr(predicate::str::contains("--force"));
 }
 

--- a/crates/shikomi-cli/tests/e2e_portability.rs
+++ b/crates/shikomi-cli/tests/e2e_portability.rs
@@ -1,9 +1,9 @@
 //! E2E テスト — `shikomi export` / `shikomi import`
 //!
 //! 対応 AC: AC-DP-06 / AC-DP-07 / AC-DP-08 / AC-DP-09 / AC-DP-10
-//! 対応 TC: TC-E2E-DP-001〜012
+//! 対応 TC: TC-E2E-DP-001〜014
 //! 設計書: `docs/features/data-portability/cli/test-design.md §5.1`
-//! 対応 Issue: #141
+//! 対応 Issue: #141 / #146
 
 mod common;
 
@@ -56,7 +56,7 @@ fn add_secret_record(dir: &Path, label: &str, value: &str) {
 }
 
 /// vault から export して JSON ファイルパスを返す。成功が前提。
-fn export_vault(dir: &Path, out_path: &PathBuf) {
+fn export_vault(dir: &Path, out_path: &Path) {
     shikomi(dir)
         .args(["export", "--output", out_path.to_str().unwrap()])
         .assert()
@@ -369,5 +369,124 @@ fn tc_e2e_dp_012_export_file_permission_is_0600_on_unix() {
         mode & 0o777,
         0o600,
         "export file should have 0600 permissions, got {mode:o}"
+    );
+}
+
+// -------------------------------------------------------------------
+// Issue #146: SQLITE_BUSY E2E — TC-E2E-DP-013 / TC-E2E-DP-014
+// 設計根拠: docs/features/data-portability/cli/test-design/e2e.md §TC-E2E-DP-013〜014
+// -------------------------------------------------------------------
+
+/// TC-E2E-DP-013: vault ロック中（daemon 相当）に import → 2 秒後 MSG-CLI-146 exit 1
+///
+/// 別 `rusqlite::Connection` で vault.db に `BEGIN EXCLUSIVE` を保持しながら
+/// `shikomi import` を実行すると、`busy_timeout(2000ms)` 超過後に exit 1 と
+/// `"vault is in use by shikomi-daemon"` が stderr に出力されることを検証する。
+///
+/// # 実行時間
+/// shikomi が ~2 秒待機するため `#[ignore]`。`cargo test -- --include-ignored` で実行可能。
+#[test]
+#[ignore = "slow: waits ~2s for SQLITE_BUSY busy_timeout (daemon lock simulation)"]
+fn tc_e2e_dp_013_import_with_persistent_lock_exits_1_with_msg_cli_146() {
+    // 1. ソース vault: レコード 1 件追加・export
+    let dir_src = setup_vault_dir();
+    add_text_record(dir_src.path(), "locked-src", "src-value");
+    let export_file = dir_src.path().join("export.json");
+    export_vault(dir_src.path(), &export_file);
+
+    // 2. デスト vault: vault.db を rusqlite で作成し EXCLUSIVE ロックを取得する
+    //    shikomi の PermissionGuard は 0600 を要求するため chmod も必要
+    let dir_dest = setup_vault_dir();
+    let vault_db = dir_dest.path().join("vault.db");
+    let lock_conn = rusqlite::Connection::open(&vault_db).expect("open lock_conn");
+    // Unix: PermissionGuard が vault.db に 0600 を要求するため権限を設定する
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut perms = std::fs::metadata(&vault_db)
+            .expect("metadata vault.db")
+            .permissions();
+        perms.set_mode(0o600);
+        std::fs::set_permissions(&vault_db, perms).expect("chmod 0600 vault.db");
+    }
+    lock_conn
+        .execute_batch("BEGIN EXCLUSIVE")
+        .expect("BEGIN EXCLUSIVE");
+
+    // 3. shikomi import を実行（lock_conn が EXCLUSIVE を保持中）
+    //    busy_timeout(2000ms) でリトライし、~2 秒後に exit 1 + MSG-CLI-146 を返す
+    shikomi(dir_dest.path())
+        .args(["import", "--input", export_file.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "vault is in use by shikomi-daemon",
+        ));
+
+    // lock_conn を明示的に保持し、assert が完了するまで EXCLUSIVE ロックを維持したことを示す
+    drop(lock_conn);
+}
+
+/// TC-E2E-DP-014: 短時間ロック（< 2s）解放後に import が透過的に成功する
+///
+/// 別 `rusqlite::Connection` で vault.db に 300ms の `BEGIN EXCLUSIVE` を保持し、
+/// その間に起動した `shikomi import` が `busy_timeout(2000ms)` の残余時間内に
+/// ロック解放を検知してリトライ成功（exit 0）することを検証する。
+///
+/// # 実行時間
+/// ロック保持 300ms + shikomi 処理時間が発生するため `#[ignore]`。
+/// `cargo test -- --include-ignored` で実行可能。
+#[test]
+#[ignore = "slow: holds SQLite EXCLUSIVE lock 300ms to verify busy_timeout retry succeeds"]
+fn tc_e2e_dp_014_import_succeeds_when_lock_released_within_busy_timeout() {
+    // 1. ソース vault: レコード 1 件追加・export
+    let dir_src = setup_vault_dir();
+    add_text_record(dir_src.path(), "transient-src", "src-value");
+    let export_file = dir_src.path().join("export.json");
+    export_vault(dir_src.path(), &export_file);
+
+    // 2. デスト vault: shikomi add で vault.db を初期化（proper schema が必要）
+    //    ロック解放後に shikomi が load() → save() を成功させるため正規スキーマが必要
+    let dir_dest = setup_vault_dir();
+    add_text_record(dir_dest.path(), "dest-existing", "dest-value");
+
+    // 3. デスト vault.db を EXCLUSIVE ロック
+    let vault_db = dir_dest.path().join("vault.db");
+    let lock_conn = rusqlite::Connection::open(&vault_db).expect("open lock_conn");
+    lock_conn
+        .execute_batch("BEGIN EXCLUSIVE")
+        .expect("BEGIN EXCLUSIVE");
+
+    // 4. shikomi import を非ブロッキングで起動（busy_timeout(2000ms) でリトライする）
+    //    assert_cmd::Command は spawn() を持たないため std::process::Command を使う
+    let shikomi_bin = assert_cmd::cargo::cargo_bin("shikomi");
+    let child_handle = std::process::Command::new(&shikomi_bin)
+        .env_remove("SHIKOMI_VAULT_DIR")
+        .env_remove("LANG")
+        .args(["--no-ipc", "--vault-dir"])
+        .arg(dir_dest.path())
+        .args(["import", "--input"])
+        .arg(export_file.as_path())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn shikomi import");
+
+    // 5. 300ms 後にロックを解放（2000ms 内なので shikomi はリトライ成功）
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    drop(lock_conn); // BEGIN EXCLUSIVE ロールバック → EXCLUSIVE 解放
+
+    // 6. shikomi import の完了を待ち、成功を検証する
+    let output = child_handle.wait_with_output().expect("wait_with_output");
+    assert!(
+        output.status.success(),
+        "import should succeed after lock released within busy_timeout(2000ms): stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("imported"),
+        "stdout should contain 'imported', got: {stdout:?}"
     );
 }

--- a/crates/shikomi-cli/tests/it_usecase_portability.rs
+++ b/crates/shikomi-cli/tests/it_usecase_portability.rs
@@ -1,7 +1,7 @@
 //! 結合テスト — `usecase::portability::export_records` / `import_records`
 //!
 //! 対応 REQ: REQ-DP-008 / REQ-DP-009 / REQ-DP-010
-//! 対応 TC: TC-IT-DP-001〜005
+//! 対応 TC: TC-IT-DP-001〜006
 //! 設計書: `docs/features/data-portability/cli/test-design.md §5.2`
 //! 対応 Issue: #141 / #146
 
@@ -233,5 +233,77 @@ fn tc_it_dp_005_import_records_sqlite_busy_timeout_returns_vault_busy() {
     assert!(
         matches!(result, Err(CliError::ImportVaultBusy)),
         "expected Err(CliError::ImportVaultBusy) after busy_timeout(2000ms) expired, got: {result:?}"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-DP-006: import_records — from_directory_with_busy_timeout repo で
+//               save() 経路が正常完了する（AtomicWriteSession busy_timeout 伝搬リグレッション確認）
+// -------------------------------------------------------------------
+
+/// TC-IT-DP-006 (REQ-DP-009 / Issue #146 服部平次指摘対応):
+/// `from_directory_with_busy_timeout` 経由の repo を使用して import_records が
+/// 正常完了する（load + save 両経路を通じたリグレッション確認）。
+///
+/// `AtomicWriteSession::new` に `busy_timeout=Some(2s)` が伝搬されても
+/// 通常 save が壊れないことを検証する。
+/// TC-IT-DP-005 が `load()` 経路の SQLITE_BUSY を検証するのに対し、
+/// 本テストは `save()` 経路のリグレッションを確認する。
+#[test]
+fn tc_it_dp_006_import_records_save_path_succeeds_with_busy_timeout_repo() {
+    use shikomi_core::{Record, RecordId, RecordKind, RecordLabel, RecordPayload, SecretString};
+    use shikomi_infra::persistence::{SqliteVaultRepository, VaultRepository};
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    // vault A — Text レコード 1 件を保存
+    let (dir_a, repo_a) = fresh_repo();
+    let now = fixed_time();
+    {
+        use shikomi_core::{Vault, VaultHeader, VaultVersion};
+        let record = Record::new(
+            RecordId::new(Uuid::now_v7()).unwrap(),
+            RecordKind::Text,
+            RecordLabel::try_new("save-path-label".to_owned()).unwrap(),
+            RecordPayload::Plaintext(SecretString::from_string("save-path-value".to_owned())),
+            now,
+        );
+        let header = VaultHeader::new_plaintext(VaultVersion::CURRENT, now).unwrap();
+        let mut vault_a = shikomi_core::Vault::new(header);
+        vault_a.add_record(record).unwrap();
+        repo_a.save(&vault_a).unwrap();
+    }
+
+    // vault A を export
+    let export_json = dir_a.path().join("save_path_export.json");
+    let export_args = ExportArgs {
+        output: export_json.clone(),
+        export_secrets: false,
+        force: false,
+    };
+    export_records(&repo_a, &export_args, dir_a.path(), now).expect("export should succeed");
+
+    // vault B — from_directory_with_busy_timeout（ロック競合なし）で import
+    // AtomicWriteSession::new に busy_timeout=Some(2s) が伝搬される経路を通す
+    let dir_b = tempfile::TempDir::new().expect("tempdir for vault B");
+    common::tighten_perms_unix(dir_b.path()); // PermissionGuard::verify_dir が 0700 を要求
+    let repo_b = SqliteVaultRepository::from_directory_with_busy_timeout(
+        dir_b.path(),
+        Duration::from_secs(2),
+    )
+    .expect("from_directory_with_busy_timeout");
+
+    let import_args = ImportArgs {
+        input: export_json,
+        on_conflict: OnConflictArg::Error,
+    };
+    let summary = import_records(&repo_b, &import_args, now)
+        .expect("import should succeed: save() path with busy_timeout must not regress");
+
+    // save() 経路（AtomicWriteSession::new(busy_timeout=Some(2s)) → finalize）が
+    // 正常完了し、レコードが 1 件追加されたことを確認する
+    assert_eq!(
+        summary.added, 1,
+        "expected 1 record added via save() path with busy_timeout repo, got: {summary:?}"
     );
 }

--- a/crates/shikomi-cli/tests/it_usecase_portability.rs
+++ b/crates/shikomi-cli/tests/it_usecase_portability.rs
@@ -9,10 +9,8 @@ mod common;
 
 use shikomi_cli::cli::{ExportArgs, ImportArgs, OnConflictArg};
 use shikomi_cli::error::CliError;
-use shikomi_cli::usecase::portability::{
-    export::export_records, import::import_records,
-};
-use shikomi_core::{RecordKind, RecordLabel, RecordPayload, SecretString, Hotkey};
+use shikomi_cli::usecase::portability::{export::export_records, import::import_records};
+use shikomi_core::{Hotkey, RecordKind, RecordLabel, RecordPayload, SecretString};
 use shikomi_infra::persistence::VaultRepository;
 
 use common::{fixed_time, fresh_repo};
@@ -38,7 +36,10 @@ fn tc_it_dp_001_export_records_empty_vault_returns_summary_with_zero_count() {
         .expect("export_records should succeed for empty vault");
 
     assert_eq!(summary.record_count, 0);
-    assert!(out.exists(), "output file should be created even for empty vault");
+    assert!(
+        out.exists(),
+        "output file should be created even for empty vault"
+    );
 
     let content = std::fs::read_to_string(&out).unwrap();
     assert!(
@@ -101,7 +102,9 @@ fn tc_it_dp_003_import_records_unknown_format_version_returns_validation_failed(
         matches!(
             result,
             Err(CliError::ImportValidationFailed(
-                shikomi_core::portability::ImportValidationError::UnknownFormatVersion { found: 999 }
+                shikomi_core::portability::ImportValidationError::UnknownFormatVersion {
+                    found: 999
+                }
             ))
         ),
         "expected ImportValidationFailed(UnknownFormatVersion {{ found: 999 }}), got: {result:?}"
@@ -146,8 +149,7 @@ fn tc_it_dp_004_import_records_hotkey_is_restored() {
         export_secrets: false,
         force: false,
     };
-    export_records(&repo_a, &export_args, dir_a.path(), now)
-        .expect("export should succeed");
+    export_records(&repo_a, &export_args, dir_a.path(), now).expect("export should succeed");
 
     // vault B に import
     let (_dir_b, repo_b) = fresh_repo();
@@ -155,17 +157,14 @@ fn tc_it_dp_004_import_records_hotkey_is_restored() {
         input: out,
         on_conflict: OnConflictArg::Error,
     };
-    let summary = import_records(&repo_b, &import_args, now)
-        .expect("import should succeed");
+    let summary = import_records(&repo_b, &import_args, now).expect("import should succeed");
     assert_eq!(summary.added, 1);
 
     // vault B のレコードの hotkey が "ctrl+2" に復元されていること
     let vault_b = repo_b.load().unwrap();
     let records: Vec<_> = vault_b.records().iter().collect();
     assert_eq!(records.len(), 1);
-    let hotkey_str = records[0]
-        .hotkey()
-        .map(|h| h.as_str().to_owned());
+    let hotkey_str = records[0].hotkey().map(|h| h.as_str().to_owned());
     assert_eq!(
         hotkey_str,
         Some("ctrl+2".to_owned()),

--- a/crates/shikomi-cli/tests/it_usecase_portability.rs
+++ b/crates/shikomi-cli/tests/it_usecase_portability.rs
@@ -176,7 +176,7 @@ fn tc_it_dp_004_import_records_hotkey_is_restored() {
 // TC-IT-DP-005: import_records — SQLITE_BUSY busy_timeout 超過 → CliError::ImportVaultBusy
 // -------------------------------------------------------------------
 
-/// TC-IT-DP-005 (REQ-DP-009 / Issue #146 §SQLITE_BUSY 設計判断):
+/// TC-IT-DP-005 (REQ-DP-009 / Issue #146 §`SQLITE_BUSY` 設計判断):
 /// `busy_timeout(2000ms)` 超過後に `CliError::ImportVaultBusy` が返る。
 ///
 /// 別 `rusqlite::Connection` で `BEGIN EXCLUSIVE` を保持して vault.db をロックした状態で
@@ -208,7 +208,7 @@ fn tc_it_dp_005_import_records_sqlite_busy_timeout_returns_vault_busy() {
     //    （`lib.rs::run_import` と同等の設定。usecase.md §busy_timeout 設定 参照）
     let repo = SqliteVaultRepository::from_directory_with_busy_timeout(
         dir.path(),
-        Duration::from_millis(2000),
+        Duration::from_secs(2),
     )
     .expect("from_directory_with_busy_timeout");
 

--- a/crates/shikomi-cli/tests/it_usecase_portability.rs
+++ b/crates/shikomi-cli/tests/it_usecase_portability.rs
@@ -1,9 +1,9 @@
 //! 結合テスト — `usecase::portability::export_records` / `import_records`
 //!
 //! 対応 REQ: REQ-DP-008 / REQ-DP-009 / REQ-DP-010
-//! 対応 TC: TC-IT-DP-001〜004
+//! 対応 TC: TC-IT-DP-001〜005
 //! 設計書: `docs/features/data-portability/cli/test-design.md §5.2`
-//! 対応 Issue: #141
+//! 対応 Issue: #141 / #146
 
 mod common;
 
@@ -169,5 +169,71 @@ fn tc_it_dp_004_import_records_hotkey_is_restored() {
         hotkey_str,
         Some("ctrl+2".to_owned()),
         "hotkey should be restored as 'ctrl+2'"
+    );
+}
+
+// -------------------------------------------------------------------
+// TC-IT-DP-005: import_records — SQLITE_BUSY busy_timeout 超過 → CliError::ImportVaultBusy
+// -------------------------------------------------------------------
+
+/// TC-IT-DP-005 (REQ-DP-009 / Issue #146 §SQLITE_BUSY 設計判断):
+/// `busy_timeout(2000ms)` 超過後に `CliError::ImportVaultBusy` が返る。
+///
+/// 別 `rusqlite::Connection` で `BEGIN EXCLUSIVE` を保持して vault.db をロックした状態で
+/// `import_records` を呼ぶと、2 秒後に `CliError::ImportVaultBusy` が返ることを検証する。
+///
+/// 逆シナリオ（ロック競合なし）は TC-IT-DP-001〜004 の `fresh_repo()` ベーステストが担保。
+///
+/// # 実行時間
+/// 実時間 ~2 秒の待機が発生するため `cargo test` ではデフォルトでスキップされる。
+/// `cargo test -- --include-ignored` で実行可能。
+#[test]
+#[ignore = "slow: waits ~2s for SQLITE_BUSY busy_timeout to expire"]
+fn tc_it_dp_005_import_records_sqlite_busy_timeout_returns_vault_busy() {
+    use shikomi_infra::persistence::SqliteVaultRepository;
+    use std::time::Duration;
+
+    // 1. vault.db を初期化（Text レコード 1 件を保存して vault.db ファイルを作成）
+    let (dir, _repo) = fresh_repo();
+    common::init_vault_with_one_text_record(dir.path(), "busy-label", "busy-value");
+
+    // 2. 別接続で BEGIN EXCLUSIVE → vault.db をロック
+    let vault_db = dir.path().join("vault.db");
+    let lock_conn = rusqlite::Connection::open(&vault_db).expect("open lock_conn");
+    lock_conn
+        .execute_batch("BEGIN EXCLUSIVE")
+        .expect("BEGIN EXCLUSIVE");
+
+    // 3. busy_timeout(2000ms) 設定の SqliteVaultRepository を取得
+    //    （`lib.rs::run_import` と同等の設定。usecase.md §busy_timeout 設定 参照）
+    let repo = SqliteVaultRepository::from_directory_with_busy_timeout(
+        dir.path(),
+        Duration::from_millis(2000),
+    )
+    .expect("from_directory_with_busy_timeout");
+
+    // 4. 空の valid ImportPayload JSON を書き出す
+    let import_json = dir.path().join("busy_import.json");
+    std::fs::write(
+        &import_json,
+        r#"{"format_version":1,"vault_name":"test","exported_at":"1970-01-01T00:00:00Z","records":[]}"#,
+    )
+    .expect("write import json");
+
+    let args = ImportArgs {
+        input: import_json,
+        on_conflict: OnConflictArg::Error,
+    };
+
+    // 5. import_records を呼出（lock_conn が EXCLUSIVE 保持中 → ~2 秒後に SQLITE_BUSY）
+    //    lock_conn を明示的に保持して import_records のロック待機中に drop されないよう保証する
+    let result = import_records(&repo, &args, fixed_time());
+
+    drop(lock_conn); // EXCLUSIVE ロック解放（result 取得後）
+
+    // 6. CliError::ImportVaultBusy を検証
+    assert!(
+        matches!(result, Err(CliError::ImportVaultBusy)),
+        "expected Err(CliError::ImportVaultBusy) after busy_timeout(2000ms) expired, got: {result:?}"
     );
 }

--- a/crates/shikomi-cli/tests/it_usecase_portability.rs
+++ b/crates/shikomi-cli/tests/it_usecase_portability.rs
@@ -206,11 +206,9 @@ fn tc_it_dp_005_import_records_sqlite_busy_timeout_returns_vault_busy() {
 
     // 3. busy_timeout(2000ms) 設定の SqliteVaultRepository を取得
     //    （`lib.rs::run_import` と同等の設定。usecase.md §busy_timeout 設定 参照）
-    let repo = SqliteVaultRepository::from_directory_with_busy_timeout(
-        dir.path(),
-        Duration::from_secs(2),
-    )
-    .expect("from_directory_with_busy_timeout");
+    let repo =
+        SqliteVaultRepository::from_directory_with_busy_timeout(dir.path(), Duration::from_secs(2))
+            .expect("from_directory_with_busy_timeout");
 
     // 4. 空の valid ImportPayload JSON を書き出す
     let import_json = dir.path().join("busy_import.json");

--- a/crates/shikomi-infra/src/persistence/error.rs
+++ b/crates/shikomi-infra/src/persistence/error.rs
@@ -332,6 +332,17 @@ pub enum PersistenceError {
         /// 失敗の人間可読理由（固定文言、secret / 絶対パス / PID を含めない）。
         reason: String,
     },
+
+    /// SQLite `SQLITE_BUSY`（エラーコード 5）— `busy_timeout` で設定された時間内に
+    /// ロックを取得できなかった（daemon が vault.db を保持中等）。
+    ///
+    /// `rusqlite::Error::SqliteFailure` の `code.code == ErrorCode::DatabaseBusy` を
+    /// **型検査**で検出する（文字列マッチング禁止）。
+    ///
+    /// 設計根拠: docs/features/data-portability/cli/detailed-design/usecase.md
+    /// §SQLITE_BUSY の検出経路（Issue #146）
+    #[error("database is busy (SQLITE_BUSY): another process holds a lock on vault.db")]
+    DatabaseBusy,
 }
 
 // -------------------------------------------------------------------
@@ -340,6 +351,14 @@ pub enum PersistenceError {
 
 impl From<rusqlite::Error> for PersistenceError {
     fn from(source: rusqlite::Error) -> Self {
+        // Issue #146: SQLITE_BUSY（エラーコード 5）を型安全に検出する。
+        // `rusqlite::Error::SqliteFailure` の `code.code` フィールドを直接比較する。
+        // 文字列マッチング（`source.to_string()` 等）は使用しない。
+        if let rusqlite::Error::SqliteFailure(ref err, _) = source {
+            if err.code == rusqlite::ErrorCode::DatabaseBusy {
+                return Self::DatabaseBusy;
+            }
+        }
         Self::Sqlite { source }
     }
 }

--- a/crates/shikomi-infra/src/persistence/repository/mod.rs
+++ b/crates/shikomi-infra/src/persistence/repository/mod.rs
@@ -267,21 +267,20 @@ impl SqliteVaultRepository {
             self.paths.vault_db(),
             OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )
-        .map_err(|e| PersistenceError::Sqlite { source: e })?;
+        .map_err(PersistenceError::from)?;
 
         // Issue #146: busy_timeout が設定されている場合（`from_directory_with_busy_timeout`
         // 経由での構築時）、コネクションに適用する。SQLITE_BUSY 発生時に SQLite が
         // `timeout` 時間リトライし、タイムアウト後も解消しない場合は
         // `PersistenceError::DatabaseBusy` を返す（`From<rusqlite::Error>` が型検査）。
         if let Some(timeout) = self.busy_timeout {
-            conn.busy_timeout(timeout)
-                .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            conn.busy_timeout(timeout).map_err(PersistenceError::from)?;
         }
 
         // Step 8: application_id 確認
         let app_id: u32 = conn
             .query_row(SchemaSql::PRAGMA_APPLICATION_ID_GET, [], |row| row.get(0))
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            .map_err(PersistenceError::from)?;
         if app_id != SchemaSql::APPLICATION_ID {
             return Err(PersistenceError::SchemaMismatch {
                 expected_application_id: SchemaSql::APPLICATION_ID,
@@ -295,7 +294,7 @@ impl SqliteVaultRepository {
         // Step 9: user_version 確認
         let user_version: u32 = conn
             .query_row(SchemaSql::PRAGMA_USER_VERSION_GET, [], |row| row.get(0))
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            .map_err(PersistenceError::from)?;
         if !(SchemaSql::USER_VERSION_SUPPORTED_MIN..=SchemaSql::USER_VERSION_SUPPORTED_MAX)
             .contains(&user_version)
         {
@@ -343,14 +342,12 @@ impl SqliteVaultRepository {
     ) -> Result<shikomi_core::VaultHeader, PersistenceError> {
         let mut stmt = conn
             .prepare(SchemaSql::SELECT_VAULT_HEADER)
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
-        let mut rows = stmt
-            .query([])
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            .map_err(PersistenceError::from)?;
+        let mut rows = stmt.query([]).map_err(PersistenceError::from)?;
 
         let row = rows
             .next()
-            .map_err(|e| PersistenceError::Sqlite { source: e })?
+            .map_err(PersistenceError::from)?
             .ok_or_else(|| PersistenceError::Corrupted {
                 table: "vault_header",
                 row_key: None,
@@ -360,11 +357,7 @@ impl SqliteVaultRepository {
         let header = Mapping::row_to_vault_header(row)?;
 
         // CHECK(id=1) 制約があるため複数行は存在しないはずだが防衛的確認
-        if rows
-            .next()
-            .map_err(|e| PersistenceError::Sqlite { source: e })?
-            .is_some()
-        {
+        if rows.next().map_err(PersistenceError::from)?.is_some() {
             return Err(PersistenceError::Corrupted {
                 table: "vault_header",
                 row_key: None,
@@ -394,18 +387,11 @@ impl SqliteVaultRepository {
             (SchemaSql::SELECT_RECORDS_ORDERED, false)
         };
 
-        let mut stmt = conn
-            .prepare(sql)
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
-        let mut rows = stmt
-            .query([])
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+        let mut stmt = conn.prepare(sql).map_err(PersistenceError::from)?;
+        let mut rows = stmt.query([]).map_err(PersistenceError::from)?;
 
         let mut records = Vec::new();
-        while let Some(row) = rows
-            .next()
-            .map_err(|e| PersistenceError::Sqlite { source: e })?
-        {
+        while let Some(row) = rows.next().map_err(PersistenceError::from)? {
             let record = if use_v1 {
                 Mapping::row_to_record_v1(row)?
             } else {

--- a/crates/shikomi-infra/src/persistence/repository/mod.rs
+++ b/crates/shikomi-infra/src/persistence/repository/mod.rs
@@ -417,7 +417,7 @@ impl SqliteVaultRepository {
         AtomicWriter::detect_orphan(self.paths.vault_db_new())?;
 
         // Step 6: `.new` 作成から SQLite COMMIT まで実行しセッションを取得
-        let session = AtomicWriteSession::new(&self.paths, vault)?;
+        let session = AtomicWriteSession::new(&self.paths, vault, self.busy_timeout)?;
 
         // Step 7: クローズ順序固定 → sidecar DACL → fsync → rename（Win: retry 補強）
         session.finalize(&ExponentialBackoffRetryPolicy)?;

--- a/crates/shikomi-infra/src/persistence/repository/mod.rs
+++ b/crates/shikomi-infra/src/persistence/repository/mod.rs
@@ -1,7 +1,7 @@
 //! `SqliteVaultRepository` — `VaultRepository` の `SQLite` 実装。
 
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use rusqlite::{Connection, OpenFlags};
 use shikomi_core::{Record, Vault, VaultHeader, VaultVersion};
@@ -27,6 +27,14 @@ use super::{
 /// `SQLite` バックエンドの `VaultRepository` 実装。
 pub struct SqliteVaultRepository {
     paths: VaultPaths,
+    /// SQLite コネクションに設定する `busy_timeout`。
+    ///
+    /// `from_directory_with_busy_timeout` 経由で構築した場合のみ `Some`。
+    /// `from_directory` / `new` 経由では `None`（既存動作を維持）。
+    ///
+    /// 設計根拠: docs/features/data-portability/cli/detailed-design/usecase.md
+    /// §busy_timeout のカプセル化設計（Issue #146）
+    busy_timeout: Option<Duration>,
 }
 
 impl SqliteVaultRepository {
@@ -53,7 +61,42 @@ impl SqliteVaultRepository {
     /// - `fs::canonicalize` 失敗: `PersistenceError::InvalidVaultDir { reason: Canonicalize }`
     pub fn from_directory(path: &Path) -> Result<Self, PersistenceError> {
         let paths = VaultPaths::new(path.to_path_buf())?;
-        Ok(Self { paths })
+        Ok(Self {
+            paths,
+            busy_timeout: None,
+        })
+    }
+
+    /// 明示的な vault ディレクトリと `busy_timeout` を指定して `SqliteVaultRepository` を構築する。
+    ///
+    /// `from_directory` と同じバリデーションを行った上で、SQLite コネクションを開く際に
+    /// `connection.busy_timeout(timeout)` を適用する（Tell, Don't Ask）。
+    ///
+    /// `lib.rs::run_import` のみが呼び出す。他の操作（daemon / export 等）は
+    /// `from_directory` / `new` を使用して既存の挙動を維持する。
+    ///
+    /// # Arguments
+    ///
+    /// - `path` — vault ディレクトリの絶対パス
+    /// - `timeout` — SQLITE_BUSY 発生時に SQLite が待機する最大時間
+    ///
+    /// # Errors
+    ///
+    /// - ディレクトリ検証失敗: `PersistenceError::InvalidVaultDir`
+    ///
+    /// # 設計根拠
+    ///
+    /// docs/features/data-portability/cli/detailed-design/usecase.md
+    /// §busy_timeout のカプセル化設計（Issue #146）
+    pub fn from_directory_with_busy_timeout(
+        path: &Path,
+        timeout: Duration,
+    ) -> Result<Self, PersistenceError> {
+        let paths = VaultPaths::new(path.to_path_buf())?;
+        Ok(Self {
+            paths,
+            busy_timeout: Some(timeout),
+        })
     }
 
     /// vault パス情報への参照を返す。
@@ -225,6 +268,15 @@ impl SqliteVaultRepository {
             OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )
         .map_err(|e| PersistenceError::Sqlite { source: e })?;
+
+        // Issue #146: busy_timeout が設定されている場合（`from_directory_with_busy_timeout`
+        // 経由での構築時）、コネクションに適用する。SQLITE_BUSY 発生時に SQLite が
+        // `timeout` 時間リトライし、タイムアウト後も解消しない場合は
+        // `PersistenceError::DatabaseBusy` を返す（`From<rusqlite::Error>` が型検査）。
+        if let Some(timeout) = self.busy_timeout {
+            conn.busy_timeout(timeout)
+                .map_err(|e| PersistenceError::Sqlite { source: e })?;
+        }
 
         // Step 8: application_id 確認
         let app_id: u32 = conn

--- a/crates/shikomi-infra/src/persistence/sqlite/atomic/session.rs
+++ b/crates/shikomi-infra/src/persistence/sqlite/atomic/session.rs
@@ -48,6 +48,7 @@ impl AtomicWriteSession {
     /// - ファイル作成失敗: `PersistenceError::AtomicWriteFailed { stage: PrepareNew }`
     /// - パーミッション設定失敗: `PersistenceError::InvalidPermission` / `PersistenceError::Io`
     /// - `SQLite` エラー（PRAGMA / DDL / TX / COMMIT）: `PersistenceError::Sqlite`
+    ///
     /// `busy_timeout` は `from_directory_with_busy_timeout` 経由で構築した
     /// `SqliteVaultRepository` の場合のみ `Some`。`vault.db.new` は新規ファイルのため
     /// 他コネクションとの競合は起きないが、将来の WAL 移行等も見据えて全接続に適用する

--- a/crates/shikomi-infra/src/persistence/sqlite/atomic/session.rs
+++ b/crates/shikomi-infra/src/persistence/sqlite/atomic/session.rs
@@ -1,6 +1,7 @@
 //! `AtomicWriteSession` — SQLite 書込セッション型（Phase 8 新設、Issue #73）。
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use rusqlite::OpenFlags;
 use shikomi_core::Vault;
@@ -47,7 +48,15 @@ impl AtomicWriteSession {
     /// - ファイル作成失敗: `PersistenceError::AtomicWriteFailed { stage: PrepareNew }`
     /// - パーミッション設定失敗: `PersistenceError::InvalidPermission` / `PersistenceError::Io`
     /// - `SQLite` エラー（PRAGMA / DDL / TX / COMMIT）: `PersistenceError::Sqlite`
-    pub(crate) fn new(paths: &VaultPaths, vault: &Vault) -> Result<Self, PersistenceError> {
+    /// `busy_timeout` は `from_directory_with_busy_timeout` 経由で構築した
+    /// `SqliteVaultRepository` の場合のみ `Some`。`vault.db.new` は新規ファイルのため
+    /// 他コネクションとの競合は起きないが、将来の WAL 移行等も見据えて全接続に適用する
+    /// （Issue #146、服部平次指摘対応）。
+    pub(crate) fn new(
+        paths: &VaultPaths,
+        vault: &Vault,
+        busy_timeout: Option<Duration>,
+    ) -> Result<Self, PersistenceError> {
         let new_path = paths.vault_db_new().to_path_buf();
         let final_path = paths.vault_db().to_path_buf();
         let dir_path = paths.dir().to_path_buf();
@@ -62,34 +71,40 @@ impl AtomicWriteSession {
                 | OpenFlags::SQLITE_OPEN_READ_WRITE
                 | OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )
-        .map_err(|e| PersistenceError::Sqlite { source: e })?;
+        .map_err(PersistenceError::from)?;
 
         // Step 6.4: ensure_file — SQLite が open 時に mode を変えた場合の再強制。
         // Windows では owner-only DACL を rename 前に設定する（`MoveFileExW` がソース SD を
         // 保持するため rename 後の vault.db へ DACL が引き継がれる、`./classes.md` §3.3 参照）。
         PermissionGuard::ensure_file(&new_path)?;
 
+        // Issue #146: busy_timeout が設定されている場合に適用する。
+        // `vault.db.new` は新規ファイルなので競合は起きないが、全接続統一ポリシー。
+        if let Some(timeout) = busy_timeout {
+            conn.busy_timeout(timeout).map_err(PersistenceError::from)?;
+        }
+
         // Step 6.5: PRAGMA 設定
         conn.execute_batch(SchemaSql::PRAGMA_APPLICATION_ID_SET)
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            .map_err(PersistenceError::from)?;
         conn.execute_batch(SchemaSql::PRAGMA_USER_VERSION_SET)
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            .map_err(PersistenceError::from)?;
         conn.execute_batch(SchemaSql::PRAGMA_JOURNAL_MODE)
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            .map_err(PersistenceError::from)?;
 
         // Step 6.6: テーブル / インデックス作成
         conn.execute_batch(SchemaSql::CREATE_VAULT_HEADER)
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            .map_err(PersistenceError::from)?;
         conn.execute_batch(SchemaSql::CREATE_RECORDS)
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            .map_err(PersistenceError::from)?;
         conn.execute_batch(SchemaSql::CREATE_HOTKEY_INDEX)
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            .map_err(PersistenceError::from)?;
 
         // Steps 6.7-6.10: 単一トランザクション内で vault_header + 全レコードを INSERT → COMMIT
         {
             let tx = conn
                 .unchecked_transaction()
-                .map_err(|e| PersistenceError::Sqlite { source: e })?;
+                .map_err(PersistenceError::from)?;
 
             let header_params = Mapping::vault_header_to_params(vault.header())?;
             tx.execute(
@@ -103,7 +118,7 @@ impl AtomicWriteSession {
                     header_params.wrapped_vek_by_recovery,
                 ],
             )
-            .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            .map_err(PersistenceError::from)?;
 
             for record in vault.records() {
                 let p = Mapping::record_to_params(record)?;
@@ -123,11 +138,10 @@ impl AtomicWriteSession {
                         p.hotkey_combo,
                     ],
                 )
-                .map_err(|e| PersistenceError::Sqlite { source: e })?;
+                .map_err(PersistenceError::from)?;
             }
 
-            tx.commit()
-                .map_err(|e| PersistenceError::Sqlite { source: e })?;
+            tx.commit().map_err(PersistenceError::from)?;
         }
 
         Ok(AtomicWriteSession {
@@ -172,7 +186,7 @@ impl AtomicWriteSession {
         conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
             .map_err(|e| {
                 AtomicWriter::cleanup_new(&path);
-                PersistenceError::Sqlite { source: e }
+                PersistenceError::from(e)
             })?;
 
         // Step 7.2: journal_mode を DELETE に再強制
@@ -181,15 +195,14 @@ impl AtomicWriteSession {
         conn.execute_batch("PRAGMA journal_mode = DELETE;")
             .map_err(|e| {
                 AtomicWriter::cleanup_new(&path);
-                PersistenceError::Sqlite { source: e }
+                PersistenceError::from(e)
             })?;
 
         // Step 7.3: 明示的 close（Drop の sqlite3_close_v2 遅延 semantics を回避）
-        // 失敗時は PersistenceError::Sqlite を直接返す（型情報を失う変換禁止、
-        // `../basic-design/error.md` §禁止事項と整合）。
+        // Issue #146: PersistenceError::from で DatabaseBusy 検出を有効化。
         if let Err((_, e)) = conn.close() {
             AtomicWriter::cleanup_new(&path);
-            return Err(PersistenceError::Sqlite { source: e });
+            return Err(PersistenceError::from(e));
         }
 
         // Step 7.4: サイドカー DACL 適用（best-effort）

--- a/crates/shikomi-infra/src/persistence/sqlite/atomic/tests.rs
+++ b/crates/shikomi-infra/src/persistence/sqlite/atomic/tests.rs
@@ -37,7 +37,7 @@ fn tc_i06_write_new_only_hook_orphan() {
 
     // 初期 vault を save（vault.db が存在する状態にする）
     let initial_vault = plaintext_vault("initial", "initial-value");
-    let session = AtomicWriteSession::new(&paths, &initial_vault).unwrap();
+    let session = AtomicWriteSession::new(&paths, &initial_vault, None).unwrap();
     session.finalize(&ExponentialBackoffRetryPolicy).unwrap();
 
     // vault.db のバイト列を記録
@@ -88,7 +88,7 @@ fn tc_u_drop_without_finalize_removes_new_file() {
     crate::persistence::permission::PermissionGuard::ensure_dir(dir.path()).unwrap();
 
     let vault = plaintext_vault("drop-guard", "test-value");
-    let session = AtomicWriteSession::new(&paths, &vault).unwrap();
+    let session = AtomicWriteSession::new(&paths, &vault, None).unwrap();
 
     assert!(
         paths.vault_db_new().exists(),
@@ -190,7 +190,7 @@ fn tc_u_finalize_failure_cleans_new_on_fsync_error() {
     crate::persistence::permission::PermissionGuard::ensure_dir(dir.path()).unwrap();
 
     let vault = plaintext_vault("finalize-fail", "test-value");
-    let session = AtomicWriteSession::new(&paths, &vault).unwrap();
+    let session = AtomicWriteSession::new(&paths, &vault, None).unwrap();
     assert!(paths.vault_db_new().exists(), ".new が作成されていない");
 
     // .new を書き込み不可（0o400）に変更 → FsyncTemp が open(.write(true)) で失敗。
@@ -246,14 +246,14 @@ fn tc_u_windows_no_sleep_retry_exhausts_on_held_file() {
 
     // 初期 vault.db を作成
     let vault1 = plaintext_vault("v1", "initial");
-    let session1 = AtomicWriteSession::new(&paths, &vault1).unwrap();
+    let session1 = AtomicWriteSession::new(&paths, &vault1, None).unwrap();
     session1
         .finalize(&ExponentialBackoffRetryPolicy)
         .expect("初期 vault 作成失敗");
 
     // 更新用 session を新規作成
     let vault2 = plaintext_vault("v2", "updated");
-    let session2 = AtomicWriteSession::new(&paths, &vault2).unwrap();
+    let session2 = AtomicWriteSession::new(&paths, &vault2, None).unwrap();
     assert!(
         paths.vault_db_new().exists(),
         "session2 作成後 .new が存在しない"

--- a/crates/shikomi-infra/src/persistence/sqlite/atomic/writer.rs
+++ b/crates/shikomi-infra/src/persistence/sqlite/atomic/writer.rs
@@ -63,7 +63,7 @@ impl AtomicWriter {
         paths: &VaultPaths,
         vault: &Vault,
     ) -> Result<(), PersistenceError> {
-        let session = AtomicWriteSession::new(paths, vault)?;
+        let session = AtomicWriteSession::new(paths, vault, None)?;
         // conn を close して SQLite ハンドルを解放し、new_path を None にして
         // Drop が cleanup_new を呼ばないようにすることで .new を残す。
         session.close_without_rename();

--- a/docs/features/data-portability/cli/test-design.md
+++ b/docs/features/data-portability/cli/test-design.md
@@ -10,9 +10,9 @@
 | 種別 | ファイル | TC 数 | 対象 |
 |------|---------|-------|------|
 | E2Eテスト | [test-design/e2e.md](test-design/e2e.md) | 14（TC-E2E-DP-001〜014）| `shikomi export` / `shikomi import` CLIコマンド（AC-DP-06〜10）|
-| 結合テスト | [test-design/it.md](test-design/it.md) | 5（TC-IT-DP-001〜005）| `export_records` / `import_records` UseCase 契約 |
+| 結合テスト | [test-design/it.md](test-design/it.md) | 6（TC-IT-DP-001〜006）| `export_records` / `import_records` UseCase 契約 |
 | ユニットテスト | [test-design/ut.md](test-design/ut.md) | 10（TC-UT-201〜210）| Presenter 純粋関数 / ExitCode マッピング / conflict ID フォーマット |
-| **合計** | | **29** | |
+| **合計** | | **30** | |
 
 ---
 
@@ -83,7 +83,8 @@
 | TC-IT-DP-002 | REQ-DP-009 | —（R1-DP-05）| 異常 | `import_records`: JSON パース失敗 → `CliError::ImportDeserializationFailed` |
 | TC-IT-DP-003 | REQ-DP-009/010 | —（R1-DP-05）| 異常 | `import_records`: `format_version: 999` → `CliError::ImportValidationFailed(UnknownFormatVersion)` |
 | TC-IT-DP-004 | REQ-DP-009/010 | AC-DP-07 | 正常 | `import_records`: hotkey フィールドが復元される（R1-DP-10）|
-| TC-IT-DP-005 | REQ-DP-009 | —（Issue #146）| 異常 | `import_records`: SQLITE_BUSY `busy_timeout(2000ms)` 超過 → `CliError::ImportVaultBusy` |
+| TC-IT-DP-005 | REQ-DP-009 | —（Issue #146）| 異常 | `import_records`: `load()` 経路 SQLITE_BUSY `busy_timeout(2000ms)` 超過 → `CliError::ImportVaultBusy` |
+| TC-IT-DP-006 | REQ-DP-009 | —（Issue #146 服部平次指摘: save() リグレッション）| 正常 | `import_records`: `from_directory_with_busy_timeout` repo で load+save 完走 → `ImportSummary { added: 1 }` |
 | TC-UT-201 | REQ-DP-011 | AC-DP-06 | 正常 | `render_exported`: English locale — 件数・パスが含まれる |
 | TC-UT-202 | REQ-DP-011 | AC-DP-06 | 正常 | `render_exported`: JapaneseEn locale — 日本語文が含まれる |
 | TC-UT-203 | REQ-DP-011 | AC-DP-07 | 正常 | `render_imported`: added / skipped / overwritten の各カウンタが文字列に反映される |
@@ -96,7 +97,7 @@
 | TC-UT-210 | REQ-DP-010/011 | —（Issue #146 MSG-CLI-146 文面保証）| 正常 | `render_error(&CliError::ImportVaultBusy, Locale::English)` → MSG-CLI-146 文面（"vault is in use" / "stop shikomi-daemon" / "shikomi daemon uninstall"）が含まれる |
 
 上位トレーサビリティ: `TC-E2E-DP-001〜012` → `AC-DP-06〜10` / `R1-DP-01〜10`（`feature-spec.md §5 Sub-B`）  
-Issue #146 追加分: `TC-E2E-DP-013〜014` / `TC-IT-DP-005` / `TC-UT-209` / `TC-UT-210` → `basic-design.md §SQLITE_BUSY 設計判断` / `§MSG-CLI-146`  
+Issue #146 追加分: `TC-E2E-DP-013〜014` / `TC-IT-DP-005〜006` / `TC-UT-209` / `TC-UT-210` → `basic-design.md §SQLITE_BUSY 設計判断` / `§MSG-CLI-146` / 服部平次指摘 `AtomicWriteSession busy_timeout 伝搬`  
 下位連結: 本設計書 TC-E2E-* の検証対象 UseCase 実装に対し、`TC-IT-DP-*`・`TC-UT-*` が白箱保証を補完する
 
 ---
@@ -106,9 +107,9 @@ Issue #146 追加分: `TC-E2E-DP-013〜014` / `TC-IT-DP-005` / `TC-UT-209` / `TC
 | グループ | ファイル | TC 数 |
 |---------|---------|-------|
 | E2E | [test-design/e2e.md](test-design/e2e.md) | 14（TC-E2E-DP-001〜014）|
-| IT | [test-design/it.md](test-design/it.md) | 5（TC-IT-DP-001〜005）|
+| IT | [test-design/it.md](test-design/it.md) | 6（TC-IT-DP-001〜006）|
 | UT | [test-design/ut.md](test-design/ut.md) | 10（TC-UT-201〜210）|
-| **合計** | | **29** |
+| **合計** | | **30** |
 
 **受入テスト（階層 1 横断）**: data-portability feature は他 feature との crossing シナリオが「端末移行（export 元 vault → 別端末 vault）」に相当する。本設計書スコープ外だが、`SC-DDM-001` / `SC-DDM-002` 系の受入テストシナリオとして将来 `docs/acceptance-tests/scenarios/` に追加する。
 

--- a/docs/features/data-portability/cli/test-design.md
+++ b/docs/features/data-portability/cli/test-design.md
@@ -9,10 +9,10 @@
 
 | 種別 | ファイル | TC 数 | 対象 |
 |------|---------|-------|------|
-| E2Eテスト | [test-design/e2e.md](test-design/e2e.md) | 12（TC-E2E-DP-001〜012）| `shikomi export` / `shikomi import` CLIコマンド（AC-DP-06〜10）|
+| E2Eテスト | [test-design/e2e.md](test-design/e2e.md) | 14（TC-E2E-DP-001〜014）| `shikomi export` / `shikomi import` CLIコマンド（AC-DP-06〜10）|
 | 結合テスト | [test-design/it.md](test-design/it.md) | 5（TC-IT-DP-001〜005）| `export_records` / `import_records` UseCase 契約 |
 | ユニットテスト | [test-design/ut.md](test-design/ut.md) | 10（TC-UT-201〜210）| Presenter 純粋関数 / ExitCode マッピング / conflict ID フォーマット |
-| **合計** | | **27** | |
+| **合計** | | **29** | |
 
 ---
 
@@ -77,6 +77,8 @@
 | TC-E2E-DP-010 | REQ-DP-005/009 | —（R1-DP-05）| 異常 | 不正 JSON ファイル → import で `MSG-CLI-143` exit 1 |
 | TC-E2E-DP-011 | REQ-DP-008 | —（R1-DP-01）| 正常 | `--force` 指定 + 出力先ファイル既存 → 上書き成功 |
 | TC-E2E-DP-012 | REQ-DP-008 | —（非機能: `0600`）| 正常 | export ファイルのパーミッションが `0600`（Unix のみ）|
+| TC-E2E-DP-013 | REQ-DP-009 | —（Issue #146 MSG-CLI-146）| 異常 | daemon が保持するロック（EXCLUSIVE 継続）→ import で `MSG-CLI-146` exit 1（~2s 待機）|
+| TC-E2E-DP-014 | REQ-DP-009 | —（Issue #146 透過的成功）| 正常 | 300ms 後にロック解放 → `busy_timeout(2000ms)` 内に import 成功（exit 0）|
 | TC-IT-DP-001 | REQ-DP-008 | AC-DP-06 | 境界値 | `export_records`: vault 空（`records: []`）→ `ExportSummary { record_count: 0 }` |
 | TC-IT-DP-002 | REQ-DP-009 | —（R1-DP-05）| 異常 | `import_records`: JSON パース失敗 → `CliError::ImportDeserializationFailed` |
 | TC-IT-DP-003 | REQ-DP-009/010 | —（R1-DP-05）| 異常 | `import_records`: `format_version: 999` → `CliError::ImportValidationFailed(UnknownFormatVersion)` |
@@ -94,7 +96,7 @@
 | TC-UT-210 | REQ-DP-010/011 | —（Issue #146 MSG-CLI-146 文面保証）| 正常 | `render_error(&CliError::ImportVaultBusy, Locale::English)` → MSG-CLI-146 文面（"vault is in use" / "stop shikomi-daemon" / "shikomi daemon uninstall"）が含まれる |
 
 上位トレーサビリティ: `TC-E2E-DP-001〜012` → `AC-DP-06〜10` / `R1-DP-01〜10`（`feature-spec.md §5 Sub-B`）  
-Issue #146 追加分: `TC-IT-DP-005` / `TC-UT-209` / `TC-UT-210` → `basic-design.md §SQLITE_BUSY 設計判断` / `§MSG-CLI-146`  
+Issue #146 追加分: `TC-E2E-DP-013〜014` / `TC-IT-DP-005` / `TC-UT-209` / `TC-UT-210` → `basic-design.md §SQLITE_BUSY 設計判断` / `§MSG-CLI-146`  
 下位連結: 本設計書 TC-E2E-* の検証対象 UseCase 実装に対し、`TC-IT-DP-*`・`TC-UT-*` が白箱保証を補完する
 
 ---
@@ -103,10 +105,10 @@ Issue #146 追加分: `TC-IT-DP-005` / `TC-UT-209` / `TC-UT-210` → `basic-desi
 
 | グループ | ファイル | TC 数 |
 |---------|---------|-------|
-| E2E | [test-design/e2e.md](test-design/e2e.md) | 12（TC-E2E-DP-001〜012）|
+| E2E | [test-design/e2e.md](test-design/e2e.md) | 14（TC-E2E-DP-001〜014）|
 | IT | [test-design/it.md](test-design/it.md) | 5（TC-IT-DP-001〜005）|
 | UT | [test-design/ut.md](test-design/ut.md) | 10（TC-UT-201〜210）|
-| **合計** | | **27** |
+| **合計** | | **29** |
 
 **受入テスト（階層 1 横断）**: data-portability feature は他 feature との crossing シナリオが「端末移行（export 元 vault → 別端末 vault）」に相当する。本設計書スコープ外だが、`SC-DDM-001` / `SC-DDM-002` 系の受入テストシナリオとして将来 `docs/acceptance-tests/scenarios/` に追加する。
 

--- a/docs/features/data-portability/cli/test-design/e2e.md
+++ b/docs/features/data-portability/cli/test-design/e2e.md
@@ -1,6 +1,6 @@
 # E2Eテスト設計 — data-portability / cli
 
-<!-- feature: data-portability / sub-feature: cli / Issue #141 -->
+<!-- feature: data-portability / sub-feature: cli / Issue #141 / Issue #146 -->
 <!-- 配置先: docs/features/data-portability/cli/test-design/e2e.md -->
 <!-- 親: ../test-design.md（インデックス）-->
 <!-- Vモデル対応: 階層 2（feature-spec.md AC-DP-06〜10 → E2Eテスト）-->
@@ -178,3 +178,33 @@
 | 前提条件 | Unix 環境。vault に任意レコードが存在する |
 | 操作 | 1. `shikomi export --output <TempDir>/out.json` を実行 / 2. `std::fs::metadata("<TempDir>/out.json").permissions().mode()` でパーミッションを取得する |
 | 期待結果 | (1) exit code 0 / (2) ファイルパーミッションの下位 9 ビットが `0o600`（`rw-------`）と一致する。`#[cfg(unix)]` で実行する |
+
+---
+
+#### TC-E2E-DP-013: vault ロック中（daemon 相当）に import → 2 秒後 MSG-CLI-146 exit 1
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-E2E-DP-013 |
+| 対応要件 | REQ-DP-009 |
+| 対応受入基準 | —（Issue #146 E2E 保証）|
+| 種別 | 異常系 |
+| 前提条件 | `<TempDir>/vault.db` が `rusqlite::Connection` の `BEGIN EXCLUSIVE` で排他ロック済み。ソース vault にレコードが 1 件存在し export.json が用意されている |
+| 操作 | 1. ソース vault に `shikomi add` でレコードを追加し export する / 2. デスト vault の vault.db を `rusqlite::Connection::open` で作成し chmod 0600 / 3. `BEGIN EXCLUSIVE` で排他ロック / 4. `shikomi import --input export.json --vault-dir dest_dir` を実行 |
+| 期待結果 | (1) exit code 1 / (2) stderr に `"vault is in use by shikomi-daemon"` が含まれる（MSG-CLI-146）/ (3) 実行に ~2 秒かかる（busy_timeout 2000ms 相当）|
+| 備考 | `#[ignore = "slow: waits ~2s for SQLITE_BUSY busy_timeout"]` — 通常 CI では `--include-ignored` で実行 |
+
+---
+
+#### TC-E2E-DP-014: 短時間ロック（< 2s）解放後に import が透過的に成功する
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-E2E-DP-014 |
+| 対応要件 | REQ-DP-009 |
+| 対応受入基準 | —（Issue #146 busy_timeout リトライ成功保証）|
+| 種別 | 正常系 |
+| 前提条件 | デスト vault の vault.db が `rusqlite::Connection` の `BEGIN EXCLUSIVE` で排他ロック済み。ソース vault に export.json が用意されている |
+| 操作 | 1. ソース vault に `shikomi add` でレコードを追加し export する / 2. デスト vault を `shikomi add` で初期化（正規スキーマ）/ 3. `BEGIN EXCLUSIVE` で排他ロック / 4. `shikomi import` を `std::process::Command::spawn()` で非ブロッキング起動 / 5. 300ms 後にロック解放（`drop(lock_conn)`）/ 6. `child.wait_with_output()` で完了待機 |
+| 期待結果 | (1) exit code 0 / (2) stdout に `"imported"` が含まれる（busy_timeout(2000ms) 内にリトライ成功）|
+| 備考 | `#[ignore = "slow: holds EXCLUSIVE lock 300ms"]` — 通常 CI では `--include-ignored` で実行 |

--- a/docs/features/data-portability/cli/test-design/it.md
+++ b/docs/features/data-portability/cli/test-design/it.md
@@ -68,7 +68,7 @@
 
 ---
 
-#### TC-IT-DP-005: `import_records` — SQLITE_BUSY `busy_timeout(2000ms)` 超過 → `CliError::ImportVaultBusy`
+#### TC-IT-DP-005: `import_records` — `load()` 経路で SQLITE_BUSY `busy_timeout(2000ms)` 超過 → `CliError::ImportVaultBusy`
 
 | 項目 | 内容 |
 |------|------|
@@ -80,3 +80,18 @@
 | 操作 | 1. `fresh_repo()` でテスト用 repo（vault.db ファイル）を生成する / 2. `rusqlite::Connection::open(&vault_db_path)` で **別の SQLite 接続**（lock_conn）を開く / 3. `lock_conn.execute("BEGIN EXCLUSIVE", [])` で排他トランザクションを開始し vault.db の書き込みロックを確保する / 4. `import_records(&repo, &args, fixed_time())` を呼ぶ（`repo` は `busy_timeout(2000ms)` 設定済みの `SqliteVaultRepository` を使用する。`SqliteVaultRepository::from_directory_with_busy_timeout()` ファクトリを使用する — `usecase.md §busy_timeout 設定` 参照）/ 5. `import_records` の戻り値を受け取る（`busy_timeout 2000ms` 超過まで待機が発生する） |
 | 期待結果 | `Err(CliError::ImportVaultBusy)` が返ること。lock_conn を保持したまま 2 秒以上経過後にエラーが返ることを確認する（`#[cfg_attr(not(slow_tests), ignore)]` アノテーション推奨 — 2 秒の実時間待機が発生するため）|
 | 補足 | **逆シナリオ**（lock 解放後に成功）は TC-IT-DP-001〜004 の `fresh_repo()` ベーステスト（競合なし = 即座に `save()` 成功）が担保する。`busy_timeout` 設定なしの場合は即座に SQLITE_BUSY が返り 2 秒待機しないため、テスト対象の repo に `busy_timeout` が適切に設定されていることを事前確認すること |
+
+---
+
+#### TC-IT-DP-006: `import_records` — `from_directory_with_busy_timeout` repo で save() 経路が正常完了する（リグレッション確認）
+
+| 項目 | 内容 |
+|------|------|
+| テストID | TC-IT-DP-006 |
+| 対応要件 | REQ-DP-009 |
+| 対応受入基準 | —（Issue #146 服部平次指摘対応: `AtomicWriteSession` `busy_timeout` 伝搬 + `map_err(PersistenceError::from)` リグレッション確認）|
+| 種別 | 正常系（リグレッション） |
+| 前提条件 | vault A に Text レコードが 1 件存在し、export 済みの JSON ファイルがある |
+| 操作 | 1. vault A から `export_records` で `export.json` を生成する / 2. `SqliteVaultRepository::from_directory_with_busy_timeout(path, Duration::from_secs(2))` で vault B の repo を取得する（ロック競合なし）/ 3. `import_records(&repo_b, &args, now)` を呼ぶ |
+| 期待結果 | `Ok(ImportSummary { added: 1, .. })` が返ること。`save()` 経路（`AtomicWriteSession::new(busy_timeout=Some(2s))` → `finalize`）が正常完了したことを示す |
+| 補足 | TC-IT-DP-005 が `load()` 経路の SQLITE_BUSY を検証するのに対し、本テストは `save()` 経路のリグレッションを確認する。`vault.db.new` は新規ファイルのため外部接続によるロック競合は発生しない。`busy_timeout` が `AtomicWriteSession::new` に正しく伝搬されても通常 save が壊れないことを証明する |


### PR DESCRIPTION
## Summary

Issue #146 — `shikomi import` の SQLITE_BUSY ハンドリング実装

- `PersistenceError::DatabaseBusy` バリアント追加（`rusqlite::ErrorCode::DatabaseBusy` の型検査、文字列マッチング禁止）
- `SqliteVaultRepository::from_directory_with_busy_timeout(path, 2000ms)` コンストラクタ追加（busy_timeout をコネクション開設時に適用、Tell, Don't Ask）
- `DataPortabilityError::VaultBusy` バリアント追加
- `CliError::ImportVaultBusy` バリアント追加（exit 1、MSG-CLI-146）
- `presenter/error.rs` に MSG-CLI-146 `lines_for` arm 追加（EN/JA 文面は `presenter.md` SSoT 値）
- `lib.rs::run_import` を `from_directory_with_busy_timeout(2000ms)` に変更
- `import_records` で `load()` / `save()` の `DatabaseBusy` を `VaultBusy` に変換
- `tc_f_u15` SSoT マトリクスに `ImportVaultBusy` エントリ追加
- `cargo fmt` による pre-existing フォーマット修正（Boy Scout Rule）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `crates/shikomi-infra/src/persistence/error.rs` | `DatabaseBusy` バリアント追加 + `From<rusqlite::Error>` 型安全検出 |
| `crates/shikomi-infra/src/persistence/repository/mod.rs` | `from_directory_with_busy_timeout` 追加 + `busy_timeout` フィールド + `load_inner` 適用 |
| `crates/shikomi-cli/src/usecase/portability/error.rs` | `VaultBusy` バリアント追加 |
| `crates/shikomi-cli/src/usecase/portability/import.rs` | `DatabaseBusy` → `VaultBusy` 変換（load / save 両経路）|
| `crates/shikomi-cli/src/error.rs` | `ImportVaultBusy` バリアント + ExitCode arm + From mapping + tc_f_u15 エントリ |
| `crates/shikomi-cli/src/presenter/error.rs` | MSG-CLI-146 `lines_for` arm |
| `crates/shikomi-cli/src/lib.rs` | `run_import` → `from_directory_with_busy_timeout(2000ms)` |

## テスト担当への観点

- `CliError::ImportVaultBusy` が `ExitCode::UserError`（exit 1）に写像されること（tc_f_u15 拡張で機械検証済み）
- MSG-CLI-146 EN / JA 文面が `presenter.md` SSoT と一致すること
- `from_directory_with_busy_timeout` で構築した repo が `busy_timeout(2000ms)` を接続に適用すること
- `DatabaseBusy` の型安全検出（文字列マッチングを使っていないこと）
- 2 秒以内にロック解消 → 透過的に成功する E2E シナリオ（daemon 停止後 import）
- 2 秒超過後に `ImportVaultBusy`（MSG-CLI-146）が表示される E2E シナリオ（daemon 起動中 import）

Closes #146