### PR TITLE
fix(release): apt repo を Debian 規約 dists/<suite>/ 配下に修正

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -121,6 +121,7 @@ jobs:
   # ---------------------------------------------------------------------------
   apt-publish:
     name: apt-publish
+    needs: rpm-publish  # gh-pages の同時 push レース回避 — rpm 完了後に実行
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     permissions:
@@ -135,8 +136,13 @@ jobs:
         # ubuntu-22.04 ランナーには dpkg-scanpackages / apt-ftparchive が初期導入されていない
         run: sudo apt-get update -y && sudo apt-get install -y apt-utils dpkg-dev
 
+      - name: clean stale apt layout (migration from pre-fix structure)
+        # 過去 run が apt/stable/ に書いた残骸を削除（apt 規約は dists/stable/）
+        run: rm -rf apt/stable apt/dists
+
       - name: setup apt repo directory
-        run: mkdir -p apt/stable/main/binary-amd64
+        # apt 規約: dists/<suite>/<component>/binary-<arch>/Packages
+        run: mkdir -p apt/dists/stable/main/binary-amd64
 
       - name: download deb package
         env:
@@ -146,16 +152,16 @@ jobs:
           gh release download "${TAG}" \
             --repo shikomi-dev/shikomi \
             --pattern "*.deb" \
-            --dir apt/stable/main/binary-amd64
+            --dir apt/dists/stable/main/binary-amd64
 
       - name: generate Packages and Release metadata
         run: |
-          cd apt/stable/main
+          cd apt/dists/stable/main
           dpkg-scanpackages binary-amd64 /dev/null > binary-amd64/Packages 2>/dev/null
           gzip -kf binary-amd64/Packages
 
           cd "${GITHUB_WORKSPACE}"
-          apt-ftparchive release apt/stable > apt/stable/Release
+          apt-ftparchive release apt/dists/stable > apt/dists/stable/Release
 
       - name: commit and push to gh-pages
         env:


### PR DESCRIPTION
## 概要

実機検証で `apt update` が 404 で失敗することが判明したため、apt repo の階層を Debian 規約 `dists/<suite>/` 配下に修正する。合わせて apt/rpm の gh-pages 同時 push レースを直列化で解消する。

## 失敗の証拠

ユーザー実機での `apt update` 出力:

```
Error: https://shikomi-dev.github.io/shikomi/apt/dists/stable/main/binary-amd64/Packages の取得に失敗しました
       404  Not Found [IP: 185.199.110.153 443]
```

apt は `deb URL stable main` ソースに対し `URL/**dists/**stable/main/binary-<arch>/Packages` を取得するが、PR #155 で配備されたワークフローは `dists/` 階層を欠いて `apt/stable/...` に配置していた。

## 変更内容

### 1. apt 出力先のパス修正（必須）

| 旧パス | 新パス |
|---|---|
| `apt/stable/Release` | `apt/dists/stable/Release` |
| `apt/stable/main/binary-amd64/Packages` | `apt/dists/stable/main/binary-amd64/Packages` |
| `apt/stable/main/binary-amd64/Packages.gz` | `apt/dists/stable/main/binary-amd64/Packages.gz` |
| `apt/stable/main/binary-amd64/*.deb` | `apt/dists/stable/main/binary-amd64/*.deb` |

### 2. gh-pages 同時 push レース修正

PR #156 dispatch で発覚した apt/rpm の race（後発が `[rejected] (fetch first)`）を `needs: rpm-publish` で直列化（同一 run 内）。

### 3. 旧 apt/stable/ の cleanup

過去 run が `apt/stable/` に書いた残骸を `rm -rf apt/stable apt/dists` で一掃する migration ステップを apt-publish 冒頭に追加。

## マージ後の手順

1. `gh workflow run package-publish.yml -R shikomi-dev/shikomi -f tag=v0.1.0`
2. apt-publish ジョブ成功確認
3. ユーザー側で:
   ```
   echo "deb [trusted=yes] https://shikomi-dev.github.io/shikomi/apt stable main" \
     | sudo tee /etc/apt/sources.list.d/shikomi.list
   sudo apt update && sudo apt install shikomi
   ```
4. `shikomi 0.1.0` がインストールされることを確認

## ブランチ命名について

`hotfix/0.1.2` は `branch-policy.yml` の `^(release|hotfix)/[0-9]+\.[0-9]+\.[0-9]+$` 適合のため。本 PR は workflow 修正のみで Cargo.toml version は据え置き。

## テスト

- [x] YAML 構文 OK
- [x] 全 run スクリプト `bash -n` OK
- [x] needs 関係追加でジョブ依存グラフ正しいこと確認
- [ ] 手動 dispatch 実行（マージ後）

Github-Issue:#154