### PR TITLE
fix(release): apt repo を Debian pool レイアウトに修正

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -136,13 +136,19 @@ jobs:
         # ubuntu-22.04 ランナーには dpkg-scanpackages / apt-ftparchive が初期導入されていない
         run: sudo apt-get update -y && sudo apt-get install -y apt-utils dpkg-dev
 
-      - name: clean stale apt layout (migration from pre-fix structure)
-        # 過去 run が apt/stable/ に書いた残骸を削除（apt 規約は dists/stable/）
-        run: rm -rf apt/stable apt/dists
+      - name: clean stale apt layout (migration from pre-pool structure)
+        # 過去 run が apt/stable/ や apt/dists/stable/main/binary-amd64/*.deb に
+        # 置いた残骸を削除（pool レイアウトでは deb は apt/pool/main/<letter>/<pkg>/）
+        run: rm -rf apt/stable apt/dists apt/pool
 
-      - name: setup apt repo directory
-        # apt 規約: dists/<suite>/<component>/binary-<arch>/Packages
-        run: mkdir -p apt/dists/stable/main/binary-amd64
+      - name: setup apt repo directory (Debian pool layout)
+        # Debian 規約:
+        #   - 実 deb: pool/<component>/<first-letter>/<package>/<deb>
+        #   - メタ:   dists/<suite>/<component>/binary-<arch>/{Packages,Packages.gz}
+        #   - Release: dists/<suite>/Release（Suite/Codename/Architectures/Components 必須）
+        run: |
+          mkdir -p apt/pool/main/s/shikomi
+          mkdir -p apt/dists/stable/main/binary-amd64
 
       - name: download deb package
         env:
@@ -152,16 +158,29 @@ jobs:
           gh release download "${TAG}" \
             --repo shikomi-dev/shikomi \
             --pattern "*.deb" \
-            --dir apt/dists/stable/main/binary-amd64
+            --dir apt/pool/main/s/shikomi \
+            --clobber
 
       - name: generate Packages and Release metadata
         run: |
-          cd apt/dists/stable/main
-          dpkg-scanpackages binary-amd64 /dev/null > binary-amd64/Packages 2>/dev/null
-          gzip -kf binary-amd64/Packages
+          # dpkg-scanpackages を apt/ から呼び、pool/... を引数に渡すと
+          # Filename: pool/main/s/shikomi/<deb> が出力される（apt が repo base
+          # からの相対 URL として正しく解決する）
+          cd apt
+          dpkg-scanpackages pool/main/s/shikomi /dev/null \
+            > dists/stable/main/binary-amd64/Packages 2>/dev/null
+          gzip -kf dists/stable/main/binary-amd64/Packages
 
-          cd "${GITHUB_WORKSPACE}"
-          apt-ftparchive release apt/dists/stable > apt/dists/stable/Release
+          # Release は Suite/Codename/Architectures/Components を明示しないと
+          # apt が「期待 stable に対し空文字を取得」と警告し検証を弾く
+          apt-ftparchive \
+            -o APT::FTPArchive::Release::Suite=stable \
+            -o APT::FTPArchive::Release::Codename=stable \
+            -o APT::FTPArchive::Release::Architectures=amd64 \
+            -o APT::FTPArchive::Release::Components=main \
+            -o APT::FTPArchive::Release::Origin=shikomi-dev \
+            -o APT::FTPArchive::Release::Label=shikomi \
+            release dists/stable > dists/stable/Release
 
       - name: commit and push to gh-pages
         env:


### PR DESCRIPTION
## 概要

実機検証で `sudo apt install shikomi` が下記 2 件で失敗。修正する。

```
Warning: ディストリビューションが競合しています:
  https://shikomi-dev.github.io/shikomi/apt stable Release
  (stable を期待していたのに  を取得しました)

Error: https://shikomi-dev.github.io/shikomi/apt/binary-amd64/shikomi_0.1.0_amd64.deb
  の取得に失敗しました 404 Not Found
```

## 原因

### 1. Release に Suite/Codename がない

`apt-ftparchive release dists/stable` を引数だけで呼ぶと、出力 Release ファイルに `Suite:` / `Codename:` フィールドが入らない。apt は sources.list の `stable` と Release の Suite/Codename が一致するか検証するため、空文字との比較で警告 → 検証失敗。

### 2. Filename パスが Debian 規約に反する

PR #157 で `dists/stable/main/binary-amd64/` に deb を直置きする構造に修正したが、`dpkg-scanpackages binary-amd64` の出力 Packages では `Filename: binary-amd64/<deb>` が記録される。apt はこれを repo base URL（`apt/`）からの相対パスとして解決するため `<base>/binary-amd64/<deb>` を取りに行くが、実 deb は `<base>/dists/stable/main/binary-amd64/<deb>` にあって 404。

Debian 規約上、メタデータ（Packages, Release）は `dists/<suite>/...` 配下、実 deb は `pool/<component>/<letter>/<package>/...` 配下に分離するのが正しい。

## 修正

### Debian pool レイアウトへ移行

```
apt/
  pool/main/s/shikomi/shikomi_0.1.0_amd64.deb   ← 実 deb（new）
  dists/stable/Release                          ← Suite/Codename 完備
  dists/stable/main/binary-amd64/
    Packages                                    ← Filename: pool/main/s/shikomi/<deb>
    Packages.gz
```

- `dpkg-scanpackages` を `cd apt && dpkg-scanpackages pool/main/s/shikomi` で呼ぶ → Filename が `pool/...` になる
- `apt-ftparchive` に下記を渡し Release を完備化:
  - `Suite=stable`
  - `Codename=stable`
  - `Architectures=amd64`
  - `Components=main`
  - `Origin=shikomi-dev`
  - `Label=shikomi`

### Clean ステップ拡張

`rm -rf apt/stable apt/dists apt/pool` で過去の不正レイアウト（apt/stable/, apt/dists/stable/main/binary-amd64/*.deb）を全削除。

## マージ後の手順

1. `gh workflow run package-publish.yml -R shikomi-dev/shikomi -f tag=v0.1.0`
2. apt-publish 成功 → ユーザー再試行:
   ```
   sudo apt update
   sudo apt install shikomi
   ```
3. 警告なし・404 なし・インストール完了を確認

Github-Issue:#154