### PR TITLE
fix(release): rpm-publish の re-run 衝突を解消（cleanup + --clobber）

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -196,6 +196,10 @@ jobs:
       - name: install createrepo_c
         run: sudo apt-get update -y && sudo apt-get install -y createrepo-c
 
+      - name: clean stale rpm packages (force re-download from release)
+        # 過去 run の rpm/packages/ が残っていると gh release download が衝突
+        run: rm -rf rpm/packages
+
       - name: setup rpm repo directory
         run: mkdir -p rpm/packages
 
@@ -207,7 +211,8 @@ jobs:
           gh release download "${TAG}" \
             --repo shikomi-dev/shikomi \
             --pattern "*.rpm" \
-            --dir rpm/packages
+            --dir rpm/packages \
+            --clobber
 
       - name: generate repodata and repo file
         run: |


### PR DESCRIPTION
## 概要

PR #157 マージ後の package-publish 再 dispatch で rpm-publish が下記で失敗。修正する。

```
rpm/packages/shikomi-0.1.0-1.x86_64.rpm already exists
(use `--clobber` to overwrite file or `--skip-existing` to skip file)
```

## 原因

過去 run が gh-pages に push した `rpm/packages/` を新しい run の checkout が引き取り、`gh release download` で同名ファイル衝突。apt-publish 側は PR #157 で migration 用 cleanup ステップを追加したが、rpm-publish 側が漏れていた。

## 変更内容

- rpm-publish に `rm -rf rpm/packages` cleanup ステップを追加
- `gh release download` に `--clobber` を defensive に追加

## マージ後の手順

1. `gh workflow run package-publish.yml -R shikomi-dev/shikomi -f tag=v0.1.0`
2. rpm-publish → apt-publish (needs) の順で完了確認
3. `apt update && apt install shikomi` 動作確認

Github-Issue:#154