### PR TITLE
feat(dist): winget / Homebrew tap / apt / rpm パッケージ配布対応 (#154)

### DIFF
--- a/.github/winget/shikomi-dev.shikomi.installer.yaml
+++ b/.github/winget/shikomi-dev.shikomi.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: shikomi-dev.shikomi
+PackageVersion: 0.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: "10.0.19041.0"
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/shikomi-dev/shikomi/releases/download/v0.1.0/shikomi_0.1.0_x64_en-US.msi
+    InstallerSha256: 44c734de11a6555e9762aa0940ee65ecc795ffef2d539fb1b9abf177294bb14d
+    UpgradeBehavior: install
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/shikomi-dev/shikomi/releases/download/v0.1.0/shikomi_0.1.0_x64-setup.exe
+    InstallerSha256: 7bec66d42980aa99eae270e90f74aaa17bbc475560f3d8a00a6a260f556b4eec
+    UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/.github/winget/shikomi-dev.shikomi.locale.en-US.yaml
+++ b/.github/winget/shikomi-dev.shikomi.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: shikomi-dev.shikomi
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: shikomi Contributors
+PublisherUrl: https://github.com/shikomi-dev
+PackageName: shikomi
+PackageUrl: https://github.com/shikomi-dev/shikomi
+License: MIT
+LicenseUrl: https://github.com/shikomi-dev/shikomi/blob/main/LICENSE
+ShortDescription: Global hotkey clipboard manager — paste registered strings into any app instantly
+Description: |-
+  shikomi (仕込み) is a multi-platform clipboard manager that pastes pre-registered strings
+  into the foreground app via a global hotkey. Supports plain-text vault (OS permission-protected)
+  and optional Argon2id + AES-256-GCM encryption.
+Tags:
+  - clipboard
+  - hotkey
+  - productivity
+  - password-manager
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/.github/winget/shikomi-dev.shikomi.yaml
+++ b/.github/winget/shikomi-dev.shikomi.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: shikomi-dev.shikomi
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -1,0 +1,197 @@
+# package-publish.yml — パッケージマネージャー配布パイプライン（Issue #154）
+# トリガ: GitHub Release が published になった時点で起動
+# 担当:
+#   winget-publish   : winget-pkgs へ自動 PR（Microsoft 審査は外部依存）
+#   homebrew-publish : homebrew-shikomi tap の formula を自動更新
+#   apt-publish      : GitHub Pages に Debian apt リポジトリを更新
+#   rpm-publish      : GitHub Pages に YUM/DNF リポジトリを更新
+
+name: Package Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # winget-publish
+  # microsoft/winget-pkgs へ自動 PR を作成する
+  # ⚠️ winget-pkgs へのマージは Microsoft の人間レビューが必要（外部依存）
+  # ---------------------------------------------------------------------------
+  winget-publish:
+    name: winget-publish
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: submit to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: shikomi-dev.shikomi
+          version: ${{ github.ref_name }}
+          release-tag: ${{ github.ref_name }}
+          installers-regex: \_x64\_en-US\.msi$|\_x64-setup\.exe$
+          token: ${{ secrets.WINGET_TOKEN }}
+        # WINGET_TOKEN: winget-pkgs リポジトリへの PR 権限を持つ PAT
+        # secrets に未設定の場合はスキップ（MVP フェーズ: 手動提出）
+        continue-on-error: true
+
+  # ---------------------------------------------------------------------------
+  # homebrew-publish
+  # shikomi-dev/homebrew-shikomi tap の Cask formula を更新する
+  # ---------------------------------------------------------------------------
+  homebrew-publish:
+    name: homebrew-publish
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: update homebrew tap formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+
+          # DMG の SHA256 を release から取得
+          gh release download "${TAG}"             --repo shikomi-dev/shikomi             --pattern SHA256SUMS.txt             --output SHA256SUMS.txt
+          DMG_SHA=$(grep "aarch64.dmg" SHA256SUMS.txt | awk '{print $1}')
+
+          # homebrew-shikomi の現在の formula を取得して更新
+          FORMULA_PATH="Casks/shikomi.rb"
+          CURRENT=$(gh api             "repos/shikomi-dev/homebrew-shikomi/contents/${FORMULA_PATH}"             --jq '.sha')
+
+          # 新しい formula 内容を生成
+          FORMULA=$(cat << RUBY
+cask "shikomi" do
+  version "${VERSION}"
+  sha256 "${DMG_SHA}"
+
+  url "https://github.com/shikomi-dev/shikomi/releases/download/v\#{version}/shikomi_\#{version}_aarch64.dmg"
+  name "shikomi"
+  desc "Global hotkey clipboard manager --- paste registered strings into any app instantly"
+  homepage "https://github.com/shikomi-dev/shikomi"
+
+  depends_on macos: ">= :monterey"
+
+  app "shikomi.app"
+
+  uninstall quit: "dev.shikomi.gui"
+
+  zap trash: [
+    "~/Library/Application Support/dev.shikomi.gui",
+    "~/.local/share/shikomi",
+  ]
+end
+RUBY
+          )
+
+          ENCODED=$(echo "${FORMULA}" | base64 -w 0)
+
+          # formula を更新コミット
+          gh api -X PUT             "repos/shikomi-dev/homebrew-shikomi/contents/${FORMULA_PATH}"             --field message="chore: update shikomi to ${VERSION}"             --field content="${ENCODED}"             --field sha="${CURRENT}"
+
+  # ---------------------------------------------------------------------------
+  # apt-publish
+  # GitHub Pages に Debian apt リポジトリを構築・更新する
+  # ユーザー手順:
+  #   echo "deb [trusted=yes] https://shikomi-dev.github.io/shikomi/apt stable main" \
+  #     | sudo tee /etc/apt/sources.list.d/shikomi.list
+  #   sudo apt update && sudo apt install shikomi
+  # ---------------------------------------------------------------------------
+  apt-publish:
+    name: apt-publish
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    permissions:
+      contents: write  # gh-pages ブランチへの push に必要
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: setup apt repo directory
+        run: mkdir -p apt/stable/main/binary-amd64
+
+      - name: download deb package
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release download "${TAG}"             --repo shikomi-dev/shikomi             --pattern "*.deb"             --dir apt/stable/main/binary-amd64
+
+      - name: generate Packages and Release metadata
+        run: |
+          cd apt/stable/main
+          dpkg-scanpackages binary-amd64 /dev/null > binary-amd64/Packages 2>/dev/null
+          gzip -kf binary-amd64/Packages
+
+          cd /home/runner/work/shikomi/shikomi
+          apt-ftparchive release apt/stable > apt/stable/Release
+
+      - name: commit and push to gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add apt/
+          git commit -m "chore: update apt repo for ${{ github.ref_name }}" || echo "no changes"
+          git push origin gh-pages
+
+  # ---------------------------------------------------------------------------
+  # rpm-publish
+  # GitHub Pages に YUM/DNF リポジトリを構築・更新する
+  # ユーザー手順:
+  #   sudo dnf config-manager --add-repo \
+  #     https://shikomi-dev.github.io/shikomi/rpm/shikomi.repo
+  #   sudo dnf install shikomi
+  # ---------------------------------------------------------------------------
+  rpm-publish:
+    name: rpm-publish
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: install createrepo_c
+        run: sudo apt-get install -y createrepo-c
+
+      - name: setup rpm repo directory
+        run: mkdir -p rpm/packages
+
+      - name: download rpm package
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release download "${TAG}"             --repo shikomi-dev/shikomi             --pattern "*.rpm"             --dir rpm/packages
+
+      - name: generate repodata and repo file
+        run: |
+          createrepo_c rpm/
+
+          cat > rpm/shikomi.repo << EOF
+[shikomi]
+name=shikomi
+baseurl=https://shikomi-dev.github.io/shikomi/rpm
+enabled=1
+gpgcheck=0
+EOF
+
+      - name: commit and push to gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add rpm/
+          git commit -m "chore: update rpm repo for ${{ github.ref_name }}" || echo "no changes"
+          git push origin gh-pages

--- a/README.md
+++ b/README.md
@@ -15,48 +15,70 @@
 | OS | 対応バージョン |
 |----|--------------|
 | Windows | 10 21H2 以降、11 |
-| macOS | 12 Monterey 以降（Apple Silicon / Intel 両対応）|
+| macOS | 12 Monterey 以降（Apple Silicon） |
 | Linux | X11 / Wayland 両対応（Ubuntu 22.04+、Arch、その他 glibc 2.35+ ディストリ）|
 
 ## インストール（Install）
 
 ### Windows
 
+**winget（Windows Package Manager）**
+
 ```powershell
 winget install shikomi-dev.shikomi
 ```
 
-または [GitHub Releases](https://github.com/shikomi-dev/shikomi/releases) から `shikomi-windows-x86_64.msi` をダウンロードして実行。
+または [GitHub Releases](https://github.com/shikomi-dev/shikomi/releases) から最新の `.msi` または `.exe` をダウンロードして実行。
 
-> **Windows SmartScreen について**: shikomi のインストーラは EV/OV コード署名済みです。インストール時に「Windows によって PC が保護されました」という SmartScreen の警告が表示された場合は、次の手順で続行できます:
-> 1. 「詳細情報」をクリック
-> 2. 発行元が **`shikomi-dev`** であることを確認
-> 3. 「実行」をクリック
->
-> 署名元が `shikomi-dev` 以外の場合は実行しないでください。
+> **Windows SmartScreen について（v0.1.0）**: v0.1.0 はコード署名なしのビルドです（Issue #130 で対応予定）。
+> インストール時に SmartScreen の警告が表示された場合は「詳細情報」→「実行」で続行できます。
+> 発行元が `shikomi-dev` であることを確認してください。
 
 ### macOS
 
+**Homebrew（推奨）**
+
 ```bash
+brew tap shikomi-dev/homebrew-shikomi
 brew install --cask shikomi
 ```
 
-または [GitHub Releases](https://github.com/shikomi-dev/shikomi/releases) から `shikomi-macos-universal.dmg` をダウンロードして開く。
+または [GitHub Releases](https://github.com/shikomi-dev/shikomi/releases) から最新の `.dmg` をダウンロードして開く。
 
-**Apple Developer ID 署名済み・Notarization 済みのため、Gatekeeper の警告は発生しない。**
+> **Gatekeeper について（v0.1.0）**: v0.1.0 は Apple Developer ID 署名なしのビルドです（Issue #130 で対応予定）。
+> 初回起動時に警告が出た場合は、右クリック → 「開く」で起動できます。
+
+> **アーキテクチャ**: v0.1.0 は Apple Silicon (arm64) 専用です。Intel Mac 対応は Issue #130 の署名対応後に追加予定。
 
 ### Linux
 
-```bash
-# apt（Ubuntu / Debian）
-sudo apt install shikomi
+**apt（Ubuntu / Debian）**
 
-# AppImage（汎用）
-chmod +x shikomi-linux-x86_64.AppImage
-./shikomi-linux-x86_64.AppImage
+```bash
+# shikomi apt リポジトリを追加
+echo "deb [trusted=yes] https://shikomi-dev.github.io/shikomi/apt stable main" \
+  | sudo tee /etc/apt/sources.list.d/shikomi.list
+sudo apt update
+sudo apt install shikomi
 ```
 
-または [GitHub Releases](https://github.com/shikomi-dev/shikomi/releases) から各パッケージをダウンロード。
+**dnf / yum（Fedora / RHEL / CentOS）**
+
+```bash
+# shikomi DNF リポジトリを追加
+sudo dnf config-manager --add-repo \
+  https://shikomi-dev.github.io/shikomi/rpm/shikomi.repo
+sudo dnf install shikomi
+```
+
+**AppImage（汎用）**
+
+[GitHub Releases](https://github.com/shikomi-dev/shikomi/releases) から `shikomi_VERSION_amd64.AppImage` をダウンロード:
+
+```bash
+chmod +x shikomi_*_amd64.AppImage
+./shikomi_*_amd64.AppImage
+```
 
 #### Linux 追加セットアップ
 

--- a/docs/features/package-distribution/ci/basic-design.md
+++ b/docs/features/package-distribution/ci/basic-design.md
@@ -1,0 +1,101 @@
+# basic-design: package-distribution / ci
+
+<!-- 階層 3 — sub-feature モジュール基本設計 | Issue #154 -->
+
+## メタデータ
+
+| 項目 | 内容 |
+|---|---|
+| Sub-feature | `ci` |
+| Feature | `package-distribution` |
+| Issue | #154 |
+| 親 feature-spec | `docs/features/package-distribution/feature-spec.md` |
+| 対応 detailed-design | `docs/features/package-distribution/ci/detailed-design.md` |
+
+## モジュール概要
+
+GitHub Release の `published` イベントを起点として、winget / Homebrew / APT / RPM の各パッケージマネージャー向けメタデータを自動更新する CI パイプライン。実装は `.github/workflows/package-publish.yml` に集約する。
+
+## コンポーネント構成
+
+```mermaid
+flowchart TD
+    R[GitHub Release published] --> WF[package-publish.yml]
+    WF --> J1[winget-publish\nwindows-latest]
+    WF --> J2[homebrew-publish\nubuntu-22.04]
+    WF --> J3[apt-publish\nubuntu-22.04]
+    WF --> J4[rpm-publish\nubuntu-22.04]
+
+    J1 --> |winget-releaser| WP[microsoft/winget-pkgs\nPR 送信]
+    J2 --> |gh api PUT| HB[shikomi-dev/homebrew-shikomi\nCasks/shikomi.rb 更新]
+    J3 --> |git push| GP1[gh-pages branch\napt/stable/main/]
+    J4 --> |git push| GP2[gh-pages branch\nrpm/]
+
+    GP1 --> GHP[GitHub Pages\nhttps://shikomi-dev.github.io/shikomi/]
+    GP2 --> GHP
+```
+
+全ジョブは並列実行。1 ジョブの失敗は他ジョブに影響しない。
+
+## §モジュール契約
+
+### REQ-PKG-CI-001: winget-publish
+
+| 区分 | 内容 |
+|---|---|
+| 入力 | GitHub Release タグ (`v*`) + GitHub Releases の MSI / NSIS インストーラー |
+| 処理 | `vedantmgoyal9/winget-releaser` アクションが winget-pkgs へ自動 PR を送信 |
+| 出力 | `microsoft/winget-pkgs` への PR（外部審査フロー） |
+| エラー時 | `WINGET_TOKEN` 未設定または API エラー時は `continue-on-error: true` でスキップ。ログに警告を記録 |
+
+### REQ-PKG-CI-002: homebrew-publish
+
+| 区分 | 内容 |
+|---|---|
+| 入力 | GitHub Release タグ + `SHA256SUMS.txt`（aarch64.dmg のハッシュを含む） |
+| 処理 | `SHA256SUMS.txt` から DMG SHA256 を抽出 → Cask formula を再生成 → GitHub Contents API (PUT) で更新 |
+| 出力 | `shikomi-dev/homebrew-shikomi` の `Casks/shikomi.rb` 更新コミット |
+| エラー時 | `HOMEBREW_TAP_TOKEN` 未設定時は GitHub API 認証エラーでジョブ失敗。シークレット設定が必要 |
+
+### REQ-PKG-CI-003: apt-publish
+
+| 区分 | 内容 |
+|---|---|
+| 入力 | GitHub Release タグ + `.deb` パッケージ |
+| 処理 | `gh-pages` ブランチを checkout → `.deb` をダウンロード → `dpkg-scanpackages` で `Packages` 生成 → `apt-ftparchive` で `Release` 生成 → `gh-pages` へ push |
+| 出力 | `https://shikomi-dev.github.io/shikomi/apt/stable/main/binary-amd64/` に公開された APT リポジトリ |
+| エラー時 | `gh-pages` ブランチが存在しない場合はジョブ失敗（初回セットアップで事前作成が必要） |
+
+### REQ-PKG-CI-004: rpm-publish
+
+| 区分 | 内容 |
+|---|---|
+| 入力 | GitHub Release タグ + `.rpm` パッケージ |
+| 処理 | `gh-pages` ブランチを checkout → `.rpm` をダウンロード → `createrepo_c` でリポジトリメタデータ生成 → `shikomi.repo` ファイル生成 → `gh-pages` へ push |
+| 出力 | `https://shikomi-dev.github.io/shikomi/rpm/` に公開された YUM/DNF リポジトリ |
+| エラー時 | APT と同様に `gh-pages` ブランチ不在でジョブ失敗 |
+
+## 外部依存関係
+
+| 依存先 | 用途 | 必要なシークレット | 必須 |
+|---|---|---|---|
+| `microsoft/winget-pkgs` | winget パッケージ登録（外部審査） | `WINGET_TOKEN`（PAT: `public_repo`）| オプション |
+| `shikomi-dev/homebrew-shikomi` | Homebrew Cask formula 管理 | `HOMEBREW_TAP_TOKEN`（PAT: `repo` write）| 必須 |
+| `gh-pages` ブランチ | APT / RPM リポジトリホスティング | `GITHUB_TOKEN`（`contents: write`）| 必須 |
+| GitHub Pages | パブリックエンドポイント | なし（リポジトリ設定で有効化済み）| 必須 |
+| `vedantmgoyal9/winget-releaser` | winget-pkgs PR 自動化アクション | `WINGET_TOKEN` | オプション |
+
+## セキュリティ上の既知負債
+
+| 項目 | 現状 | 解消方針 |
+|---|---|---|
+| APT 未署名 | `[trusted=yes]` で GPG 検証をバイパス | Issue #130 完了後に GPG 鍵を生成し `signed-by=` へ移行、`Release.gpg` と `InRelease` を追加 |
+| RPM 未署名 | `gpgcheck=0` | Issue #130 完了後に RPM-GPG-KEY を生成し `gpgcheck=1` へ移行 |
+| winget アクションの `@main` 固定 | `vedantmgoyal9/winget-releaser@main` はコミットハッシュ固定でない | 次回リリース時にコミットハッシュへ固定する（OWASP A08 対応）|
+
+## 初回セットアップ手順（運用上の前提）
+
+1. `gh-pages` ブランチが空コミットで存在すること（Issue #154 PR でセットアップ済み）
+2. GitHub Pages がリポジトリ設定 → Pages → Source: `gh-pages / /` で有効であること（Issue #154 PR でセットアップ済み）
+3. `HOMEBREW_TAP_TOKEN` シークレットを Organization または Repository に設定すること
+4. `WINGET_TOKEN` シークレットを設定すること（オプション、未設定時はスキップ）

--- a/docs/features/package-distribution/ci/detailed-design.md
+++ b/docs/features/package-distribution/ci/detailed-design.md
@@ -1,0 +1,203 @@
+# detailed-design: package-distribution / ci
+
+<!-- 階層 3 — sub-feature モジュール詳細設計 | Issue #154 -->
+
+## メタデータ
+
+| 項目 | 内容 |
+|---|---|
+| Sub-feature | `ci` |
+| Feature | `package-distribution` |
+| Issue | #154 |
+| 対応 basic-design | `docs/features/package-distribution/ci/basic-design.md` |
+
+## ワークフロー: `package-publish.yml`
+
+### トリガ
+
+```
+on:
+  release:
+    types: [published]
+```
+
+`draft` / `prereleased` では動作しない。`published` 状態への遷移のみで起動する。
+
+### パーミッション設計
+
+```mermaid
+flowchart LR
+    subgraph "contents: read (デフォルト)"
+        J1[winget-publish]
+        J2[homebrew-publish]
+    end
+    subgraph "contents: write (個別付与)"
+        J3[apt-publish]
+        J4[rpm-publish]
+    end
+```
+
+最小権限原則に従い、`gh-pages` への git push が必要な `apt-publish` / `rpm-publish` にのみ `contents: write` を付与する。
+
+### ジョブ詳細: winget-publish
+
+| 項目 | 内容 |
+|---|---|
+| ランナー | `windows-latest` |
+| タイムアウト | 15 分 |
+| アクション | `vedantmgoyal9/winget-releaser@main` |
+| インストーラー照合 | `installers-regex: \_x64\_en-US\.msi$\|\_x64-setup\.exe$` |
+| 失敗挙動 | `continue-on-error: true`（`WINGET_TOKEN` 未設定時はスキップ）|
+
+`.github/winget/` に格納された 3 点セット:
+
+| ファイル | ManifestType | 用途 |
+|---|---|---|
+| `shikomi-dev.shikomi.yaml` | `version` | バージョン manifest |
+| `shikomi-dev.shikomi.installer.yaml` | `installer` | MSI (x64) + NSIS exe (x64)、SHA256 固定 |
+| `shikomi-dev.shikomi.locale.en-US.yaml` | `defaultLocale` | パッケージ名・説明・タグ・ライセンス |
+
+`winget-releaser` は上記 Static マニフェストを参照し、新バージョンの installer URL と SHA256 を動的に書き換えて `winget-pkgs` へ PR を送信する。
+
+### ジョブ詳細: homebrew-publish
+
+| 項目 | 内容 |
+|---|---|
+| ランナー | `ubuntu-22.04` |
+| タイムアウト | 10 分 |
+| 認証 | `HOMEBREW_TAP_TOKEN`（GitHub PAT: `repo` write）|
+
+処理フロー:
+
+```mermaid
+sequenceDiagram
+    participant CI as homebrew-publish job
+    participant GHR as GitHub Releases
+    participant TAP as homebrew-shikomi repo
+
+    CI->>GHR: gh release download SHA256SUMS.txt
+    GHR-->>CI: SHA256SUMS.txt
+    CI->>CI: grep "aarch64.dmg" | awk '{print $1}'
+    CI->>TAP: gh api GET Casks/shikomi.rb (blob SHA 取得)
+    TAP-->>CI: current blob SHA
+    CI->>CI: Cask formula を Heredoc で再生成
+    CI->>TAP: gh api PUT Casks/shikomi.rb (blob SHA 必須)
+    TAP-->>CI: 200 OK
+```
+
+Cask formula の構造（`shikomi-dev/homebrew-shikomi/Casks/shikomi.rb`）:
+
+| フィールド | 内容 |
+|---|---|
+| `version` | リリースタグから `v` プレフィックスを除いた文字列 |
+| `sha256` | `SHA256SUMS.txt` から抽出した `aarch64.dmg` の SHA256 |
+| `url` | `https://github.com/shikomi-dev/shikomi/releases/download/v#{version}/shikomi_#{version}_aarch64.dmg` |
+| `depends_on macos` | `>= :monterey`（macOS 12 Monterey 以降） |
+| `app` | `shikomi.app` |
+| `uninstall quit` | `dev.shikomi.gui` |
+
+### ジョブ詳細: apt-publish
+
+| 項目 | 内容 |
+|---|---|
+| ランナー | `ubuntu-22.04` |
+| タイムアウト | 15 分 |
+| パーミッション | `contents: write` |
+
+`gh-pages` ブランチ内のディレクトリ構造:
+
+```
+apt/
+  stable/
+    main/
+      binary-amd64/
+        shikomi_X.Y.Z_amd64.deb   ← ダウンロードした .deb
+        Packages                   ← dpkg-scanpackages 生成
+        Packages.gz                ← gzip -kf
+    Release                        ← apt-ftparchive release 生成
+```
+
+ユーザー側セットアップコマンド（README 掲載）:
+
+```bash
+echo "deb [trusted=yes] https://shikomi-dev.github.io/shikomi/apt stable main" | \
+  sudo tee /etc/apt/sources.list.d/shikomi.list
+sudo apt update && sudo apt install shikomi
+```
+
+⚠️ `[trusted=yes]` は GPG 署名なし配布の暫定措置。Issue #130 完了後に以下へ移行する:
+```bash
+curl -sSL https://shikomi-dev.github.io/shikomi/apt/gpg.key | \
+  sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/shikomi.gpg
+echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/shikomi.gpg] ..." | \
+  sudo tee /etc/apt/sources.list.d/shikomi.list
+```
+
+### ジョブ詳細: rpm-publish
+
+| 項目 | 内容 |
+|---|---|
+| ランナー | `ubuntu-22.04` |
+| タイムアウト | 15 分 |
+| パーミッション | `contents: write` |
+| 追加パッケージ | `createrepo-c` |
+
+`gh-pages` ブランチ内のディレクトリ構造:
+
+```
+rpm/
+  packages/
+    shikomi-X.Y.Z-1.x86_64.rpm   ← ダウンロードした .rpm
+  repodata/
+    repomd.xml                    ← createrepo_c 生成
+    ...
+  shikomi.repo                    ← ユーザーが追加するリポジトリ設定
+```
+
+生成される `shikomi.repo`:
+
+```ini
+[shikomi]
+name=shikomi
+baseurl=https://shikomi-dev.github.io/shikomi/rpm
+enabled=1
+gpgcheck=0
+```
+
+⚠️ `gpgcheck=0` は GPG 署名なし配布の暫定措置。Issue #130 完了後に `gpgcheck=1` + `gpgkey=` へ移行する。
+
+ユーザー側セットアップコマンド（README 掲載）:
+
+```bash
+sudo dnf config-manager \
+  --add-repo https://shikomi-dev.github.io/shikomi/rpm/shikomi.repo
+sudo dnf install shikomi
+```
+
+## winget マニフェスト スキーマバージョン
+
+| ファイル | スキーマ |
+|---|---|
+| `shikomi-dev.shikomi.yaml` | `https://aka.ms/winget-manifest.version.1.6.0.schema.json` |
+| `shikomi-dev.shikomi.installer.yaml` | `https://aka.ms/winget-manifest.installer.1.6.0.schema.json` |
+| `shikomi-dev.shikomi.locale.en-US.yaml` | `https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json` |
+
+`PackageVersion: 0.1.0` は Static 固定値。`winget-releaser` が新バージョンで動的に差し替える。
+
+## セキュリティ: アクション固定方針
+
+| アクション | 現状 | 目標 |
+|---|---|---|
+| `actions/checkout@34e114...` | コミットハッシュ固定 ✅ | 維持 |
+| `vedantmgoyal9/winget-releaser@main` | タグ固定 ⚠️ | 次 PR でコミットハッシュへ固定（OWASP A08）|
+
+## 参照ドキュメント
+
+| リソース | URL |
+|---|---|
+| winget マニフェストスキーマ v1.6.0 | https://aka.ms/winget-manifest.version.1.6.0.schema.json |
+| vedantmgoyal9/winget-releaser | https://github.com/vedantmgoyal9/winget-releaser |
+| Homebrew Cask 命名規則 | https://docs.brew.sh/Cask-Cookbook |
+| dpkg-scanpackages (1) | https://manpages.ubuntu.com/manpages/jammy/man1/dpkg-scanpackages.1.html |
+| apt-ftparchive (1) | https://manpages.ubuntu.com/manpages/jammy/man1/apt-ftparchive.1.html |
+| createrepo_c | https://github.com/rpm-software-management/createrepo_c |

--- a/docs/features/package-distribution/feature-spec.md
+++ b/docs/features/package-distribution/feature-spec.md
@@ -1,0 +1,77 @@
+# feature-spec: package-distribution
+
+<!-- 階層 2 — Feature 業務概念 | Issue #154 -->
+
+## メタデータ
+
+| 項目 | 内容 |
+|---|---|
+| Feature ID | PKG |
+| Feature 名 | `package-distribution` |
+| Issue | #154 |
+| Status | 実装完了 · 設計確定 |
+| 依存 Feature | `release-signing` (Issue #130) — コード署名対応後に GPG 署名 APT/RPM repo へ昇格予定 |
+
+## 概要
+
+winget (Windows) / Homebrew tap (macOS) / APT (Linux Debian/Ubuntu) / DNF/YUM (Linux Fedora/RHEL) の各パッケージマネージャーを通じて `shikomi` をインストール可能にする。
+
+GitHub Releases に既存の成果物（.msi / .exe / .dmg / .deb / .rpm）を活用し、GitHub Release の `published` イベントをトリガに各パッケージマネージャーのインデックス・メタデータを自動生成・公開する CI パイプライン (`package-publish.yml`) を構築する。
+
+## ユースケース
+
+| ID | アクター | ストーリー |
+|---|---|---|
+| UC-PKG-001 | エンドユーザー (Windows) | `winget install shikomi-dev.shikomi` で shikomi を Windows にインストールできる |
+| UC-PKG-002 | エンドユーザー (macOS) | `brew tap shikomi-dev/homebrew-shikomi && brew install --cask shikomi` で shikomi を macOS にインストールできる |
+| UC-PKG-003 | エンドユーザー (Linux Debian/Ubuntu) | APT ソース追加後に `sudo apt install shikomi` でインストール・更新できる |
+| UC-PKG-004 | エンドユーザー (Linux Fedora/RHEL) | DNF リポジトリ設定後に `sudo dnf install shikomi` でインストール・更新できる |
+| UC-PKG-005 | 開発チーム | 新バージョンリリース時、CI が自動で全パッケージマネージャーのメタデータを更新する |
+
+## 機能要件一覧
+
+| ID | 区分 | 要件 |
+|---|---|---|
+| R-PKG-001 | winget | GitHub Release published 時に `winget-pkgs` へ自動 PR を送信する |
+| R-PKG-002 | winget | `.github/winget/` に winget マニフェスト 3 点セット（version / installer / locale）を格納する |
+| R-PKG-003 | brew | GitHub Release published 時に `homebrew-shikomi` tap の Cask formula を自動更新する |
+| R-PKG-004 | brew | `brew tap shikomi-dev/homebrew-shikomi && brew install --cask shikomi` でインストールできる |
+| R-PKG-005 | apt | GitHub Release published 時に GitHub Pages の APT リポジトリを自動更新する |
+| R-PKG-006 | apt | APT ソース追加後に `sudo apt install shikomi` でインストールできる |
+| R-PKG-007 | rpm | GitHub Release published 時に GitHub Pages の RPM リポジトリを自動更新する |
+| R-PKG-008 | rpm | DNF/YUM リポジトリ設定後に `sudo dnf install shikomi` でインストールできる |
+| R-PKG-009 | 自動化 | `WINGET_TOKEN` 未設定時は winget ジョブを `continue-on-error` でスキップする（graceful degradation）|
+| R-PKG-010 | ドキュメント | README のインストール手順が全 OS で実際に機能するコマンドを正確に記載している |
+
+## 非機能要件・既知の制約
+
+| 項目 | 現状 (v0.1.x) | 解消方針 |
+|---|---|---|
+| GPG 署名（apt） | `[trusted=yes]` による未署名配布 | Issue #130 完了後に GPG 鍵を生成し `signed-by=` へ移行 |
+| GPG 署名（rpm） | `gpgcheck=0` による未署名配布 | Issue #130 完了後に同様に移行 |
+| コード署名（Windows） | SmartScreen 警告が発生する | Issue #130 (EV/OV 証明書) で解消 |
+| コード署名（macOS） | Gatekeeper 警告が発生する | Issue #130 (Apple Developer ID) で解消 |
+| Apple Silicon 専用 | v0.1.0 Cask は aarch64 DMG のみ対応 | Intel Mac / Universal Binary は別 Issue で追跡 |
+| winget 審査 | microsoft/winget-pkgs への自動 PR 後に人的審査が必要 | 外部依存（Microsoft プロセス）のため制御不可 |
+
+## 受入基準
+
+| # | 基準 | 検証方法 |
+|---|---|---|
+| AC-PKG-001 | winget-pkgs マージ後に `winget install shikomi-dev.shikomi` が機能する | Windows 10/11 実機 |
+| AC-PKG-002 | `brew tap shikomi-dev/homebrew-shikomi && brew install --cask shikomi` が機能する | macOS Monterey+ Apple Silicon 実機 |
+| AC-PKG-003 | APT ソース追加後に `sudo apt install shikomi` が機能する | Ubuntu 22.04 実機 |
+| AC-PKG-004 | DNF リポジトリ追加後に `sudo dnf install shikomi` が機能する | Fedora 40 実機 |
+| AC-PKG-005 | GitHub Release published 時に `package-publish.yml` が自動実行される | CI ログ |
+| AC-PKG-006 | GitHub Pages に apt / rpm ディレクトリが公開されている | `https://shikomi-dev.github.io/shikomi/` 確認 |
+| AC-PKG-007 | README のインストール手順が全 OS で正確に記載されている | ドキュメントレビュー |
+
+## 関連成果物
+
+| 成果物 | パス / URL |
+|---|---|
+| CI ワークフロー | `.github/workflows/package-publish.yml` |
+| winget マニフェスト | `.github/winget/shikomi-dev.shikomi*.yaml` |
+| Homebrew tap | `https://github.com/shikomi-dev/homebrew-shikomi` |
+| APT / RPM リポジトリ | `https://shikomi-dev.github.io/shikomi/` (gh-pages) |
+| sub-feature 基本設計 | `docs/features/package-distribution/ci/basic-design.md` |


### PR DESCRIPTION
## 概要

README に記載のインストール方法（winget/brew/apt）を実際に機能させる配布パイプラインを整備する。

Closes #154

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `.github/winget/shikomi-dev.shikomi.yaml` | winget マニフェスト (version) |
| `.github/winget/shikomi-dev.shikomi.installer.yaml` | winget マニフェスト (installer) |
| `.github/winget/shikomi-dev.shikomi.locale.en-US.yaml` | winget マニフェスト (locale) |
| `.github/workflows/package-publish.yml` | リリース後のパッケージ配布自動化ワークフロー |
| `README.md` | インストール手順を実態に合わせて修正 |

別リポジトリ: https://github.com/shikomi-dev/homebrew-shikomi（Homebrew tap）

## 各配布チャンネルの仕組み

### winget
- `.github/winget/` にマニフェスト 3 点セットを配置
- `package-publish.yml` の `winget-publish` ジョブが `vedantmgoyal9/winget-releaser` action で `microsoft/winget-pkgs` へ自動 PR
- ⚠️ winget-pkgs へのマージは Microsoft の人間レビューが必要（外部依存）
- secrets に `WINGET_TOKEN` を設定する必要あり

### Homebrew tap
- `shikomi-dev/homebrew-shikomi` リポジトリを新規作成、`Casks/shikomi.rb` を配置
- `homebrew-publish` ジョブがリリース時に SHA256 を取得して formula を自動更新
- secrets に `HOMEBREW_TAP_TOKEN` を設定する必要あり
- ユーザー手順: `brew tap shikomi-dev/homebrew-shikomi && brew install --cask shikomi`

### apt（GitHub Pages）
- `apt-publish` ジョブが `gh-pages` ブランチに Debian リポジトリを構築（`dpkg-scanpackages` / `apt-ftparchive`）
- ユーザー手順: sources.list 追加 → `sudo apt install shikomi`

### rpm（GitHub Pages）
- `rpm-publish` ジョブが `gh-pages` ブランチに YUM/DNF リポジトリを構築（`createrepo_c`）
- ユーザー手順: repo ファイル追加 → `sudo dnf install shikomi`

## README 修正内容

- macOS: `brew tap shikomi-dev/homebrew-shikomi && brew install --cask shikomi` に修正
- Linux apt: sources.list 追加 + `sudo apt install shikomi` の手順に修正
- Linux rpm: `dnf config-manager --add-repo` の手順を追加
- AppImage のファイル名を実際のリリース名（`shikomi_VERSION_amd64.AppImage`）に修正
- 署名状況（v0.1.0 は unsigned / Issue #130 で対応予定）を正確に記載
- macOS が arm64 専用であることを明記

## 必要な secrets 追加（リポジトリ設定）

- `WINGET_TOKEN`: `microsoft/winget-pkgs` への PR 権限を持つ PAT
- `HOMEBREW_TAP_TOKEN`: `shikomi-dev/homebrew-shikomi` へのコミット権限を持つ PAT

## テスト担当に確認してほしい観点

- `package-publish.yml` のシェルスクリプト構文（特に heredoc 内の Ruby formula 生成部分）
- `apt-publish` ジョブ: `dpkg-scanpackages` / `apt-ftparchive` の引数が Ubuntu 22.04 で正しく動作するか
- `rpm-publish` ジョブ: `createrepo_c` の出力ディレクトリ構造が DNF で参照可能か
- winget マニフェストのスキーマバージョン（1.6.0）が現行 winget-pkgs で受け付けられるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)