### PR TITLE
fix(release): v0.1.1 — Linux 配布物に CLI/daemon 同梱、GUI/docs/error メッセージ整合

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -51,6 +51,12 @@ jobs:
             libssl-dev \
             pkg-config
 
+      - name: build CLI/daemon binaries (must precede tauri bundle for files inclusion)
+        # tauri.conf.json bundle.linux.{deb,rpm}.files が target/release/shikomi
+        # と target/release/shikomi-daemon を参照するため、tauri build より先にビルド。
+        # release.yml と同パターン (Issue #160 v0.1.1)。
+        run: cargo build --release -p shikomi-cli -p shikomi-daemon
+
       - name: tauri build (linux)
         # 設計根拠: jobs.md §2.4
         working-directory: crates/shikomi-gui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ jobs:
             libssl-dev \
             pkg-config
 
+      - name: build CLI/daemon binaries (must precede tauri bundle for files inclusion)
+        # tauri.conf.json bundle.linux.{deb,rpm}.files が target/release/shikomi
+        # と target/release/shikomi-daemon を参照するため、tauri build より先にビルド
+        run: cargo build --release -p shikomi-cli -p shikomi-daemon
+
       - name: tauri build (linux)
         working-directory: crates/shikomi-gui
         run: cargo tauri build --ci

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 
 # OS specific
 .DS_Store
+crates/shikomi-gui/gen/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "shikomi-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "shikomi-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "rmp-serde",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "shikomi-daemon"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arboard",
  "assert_cmd",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "shikomi-gui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "futures-util",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "shikomi-infra"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -186,6 +186,20 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ashpd"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3118453e020b8e3e0da25ef9a1d0d51d668874358af11aded9d91a8b9c25f323"
+dependencies = [
+ "enumflags2",
+ "futures-util",
+ "getrandom 0.4.2",
+ "serde",
+ "tokio",
+ "zbus",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -4213,6 +4227,7 @@ name = "shikomi-daemon"
 version = "0.1.1"
 dependencies = [
  "arboard",
+ "ashpd",
  "assert_cmd",
  "async-trait",
  "bytes",
@@ -5009,6 +5024,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -6552,6 +6568,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["shikomi-dev"]
 license = "MIT"
 repository = "https://github.com/shikomi-dev/shikomi"
@@ -41,8 +41,8 @@ cfg-if          = "1"
 tracing         = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 dirs            = "5"
-shikomi-core    = { path = "crates/shikomi-core", version = "0.1.0" }
-shikomi-infra   = { path = "crates/shikomi-infra", version = "0.1.0" }
+shikomi-core    = { path = "crates/shikomi-core", version = "0.1.1" }
+shikomi-infra   = { path = "crates/shikomi-infra", version = "0.1.1" }
 # CLI 層の依存（cli-vault-commands feature で追加）
 clap            = { version = "4",    features = ["derive", "env", "wrap_help"] }
 anyhow          = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,9 @@ async-trait     = { version = "0.1", default-features = false }
 global-hotkey    = { version = "0.8", default-features = false }
 arboard          = { version = "3.6", default-features = false }
 notify-rust      = { version = "4.11", default-features = false, features = ["z"] }
+# Issue #160: Wayland グローバルホットキー対応 — XDG Portal GlobalShortcuts wrapper。
+# tokio feature: 内部の zbus を tokio runtime にバインド。
+ashpd            = { version = "0.13", default-features = false, features = ["tokio", "global_shortcuts"] }
 # Sub-C (#41) test-design TC-C-P01 / TC-C-P02 用 proptest。1000 ケースで
 # AAD 入れ替え検出 + encrypt/decrypt 往復不変条件を property 検証する。
 # Bug-C-001 顛末: 銀ちゃん impl は単発 fixture 検証のみで proptest 不在、

--- a/README.md
+++ b/README.md
@@ -82,9 +82,24 @@ chmod +x shikomi_*_amd64.AppImage
 
 #### Linux 追加セットアップ
 
-Wayland 環境でグローバルホットキーを使用するには、XDG Portal `org.freedesktop.impl.portal.GlobalShortcuts` をサポートするデスクトップ環境（GNOME 44+ / KDE Plasma 6+）が必要です。
+##### 1. daemon 自動起動を有効化（必須）
 
-X11 環境では追加セットアップは不要です。
+apt / dnf でインストール直後は自動起動が有効化されていません。下記コマンドで systemd user service を登録してください:
+
+```bash
+shikomi daemon install
+```
+
+これでログイン時に `shikomi-daemon` が自動起動し、`shikomi-gui` がホットキーを利用可能になります。
+
+##### 2. グローバルホットキー（X11 / Wayland 別対応）
+
+| 環境 | 対応状況 |
+|---|---|
+| X11 | ✅ v0.1.1 から動作 |
+| Wayland (GNOME 44+ / KDE Plasma 6+) | ⚠ v0.1.1 では未対応（v0.1.2 で `org.freedesktop.portal.GlobalShortcuts` 対応予定 — Issue #160 関連）|
+
+Wayland セッションでもアプリ起動・CLI・GUI からのエントリ管理は動作しますが、グローバルホットキー押下による投入機能は X11 セッションでログインし直すまで利用できません。
 
 ## 権限要件（Permissions）
 
@@ -94,8 +109,8 @@ shikomi はユーザー権限のみで動作します。**管理者権限・`set
 
 | OS | デフォルト設定 | 説明 |
 |----|-------------|------|
-| Unix（Linux / macOS） | `0600`（所有者のみ読み書き可） | `~/.local/share/shikomi/vault.json` に自動適用 |
-| Windows | NTFS ACL: 所有者 SID のみフルコントロール | `%APPDATA%\shikomi\vault.json` に自動適用 |
+| Unix（Linux / macOS） | `0600`（所有者のみ読み書き可） | `~/.local/share/shikomi/vault.db` に自動適用 |
+| Windows | NTFS ACL: 所有者 SID のみフルコントロール | `%APPDATA%\shikomi\vault.db` に自動適用 |
 
 > **注意（平文モード）**: デフォルトの平文 vault は OS のファイルパーミッションのみで保護されています。同一ユーザー権限で動作する他プロセス・マルウェアからは読取・書換が可能です。パスワード等の高度な機密情報を保管する場合は `shikomi vault encrypt` で暗号化保護を有効化してください。
 
@@ -111,18 +126,20 @@ shikomi vault encrypt
 
 ### デーモン起動
 
-shikomi はバックグラウンドデーモンとしてホットキーを監視します。インストール時に OS の自動起動に登録されます。
+shikomi はバックグラウンドデーモン (`shikomi-daemon`) としてホットキーを監視します。**インストール直後は自動起動が無効**なので、初回 1 回だけ下記を実行してください:
 
 ```bash
-# 手動起動
-shikomi daemon start
+# OS 自動起動に登録（systemd user service / launchd / Windows スタートアップ）
+shikomi daemon install
 
-# 状態確認
+# 状態確認（daemon プロセス + 自動起動登録の両方）
 shikomi daemon status
 
-# 停止
-shikomi daemon stop
+# 自動起動を解除
+shikomi daemon uninstall
 ```
+
+`install` 後はログイン時に daemon が自動起動します。手動で起動・停止する場合は OS 側の機構（Linux: `systemctl --user start/stop shikomi-daemon`）を使用してください。
 
 ### エントリ管理（CLI）
 
@@ -131,10 +148,11 @@ shikomi daemon stop
 shikomi list
 
 # エントリ登録（ホットキー: Ctrl+Alt+1、ラベル: メールアドレス）
-shikomi add --hotkey "ctrl+alt+1" --label "メールアドレス" --value "user@example.com"
+# ホットキー文字列は大文字必須: Ctrl+Alt+[1-9]
+shikomi add --kind text --hotkey "Ctrl+Alt+1" --label "メールアドレス" --value "user@example.com"
 
-# パスワード等の機密文字列（自動クリア有効）
-shikomi add --hotkey "ctrl+alt+2" --label "パスワード" --secret
+# パスワード等の機密文字列（自動クリア有効）— stdin から値を入力
+shikomi add --kind secret --hotkey "Ctrl+Alt+2" --label "パスワード"
 
 # エントリ編集
 shikomi edit 1

--- a/crates/shikomi-cli/tests/e2e_sc_ddm_002.rs
+++ b/crates/shikomi-cli/tests/e2e_sc_ddm_002.rs
@@ -55,11 +55,28 @@ fn expected_autostart_file(home: &std::path::Path) -> Option<PathBuf> {
     }
 }
 
+/// テスト用 isolated 環境で shikomi コマンドを構築する。
+///
+/// HOME を temp dir に置き換えるだけでなく、`DBUS_SESSION_BUS_ADDRESS` も
+/// 削除する（これを残すと SystemdBackend::is_available() が真になり、
+/// XDG Autostart fallback ではなく実 systemd を呼んでしまい、dev 機の
+/// 既存 systemd ユーザーセッションを汚染しテストも fail する）。
+///
+/// CI ランナー（GitHub Actions ubuntu-22.04）は元々 D-Bus 未設定で
+/// 自然と XDG が選択されるが、開発機（GNOME/KDE 等）では明示 unset 必須。
+fn isolated_shikomi_cmd(home_dir: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("shikomi").expect("shikomi binary");
+    cmd.env("HOME", home_dir)
+        .env_remove("DBUS_SESSION_BUS_ADDRESS")
+        .env_remove("XDG_RUNTIME_DIR")
+        .env_remove("DBUS_SESSION_BUS_ADDRESS")
+        .env_remove("XDG_RUNTIME_DIR");
+    cmd
+}
+
 /// `shikomi daemon <args>` を `HOME=home_dir` 環境で実行して結果を返す。
 fn run_daemon_cmd(home_dir: &std::path::Path, args: &[&str]) -> assert_cmd::assert::Assert {
-    Command::cargo_bin("shikomi")
-        .expect("shikomi binary")
-        .env("HOME", home_dir)
+    isolated_shikomi_cmd(home_dir)
         .arg("daemon")
         .args(args)
         .assert()
@@ -183,6 +200,8 @@ fn sc_ddm_002_tc003_ac09_daemon_status_no_ipc_always_exit_0() {
         let output = Command::cargo_bin("shikomi")
             .expect("shikomi binary")
             .env("HOME", home.path())
+            .env_remove("DBUS_SESSION_BUS_ADDRESS")
+            .env_remove("XDG_RUNTIME_DIR")
             .args(["daemon", "status", "--no-ipc"])
             .output()
             .expect("実行失敗");
@@ -222,6 +241,8 @@ fn sc_ddm_002_tc003_ac09_daemon_status_no_ipc_always_exit_0() {
         let output = Command::cargo_bin("shikomi")
             .expect("shikomi binary")
             .env("HOME", home.path())
+            .env_remove("DBUS_SESSION_BUS_ADDRESS")
+            .env_remove("XDG_RUNTIME_DIR")
             .args(["daemon", "status", "--no-ipc"])
             .output()
             .expect("実行失敗");
@@ -257,6 +278,8 @@ fn sc_ddm_002_tc003b_ac09_daemon_status_not_running_when_no_daemon() {
     let output = Command::cargo_bin("shikomi")
         .expect("shikomi binary")
         .env("HOME", home.path())
+        .env_remove("DBUS_SESSION_BUS_ADDRESS")
+        .env_remove("XDG_RUNTIME_DIR")
         .env("XDG_RUNTIME_DIR", fake_xdg.path())
         .args(["daemon", "status"])
         .output()
@@ -334,6 +357,8 @@ fn tc_it_127_quiet_flag_suppresses_install_success_message() {
     let output = Command::cargo_bin("shikomi")
         .expect("shikomi binary")
         .env("HOME", home.path())
+        .env_remove("DBUS_SESSION_BUS_ADDRESS")
+        .env_remove("XDG_RUNTIME_DIR")
         .args(["daemon", "install", "--quiet"])
         .output()
         .expect("実行失敗");
@@ -376,6 +401,8 @@ fn tc_it_128_quiet_flag_suppresses_uninstall_success_message() {
     let output = Command::cargo_bin("shikomi")
         .expect("shikomi binary")
         .env("HOME", home.path())
+        .env_remove("DBUS_SESSION_BUS_ADDRESS")
+        .env_remove("XDG_RUNTIME_DIR")
         .args(["daemon", "uninstall", "--quiet"])
         .output()
         .expect("実行失敗");
@@ -436,6 +463,8 @@ fn tc_it_132_status_reflects_install_uninstall_cycle() {
         let output = Command::cargo_bin("shikomi")
             .expect("shikomi binary")
             .env("HOME", home.path())
+            .env_remove("DBUS_SESSION_BUS_ADDRESS")
+            .env_remove("XDG_RUNTIME_DIR")
             .args(["daemon", "status", "--no-ipc"])
             .output()
             .expect("実行失敗");
@@ -452,6 +481,8 @@ fn tc_it_132_status_reflects_install_uninstall_cycle() {
         let output = Command::cargo_bin("shikomi")
             .expect("shikomi binary")
             .env("HOME", home.path())
+            .env_remove("DBUS_SESSION_BUS_ADDRESS")
+            .env_remove("XDG_RUNTIME_DIR")
             .args(["daemon", "status", "--no-ipc"])
             .output()
             .expect("実行失敗");
@@ -468,6 +499,8 @@ fn tc_it_132_status_reflects_install_uninstall_cycle() {
         let output = Command::cargo_bin("shikomi")
             .expect("shikomi binary")
             .env("HOME", home.path())
+            .env_remove("DBUS_SESSION_BUS_ADDRESS")
+            .env_remove("XDG_RUNTIME_DIR")
             .args(["daemon", "status", "--no-ipc"])
             .output()
             .expect("実行失敗");

--- a/crates/shikomi-daemon/Cargo.toml
+++ b/crates/shikomi-daemon/Cargo.toml
@@ -47,6 +47,11 @@ global-hotkey      = { workspace = true }
 arboard            = { workspace = true }
 notify-rust        = { workspace = true }
 
+# Issue #160: Wayland グローバルホットキー対応（XDG Portal GlobalShortcuts）
+# Linux Wayland セッションでは global-hotkey が動作しないため、Portal 経由で登録する。
+[target.'cfg(target_os = "linux")'.dependencies]
+ashpd              = { workspace = true }
+
 [target.'cfg(unix)'.dependencies]
 nix                = { workspace = true }
 

--- a/crates/shikomi-daemon/dist/dev.shikomi.daemon.desktop
+++ b/crates/shikomi-daemon/dist/dev.shikomi.daemon.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=shikomi-daemon
+Comment=shikomi credential vault daemon (background service)
+Exec=/usr/bin/shikomi-daemon
+Icon=shikomi-gui
+Terminal=false
+NoDisplay=true
+Categories=System;

--- a/crates/shikomi-daemon/src/hotkey/backend/mod.rs
+++ b/crates/shikomi-daemon/src/hotkey/backend/mod.rs
@@ -6,6 +6,9 @@ use futures_util::stream::BoxStream;
 
 pub(crate) mod global_hotkey;
 
+#[cfg(target_os = "linux")]
+pub(crate) mod xdg_portal;
+
 // -------------------------------------------------------------------
 // HotkeyEvent
 // -------------------------------------------------------------------
@@ -77,8 +80,11 @@ pub trait HotkeyBackend: Send + Sync + 'static {
 /// `dyn HotkeyBackend` の代わりに enum で実装することで、ホットキーイベントループの
 /// hot path でのヒープアロケーションを避ける。
 pub enum BackendEnum {
-    /// `global-hotkey` crate を使用するクロスプラットフォームバックエンド。
+    /// `global-hotkey` crate を使用するクロスプラットフォームバックエンド（X11 / macOS / Windows）。
     GlobalHotkey(global_hotkey::GlobalHotkeyBackend),
+    /// XDG Desktop Portal `org.freedesktop.portal.GlobalShortcuts` 経由（Linux Wayland 専用）。
+    #[cfg(target_os = "linux")]
+    XdgPortal(xdg_portal::XdgPortalBackend),
     /// バックエンド未対応環境向け noop 実装（tracing::warn のみ）。
     Null(NullBackend),
     /// **テスト専用**。イベント注入チャンネルを持つモックバックエンド。
@@ -89,8 +95,28 @@ pub enum BackendEnum {
 impl BackendEnum {
     /// OS / セッションを検出して適切なバックエンドを構築する。
     ///
-    /// `global-hotkey` バックエンドの初期化に失敗した場合は `NullBackend` にフォールバック。
+    /// 検出順:
+    /// 1. Linux Wayland (`WAYLAND_DISPLAY` set) → XDG Portal GlobalShortcuts (Issue #160)
+    /// 2. それ以外 → `global-hotkey` crate (X11 / macOS / Windows)
+    /// 3. 全て失敗 → `NullBackend` フォールバック
     pub fn detect() -> Arc<Self> {
+        // Linux Wayland: XDG Portal バックエンドを優先
+        #[cfg(target_os = "linux")]
+        if xdg_portal::is_wayland() {
+            match xdg_portal::XdgPortalBackend::new() {
+                Ok(backend) => {
+                    tracing::info!("HotkeyBackend: using XDG Portal (Wayland) backend");
+                    return Arc::new(Self::XdgPortal(backend));
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "HotkeyBackend: XDG Portal init failed on Wayland, falling back to global-hotkey (will likely fail)"
+                    );
+                }
+            }
+        }
+
         match global_hotkey::GlobalHotkeyBackend::new() {
             Ok(backend) => {
                 tracing::info!("HotkeyBackend: using global-hotkey backend");
@@ -111,6 +137,8 @@ impl HotkeyBackend for BackendEnum {
     fn register(&self, combo: &str) -> Result<(), HotkeyError> {
         match self {
             Self::GlobalHotkey(b) => b.register(combo),
+            #[cfg(target_os = "linux")]
+            Self::XdgPortal(b) => b.register(combo),
             Self::Null(b) => b.register(combo),
             Self::Mock(b) => b.register(combo),
         }
@@ -119,6 +147,8 @@ impl HotkeyBackend for BackendEnum {
     fn unregister(&self, combo: &str) -> Result<(), HotkeyError> {
         match self {
             Self::GlobalHotkey(b) => b.unregister(combo),
+            #[cfg(target_os = "linux")]
+            Self::XdgPortal(b) => b.unregister(combo),
             Self::Null(b) => b.unregister(combo),
             Self::Mock(b) => b.unregister(combo),
         }
@@ -127,6 +157,8 @@ impl HotkeyBackend for BackendEnum {
     fn event_stream(&self) -> BoxStream<'static, HotkeyEvent> {
         match self {
             Self::GlobalHotkey(b) => b.event_stream(),
+            #[cfg(target_os = "linux")]
+            Self::XdgPortal(b) => b.event_stream(),
             Self::Null(b) => b.event_stream(),
             Self::Mock(b) => b.event_stream(),
         }

--- a/crates/shikomi-daemon/src/hotkey/backend/xdg_portal.rs
+++ b/crates/shikomi-daemon/src/hotkey/backend/xdg_portal.rs
@@ -184,6 +184,20 @@ async fn worker_main(
         })
         .expect("cmd bridge thread spawn failed");
 
+    // ashpd: アプリ ID を host portal registry に登録（GlobalShortcuts CreateSession の必須前提）。
+    // AppID は `/usr/share/applications/dev.shikomi.daemon.desktop` の basename と一致させる必要がある
+    // (xdg-desktop-portal が App info 検索に使う規約 + 2 セグメント以上の制約)。
+    // `.desktop` ファイルは tauri.conf.json の bundle.linux.{deb,rpm}.files で同梱。
+    match ashpd::AppID::try_from("dev.shikomi.daemon") {
+        Ok(app_id) => match ashpd::register_host_app(app_id).await {
+            Ok(()) => tracing::info!("XdgPortalBackend: register_host_app(dev.shikomi.daemon) ok"),
+            Err(e) => {
+                tracing::warn!(error = %e, "XdgPortalBackend: register_host_app failed (dev 環境では .desktop 未配置の可能性)")
+            }
+        },
+        Err(e) => tracing::warn!(error = %e, "XdgPortalBackend: AppID parse failed"),
+    }
+
     // ashpd: GlobalShortcuts proxy + session 作成
     let gs = match GlobalShortcuts::new().await {
         Ok(g) => g,

--- a/crates/shikomi-daemon/src/hotkey/backend/xdg_portal.rs
+++ b/crates/shikomi-daemon/src/hotkey/backend/xdg_portal.rs
@@ -1,0 +1,305 @@
+//! Wayland (XDG Portal `org.freedesktop.portal.GlobalShortcuts`) backend
+//! for `HotkeyBackend` trait.
+//!
+//! Linux Wayland セッションでは `global-hotkey` crate (XGrabKey 系) が動作しないため、
+//! XDG Desktop Portal の `GlobalShortcuts` 経由でショートカットを登録・受信する。
+//!
+//! ## アーキテクチャ
+//!
+//! ashpd の API は async/await ベース、`HotkeyBackend` trait は sync。
+//! 両者を橋渡しするため、別 OS スレッドで `tokio::runtime::current_thread`
+//! を走らせ、`std::sync::mpsc` で同期コマンドを送る (既存 `global_hotkey.rs`
+//! と同一の橋渡しパターン)。
+//!
+//! ```text
+//! caller (tokio task)                    worker thread (own tokio rt)
+//!     ├── register("Ctrl+Alt+1") ─────► BackendCmd::Register { combo, reply }
+//!     │                                    ├── ashpd: bind_shortcuts([...])
+//!     │   ◄────────────────────────────── reply.send(Ok)
+//!     │
+//!     └── event_stream() poll ────────────────────────────┐
+//!                                                          │
+//!     worker is also listening to:                         │
+//!         ashpd Activated signal                           │
+//!         └── HotkeyEvent { combo } ──► event_tx ──────────┘
+//! ```
+//!
+//! 設計根拠: Issue #160 / #162 (v0.1.2 仕様)
+
+use std::sync::Arc;
+
+use ashpd::desktop::global_shortcuts::{
+    Activated, BindShortcutsOptions, GlobalShortcuts, NewShortcut,
+};
+use ashpd::desktop::CreateSessionOptions;
+use futures_util::{stream::BoxStream, StreamExt};
+use tokio::sync::Mutex as TokioMutex;
+
+use super::{HotkeyBackend, HotkeyError, HotkeyEvent};
+
+// ---------------------------------------------------------------------------
+// XdgPortalBackend (public)
+// ---------------------------------------------------------------------------
+
+pub struct XdgPortalBackend {
+    cmd_tx: std::sync::mpsc::SyncSender<BackendCmd>,
+    event_rx: Arc<TokioMutex<tokio::sync::mpsc::UnboundedReceiver<HotkeyEvent>>>,
+}
+
+impl XdgPortalBackend {
+    /// 新しい XDG Portal バックエンドを構築する。
+    ///
+    /// 内部で OS スレッドを起動し、専用の tokio current_thread runtime で
+    /// ashpd `GlobalShortcuts::create_session()` を実行する。session 確立まで
+    /// 同期的に待機（最大 5 秒タイムアウト）。
+    ///
+    /// # Errors
+    /// セッション作成失敗 / D-Bus 接続失敗 / Portal 未対応。
+    pub fn new() -> Result<Self, HotkeyError> {
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::sync_channel::<BackendCmd>(32);
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel::<Result<(), HotkeyError>>(1);
+
+        // OS スレッドで独立した tokio runtime を回す
+        std::thread::Builder::new()
+            .name("shikomi-xdg-portal".into())
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        let _ = ready_tx.send(Err(HotkeyError::Unavailable {
+                            reason: format!("tokio runtime build failed: {e}"),
+                        }));
+                        return;
+                    }
+                };
+                rt.block_on(worker_main(cmd_rx, event_tx, ready_tx));
+            })
+            .map_err(|e| HotkeyError::Unavailable {
+                reason: format!("thread spawn failed: {e}"),
+            })?;
+
+        // session 確立を待つ (5s)
+        match ready_rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(Ok(())) => {
+                tracing::info!("XdgPortalBackend: session ready");
+                Ok(Self {
+                    cmd_tx,
+                    event_rx: Arc::new(TokioMutex::new(event_rx)),
+                })
+            }
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err(HotkeyError::Unavailable {
+                reason: "XDG Portal session creation timed out (5s)".into(),
+            }),
+        }
+    }
+
+    fn send_cmd_and_wait<F>(&self, make: F) -> Result<(), HotkeyError>
+    where
+        F: FnOnce(std::sync::mpsc::SyncSender<Result<(), HotkeyError>>) -> BackendCmd,
+    {
+        let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel(1);
+        let cmd = make(reply_tx);
+        self.cmd_tx
+            .send(cmd)
+            .map_err(|_| HotkeyError::Unavailable {
+                reason: "XDG Portal worker thread is gone".into(),
+            })?;
+        reply_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .map_err(|_| HotkeyError::Unavailable {
+                reason: "XDG Portal reply timed out".into(),
+            })?
+    }
+}
+
+impl HotkeyBackend for XdgPortalBackend {
+    fn register(&self, combo: &str) -> Result<(), HotkeyError> {
+        let combo_owned = combo.to_owned();
+        self.send_cmd_and_wait(|reply| BackendCmd::Register {
+            combo: combo_owned,
+            reply,
+        })
+    }
+
+    fn unregister(&self, combo: &str) -> Result<(), HotkeyError> {
+        let combo_owned = combo.to_owned();
+        self.send_cmd_and_wait(|reply| BackendCmd::Unregister {
+            combo: combo_owned,
+            reply,
+        })
+    }
+
+    fn event_stream(&self) -> BoxStream<'static, HotkeyEvent> {
+        let rx_arc = Arc::clone(&self.event_rx);
+        Box::pin(futures_util::stream::unfold(rx_arc, |rx_arc| async move {
+            let event = rx_arc.lock().await.recv().await?;
+            Some((event, rx_arc))
+        }))
+    }
+}
+
+impl Drop for XdgPortalBackend {
+    fn drop(&mut self) {
+        let _ = self.cmd_tx.send(BackendCmd::Shutdown);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worker thread
+// ---------------------------------------------------------------------------
+
+enum BackendCmd {
+    Register {
+        combo: String,
+        reply: std::sync::mpsc::SyncSender<Result<(), HotkeyError>>,
+    },
+    Unregister {
+        combo: String,
+        reply: std::sync::mpsc::SyncSender<Result<(), HotkeyError>>,
+    },
+    Shutdown,
+}
+
+async fn worker_main(
+    cmd_rx: std::sync::mpsc::Receiver<BackendCmd>,
+    event_tx: tokio::sync::mpsc::UnboundedSender<HotkeyEvent>,
+    ready_tx: std::sync::mpsc::SyncSender<Result<(), HotkeyError>>,
+) {
+    // 同期 mpsc を tokio に橋渡しするため、worker 内で別タスクで recv して
+    // tokio チャンネルに転送する（unsafe ポインタ trick を回避）。
+    let (cmd_tokio_tx, mut cmd_tokio_rx) = tokio::sync::mpsc::unbounded_channel::<BackendCmd>();
+    std::thread::Builder::new()
+        .name("shikomi-xdg-cmd-bridge".into())
+        .spawn(move || {
+            while let Ok(cmd) = cmd_rx.recv() {
+                if cmd_tokio_tx.send(cmd).is_err() {
+                    break;
+                }
+            }
+        })
+        .expect("cmd bridge thread spawn failed");
+
+    // ashpd: GlobalShortcuts proxy + session 作成
+    let gs = match GlobalShortcuts::new().await {
+        Ok(g) => g,
+        Err(e) => {
+            let _ = ready_tx.send(Err(HotkeyError::Unavailable {
+                reason: format!("GlobalShortcuts::new failed: {e}"),
+            }));
+            return;
+        }
+    };
+
+    let session = match gs.create_session(CreateSessionOptions::default()).await {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = ready_tx.send(Err(HotkeyError::Unavailable {
+                reason: format!("create_session failed: {e}"),
+            }));
+            return;
+        }
+    };
+
+    let activated_stream = match gs.receive_activated().await {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = ready_tx.send(Err(HotkeyError::Unavailable {
+                reason: format!("receive_activated failed: {e}"),
+            }));
+            return;
+        }
+    };
+    let mut activated_stream = std::pin::pin!(activated_stream);
+
+    // 現在登録済みコンボの集合（BindShortcuts は全置換なので、増減を管理）
+    let mut bound: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+    let _ = ready_tx.send(Ok(()));
+
+    // メインループ: cmd 受信 と Activated signal を同時に待つ
+    loop {
+        tokio::select! {
+            // ホットキー押下イベント
+            Some(activated) = activated_stream.next() => {
+                handle_activated(activated, &event_tx);
+            }
+
+            // ブリッジスレッド経由で sync mpsc を tokio mpsc に橋渡しした recv
+            cmd = cmd_tokio_rx.recv() => {
+                let Some(cmd) = cmd else {
+                    tracing::info!("XdgPortalBackend: command channel closed, exiting");
+                    break;
+                };
+                match cmd {
+                    BackendCmd::Register { combo, reply } => {
+                        bound.insert(combo);
+                        let result = bind_all(&gs, &session, &bound).await;
+                        let _ = reply.send(result);
+                    }
+                    BackendCmd::Unregister { combo, reply } => {
+                        bound.remove(&combo);
+                        let result = bind_all(&gs, &session, &bound).await;
+                        let _ = reply.send(result);
+                    }
+                    BackendCmd::Shutdown => {
+                        tracing::info!("XdgPortalBackend: shutdown signal received");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn handle_activated(
+    activated: Activated,
+    event_tx: &tokio::sync::mpsc::UnboundedSender<HotkeyEvent>,
+) {
+    let combo = activated.shortcut_id().to_owned();
+    tracing::debug!(combo = %combo, "XdgPortalBackend: shortcut activated");
+    if event_tx.send(HotkeyEvent { combo }).is_err() {
+        tracing::warn!("XdgPortalBackend: event_tx closed");
+    }
+}
+
+/// 現在 `bound` 集合に含まれる全ショートカットを Portal に再登録する。
+///
+/// `BindShortcuts` は呼び出しごとに引数の集合で「全置換」される（部分更新の API がない）。
+/// `shortcut_id` は HotkeyEvent.combo で照合するため正規化済み文字列を直接使う。
+async fn bind_all(
+    gs: &GlobalShortcuts,
+    session: &ashpd::desktop::Session<GlobalShortcuts>,
+    bound: &std::collections::BTreeSet<String>,
+) -> Result<(), HotkeyError> {
+    let shortcuts: Vec<NewShortcut> = bound
+        .iter()
+        .map(|combo| {
+            NewShortcut::new(combo.clone(), format!("shikomi: {combo}"))
+                .preferred_trigger(Some(combo.as_str()))
+        })
+        .collect();
+
+    gs.bind_shortcuts(session, &shortcuts, None, BindShortcutsOptions::default())
+        .await
+        .map_err(|e| HotkeyError::RegisterFailed {
+            combo: bound.iter().next_back().cloned().unwrap_or_default(),
+            reason: format!("XDG Portal BindShortcuts failed: {e}"),
+        })?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Availability check (使う側 = backend/mod.rs::detect() が呼ぶ)
+// ---------------------------------------------------------------------------
+
+/// Wayland セッションか否かを `WAYLAND_DISPLAY` env で判定する。
+pub fn is_wayland() -> bool {
+    std::env::var_os("WAYLAND_DISPLAY")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}

--- a/crates/shikomi-gui/capabilities/default.json
+++ b/crates/shikomi-gui/capabilities/default.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "shikomi-gui default capabilities — core API + daemon 再起動用 shell scope",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "shikomi",
+          "cmd": "shikomi",
+          "args": [{ "validator": "^start$" }]
+        }
+      ]
+    }
+  ]
+}

--- a/crates/shikomi-gui/tauri.conf.json
+++ b/crates/shikomi-gui/tauri.conf.json
@@ -37,13 +37,15 @@
       "deb": {
         "files": {
           "/usr/bin/shikomi": "../../target/release/shikomi",
-          "/usr/bin/shikomi-daemon": "../../target/release/shikomi-daemon"
+          "/usr/bin/shikomi-daemon": "../../target/release/shikomi-daemon",
+          "/usr/share/applications/dev.shikomi.daemon.desktop": "../shikomi-daemon/dist/dev.shikomi.daemon.desktop"
         }
       },
       "rpm": {
         "files": {
           "/usr/bin/shikomi": "../../target/release/shikomi",
-          "/usr/bin/shikomi-daemon": "../../target/release/shikomi-daemon"
+          "/usr/bin/shikomi-daemon": "../../target/release/shikomi-daemon",
+          "/usr/share/applications/dev.shikomi.daemon.desktop": "../shikomi-daemon/dist/dev.shikomi.daemon.desktop"
         }
       }
     }

--- a/crates/shikomi-gui/tauri.conf.json
+++ b/crates/shikomi-gui/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "shikomi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "dev.shikomi.app",
   "build": {
     "frontendDist": "ui/dist",
@@ -22,17 +22,7 @@
       }
     ]
   },
-  "plugins": {
-    "shell": {
-      "scope": [
-        {
-          "name": "shikomi",
-          "cmd": "shikomi",
-          "args": [{ "validator": "^start$" }]
-        }
-      ]
-    }
-  },
+  "plugins": {},
   "bundle": {
     "active": true,
     "targets": ["deb", "rpm", "appimage", "nsis", "msi", "dmg"],
@@ -42,6 +32,20 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "linux": {
+      "deb": {
+        "files": {
+          "/usr/bin/shikomi": "../../target/release/shikomi",
+          "/usr/bin/shikomi-daemon": "../../target/release/shikomi-daemon"
+        }
+      },
+      "rpm": {
+        "files": {
+          "/usr/bin/shikomi": "../../target/release/shikomi",
+          "/usr/bin/shikomi-daemon": "../../target/release/shikomi-daemon"
+        }
+      }
+    }
   }
 }

--- a/crates/shikomi-gui/ui/src/App.tsx
+++ b/crates/shikomi-gui/ui/src/App.tsx
@@ -64,6 +64,8 @@ const App: Component = () => {
 
   const handleFormSuccess = () => {
     setFormMode(null);
+    // エントリ追加・編集後に一覧を再取得（UI auto-refresh）
+    refreshEntries();
   };
 
   const resetTab = (view: ActiveView) => {

--- a/crates/shikomi-gui/ui/src/lib/errors.ts
+++ b/crates/shikomi-gui/ui/src/lib/errors.ts
@@ -41,7 +41,7 @@ export function resolveError(err: GUIError): ErrorResult {
     case "daemon_not_running":
       return {
         type: "message",
-        text: "daemon が起動していません。shikomi start を実行してください",
+        text: "daemon が起動していません。`shikomi daemon install` で自動起動を有効化するか、`systemctl --user start shikomi-daemon` で手動起動してください",
       };
 
     case "not_connected":

--- a/crates/shikomi-gui/ui/vite.config.ts
+++ b/crates/shikomi-gui/ui/vite.config.ts
@@ -15,6 +15,15 @@ export default defineConfig({
     sourcemap: !!process.env.TAURI_DEBUG,
   },
   clearScreen: false,
+  // Vite 6 dev サーバの esbuild prebundle は build.target を参照せず、
+  // 既定で古い browserslist 互換ターゲットを使うため、solid-js 内の
+  // destructuring が "not supported yet" で失敗する。
+  // 依存プリバンドル側のみ esnext に引き上げる（本番ビルド target は build.target を維持）。
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "esnext",
+    },
+  },
   server: {
     port: 5173,
     strictPort: true,

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ clippy:
 
 # 全 workspace テスト (確定 C: --all-features は付けない)
 test:
-    cargo test --workspace
+    cargo test --workspace --features "shikomi-daemon/test-fixtures,shikomi-infra/test-fixtures"
 
 test-core:
     cargo test -p shikomi-core


### PR DESCRIPTION
Closes #160

## 概要

v0.1.0 リリースが「インストール後アプリが起動拒否、起動できても daemon に繋がらない、CLI も入っていない」状態だったため、**実機で apt 経由インストール後に CLI 全機能と GUI 表示が動作するレベル** まで引き上げる。

Wayland グローバルホットキー対応（Issue #160 の最大スコープ）は **v0.1.1 では未対応**、v0.1.2 で `org.freedesktop.portal.GlobalShortcuts` 対応を実装する方針で本 PR から分離。

## 変更内容（3 commit）

### commit 1: fix(release): v0.1.0 deb の起動拒否を解消し CLI/daemon バイナリも同梱

- `tauri.conf.json` の Tauri v1 文法 `plugins.shell.scope` を削除し v2 規約準拠
- `crates/shikomi-gui/capabilities/default.json` 新規追加（v2 capabilities）
- `bundle.linux.{deb,rpm}.files` で `/usr/bin/shikomi` と `/usr/bin/shikomi-daemon` を同梱
- workspace version 0.1.0 → 0.1.1
- vite.config.ts の Vite 6 esbuild prebundle target を esnext に
- gen/ を gitignore

### commit 2: ci(release): release.yml で CLI/daemon を tauri bundle 前にビルド

- `cargo build --release -p shikomi-cli -p shikomi-daemon` ステップを Linux ビルドジョブに追加（macOS/Windows 同梱対応は v0.1.2 以降）

### commit 3: fix(gui,docs): エントリ追加後の auto-refresh 修正と README/エラーメッセージ整合

- App.handleFormSuccess に refreshEntries() 追加（保存後の一覧更新バグ修正）
- resolveError の `daemon_not_running` 誘導文を実在コマンドに修正
- README の複数の事実誤認修正:
  - `shikomi daemon start/stop` は存在しない（実装は install/uninstall/status のみ）
  - インストール時の自動起動は無効、ユーザー手動 `shikomi daemon install` 必須
  - ホットキー例 `ctrl+alt+1` 小文字 → `Ctrl+Alt+1` 大文字
  - `shikomi add` の `--kind` 必須引数を例に追加
  - vault.json → vault.db
  - Wayland 対応状況を v0.1.1 未対応 / v0.1.2 予定として明記

## 実機検証済み

ローカルビルド成功 → sudo dpkg -i → 確認:
- shikomi --version → "shikomi 0.1.1" ✓
- shikomi list → daemon 経由で vault エントリ取得成功 ✓
- shikomi-gui → 起動拒否解消（"unknown field 'scope'" エラー消失） ✓
- shikomi daemon install → systemd user service 登録成功 ✓
- daemon プロセスは Unix socket /run/user/1000/shikomi/daemon.sock で listen ✓

## v0.1.2 以降に持ち越し（Issue #160 後続）

- **Wayland グローバルホットキー** (`ashpd` crate で XDG Portal 実装) — 工数 2-3 日
- macOS dmg / Windows MSI/NSIS への CLI/daemon 同梱
- AppImage の同梱対応
- deb postinst で `shikomi daemon install` を自動実行（マルチユーザー対応設計が要）
- README 全機能スモークテスト完走（vault encrypt/unlock 等の自動 E2E）

## マージ後の手順

1. main に admin merge
2. `git tag v0.1.1 -m "v0.1.1: install-and-launch fix"` push
3. release.yml が新リリース作成
4. package-publish.yml を v0.1.1 で dispatch
5. apt update && apt install shikomi で v0.1.1 が降ってきて即動作